### PR TITLE
Document SelectorsDict usage for relational provider and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ pip install -e .
 
 # Quick Start
 
+### Selectors are JSON-only
+
+Providers receive a `selectors` argument that **must be JSON-serializable**. The
+shared alias `SelectorsDict` (see `fetchgraph/json_types.py`) represents
+`Dict[str, JSONValue]` and is used across protocols and models. The planner/LLM
+produces this structure, so do not place runtime-only Python objects (e.g.
+connections, DataFrames) into `selectors`; pass such hints through `**kwargs`
+instead. Providers can publish the expected shape via `ProviderInfo.selectors_schema`
+(a JSON Schema) and optional `examples` containing stringified JSON payloads.
+
+Relational providers require `selectors` to include a string field `"op"` that
+chooses the operation (e.g., `"schema"`, `"semantic_only"`, `"query"`). The
+complete set of supported shapes is described by the schema returned from
+`RelationalDataProvider.describe()`.
+
 ```python
 from fetchgraph import (
   BaseGraphAgent, ContextPacker, BaselineSpec, ContextFetchSpec,
@@ -49,6 +64,53 @@ agent = BaseGraphAgent(
 )
 
 print(agent.run("FeatureX"))
+```
+
+## Working with selectors
+
+- **Plan-time inputs**: The planner/LLM crafts `selectors` (a `SelectorsDict`) for
+  each `ContextFetchSpec`. These inputs must be JSON-serializable and should be
+  validated by providers using their published JSON Schema.
+- **Provider contract**: Implementations of `ContextProvider.fetch` should accept
+  `selectors: Optional[SelectorsDict] = None` and treat `**kwargs` as optional
+  runtime hints that may be non-serializable.
+- **Schema + examples**: Providers can guide planners by returning
+  `ProviderInfo(selectors_schema=..., examples=[...])` from `describe()`.
+
+Example for a relational provider that requires an `"op"` selector:
+
+```python
+from fetchgraph.json_types import SelectorsDict
+from fetchgraph.models import ProviderInfo
+
+class RelationalDataProvider:
+    name = "relational"
+
+    def fetch(self, feature_name: str, selectors: SelectorsDict, **kwargs):
+        op = selectors.get("op")
+        if not op:
+            raise ValueError("selectors.op is required")
+        ...  # existing logic for schema/semantic_only/query
+
+    def describe(self) -> ProviderInfo:
+        schema = {
+            "oneOf": [
+                {"type": "object", "required": ["op"], "properties": {"op": {"const": "schema"}}},
+                {"type": "object", "required": ["op", "sql"], "properties": {"op": {"const": "query"}, "sql": {"type": "string"}}},
+            ]
+        }
+        return ProviderInfo(
+            name=self.name,
+            selectors_schema=schema,
+            examples=["{\"op\":\"schema\"}", "{\"op\":\"query\",\"sql\":\"select 1\"}"],
+        )
+```
+
+During planning you can feed selectors into `ContextFetchSpec` to fix the
+operation:
+
+```python
+fetch_spec = ContextFetchSpec(provider="relational", selectors={"op": "schema"})
 ```
 
 ---

--- a/src/fetchgraph/json_types.py
+++ b/src/fetchgraph/json_types.py
@@ -1,0 +1,12 @@
+"""Type aliases for JSON-like structures used in provider selectors.
+
+These aliases describe data that must remain JSON-serializable and are
+intended for use with the ``selectors`` argument in provider protocols.
+"""
+
+from typing import Dict, List, Union
+
+JSONPrimitive = Union[str, int, float, bool, None]
+JSONValue = Union[JSONPrimitive, Dict[str, "JSONValue"], List["JSONValue"]]
+JSONDict = Dict[str, JSONValue]
+SelectorsDict = JSONDict

--- a/src/fetchgraph/models.py
+++ b/src/fetchgraph/models.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from .json_types import SelectorsDict
+
 from pydantic import BaseModel, Field
 
 
@@ -21,6 +23,13 @@ class TaskProfile(BaseModel):
 
 
 class ProviderInfo(BaseModel):
+    """Metadata describing a provider and its selector contract.
+
+    - ``selectors_schema`` is a JSON Schema describing the expected ``SelectorsDict``
+      structure for ``selectors`` passed to the provider.
+    - ``examples`` are stringified JSON examples of valid ``selectors`` payloads.
+    """
+
     name: str
     description: str = ""
     selectors_schema: Dict[str, Any] = Field(default_factory=dict)
@@ -40,9 +49,16 @@ ProviderType = str
 
 
 class ContextFetchSpec(BaseModel):
+    """Specification for a single provider fetch step.
+
+    ``selectors`` is a JSON-serializable object describing provider-specific
+    fetch parameters. Its allowed structure is defined by the provider via
+    ``ProviderInfo.selectors_schema``.
+    """
+
     provider: ProviderType
     mode: str = "full"
-    selectors: Dict[str, Any] = Field(default_factory=dict)
+    selectors: SelectorsDict = Field(default_factory=dict)
     max_tokens: Optional[int] = None
 
 

--- a/src/fetchgraph/protocols.py
+++ b/src/fetchgraph/protocols.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Protocol, overload, runtime_checkable
+from typing import Any, List, Optional, Protocol, overload, runtime_checkable
 
 from .models import ProviderInfo, RawLLMOutput
+from .json_types import SelectorsDict
 
 
 class LLMInvoke(Protocol):
@@ -28,19 +29,40 @@ class Saver(Protocol):
 class ContextProvider(Protocol):
     name: str
 
-    def fetch(self, feature_name: str, selectors: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Any: ...
+    def fetch(self, feature_name: str, selectors: Optional[SelectorsDict] = None, **kwargs: Any) -> Any:
+        """Fetch data for a feature, optionally constrained by selectors.
+
+        The ``selectors`` argument is a strictly JSON-compatible dictionary (see
+        ``SelectorsDict``) and is part of the planned contract produced by the
+        planner/LLM. Arbitrary Python objects (DataFrames, connections, models,
+        etc.) are not allowed in ``selectors``; pass any non-serializable values
+        via ``**kwargs`` instead. ``**kwargs`` is reserved for runtime hints or
+        options that do not flow through the planner and may contain
+        non-serializable objects.
+        """
+
+        ...
 
     def serialize(self, obj: Any) -> str: ...
 
 
 @runtime_checkable
 class SupportsFilter(Protocol):
-    def filter(self, obj: Any, selectors: Optional[Dict[str, Any]] = None) -> Any: ...
+    def filter(self, obj: Any, selectors: Optional[SelectorsDict] = None) -> Any: ...
 
 
 @runtime_checkable
 class SupportsDescribe(Protocol):
-    def describe(self) -> ProviderInfo: ...
+    def describe(self) -> ProviderInfo:
+        """Describe the provider, including selector expectations.
+
+        ``ProviderInfo.selectors_schema`` (when present) should be a JSON
+        Schema (Draft 7 or similar) for the ``selectors`` field. Any
+        ``ProviderInfo.examples`` entries should be stringified JSON samples of
+        valid ``selectors`` ready to be inserted directly into a plan.
+        """
+
+        ...
 
 
 __all__ = [

--- a/src/fetchgraph/relational_composite.py
+++ b/src/fetchgraph/relational_composite.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 """Composite relational provider that delegates to child providers."""
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+from .json_types import SelectorsDict
 from .relational_base import RelationalDataProvider
 from .relational_models import (
     ComparisonFilter,
@@ -30,7 +31,7 @@ class CompositeRelationalProvider(RelationalDataProvider):
         super().__init__(name=name, entities=entities, relations=relations)
         self.children = children
 
-    def fetch(self, feature_name: str, selectors=None, **kwargs):
+    def fetch(self, feature_name: str, selectors: Optional[SelectorsDict] = None, **kwargs):
         selectors = selectors or {}
         op = selectors.get("op")
         if op != "query":


### PR DESCRIPTION
## Summary
- add SelectorsDict typing to relational provider fetch signatures and composite delegator
- document JSON selector contract, required "op" field, and schema linkage for describe()
- expand README with guidance on JSON-only selectors, schemas/examples, and relational provider usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692976e0136c832f91ea78bb987cb985)