### PR TITLE
Add pgvector semantic backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,36 @@ query text. Fields must be a subset of the indexed CSV columns (not including
 the reserved `__all__` combined projection). By default, field similarities are
 summed; adjust the backend if you need a different aggregation strategy.
 
+### pgvector / LangChain vector stores
+
+If you already manage embeddings in PostgreSQL with ``pgvector`` via LangChain,
+you can supply your existing vector stores directly:
+
+```python
+from langchain_community.vectorstores.pgvector import PGVector
+from fetchgraph.semantic_backend import PgVectorSemanticBackend, PgVectorSemanticSource
+
+vector_store = PGVector.from_existing_index(
+    collection_name="product_vectors", connection_string="postgresql+psycopg://..."
+)
+
+semantic_backend = PgVectorSemanticBackend(
+    {
+        "product": PgVectorSemanticSource(
+            entity="product",
+            vector_store=vector_store,
+            metadata_entity_key="entity",  # optional, defaults to "entity"
+            metadata_field_key="field",    # optional, defaults to "field"
+            id_metadata_keys=("id",),       # optional metadata key(s) to read the row identifier
+            score_kind="distance",          # convert pgvector distances into similarity scores
+        )
+    }
+)
+```
+
+The backend will filter returned documents by entity and requested fields using
+Document metadata before converting scores into :class:`SemanticMatch` entries.
+
 ---
 
 ## LICENSE

--- a/src/fetchgraph/__init__.py
+++ b/src/fetchgraph/__init__.py
@@ -58,7 +58,14 @@ from .relational_provider import (
     SemanticOnlyRequest,
     SemanticOnlyResult,
 )
-from .semantic_backend import CsvEmbeddingBuilder, CsvSemanticBackend, CsvSemanticSource
+from .semantic_backend import (
+    CsvEmbeddingBuilder,
+    CsvSemanticBackend,
+    CsvSemanticSource,
+    PgVectorSemanticBackend,
+    PgVectorSemanticSource,
+    VectorStoreLike,
+)
 
 __all__ = [
     "RawLLMOutput",
@@ -106,6 +113,9 @@ __all__ = [
     "CsvSemanticBackend",
     "CsvSemanticSource",
     "CsvEmbeddingBuilder",
+    "PgVectorSemanticBackend",
+    "PgVectorSemanticSource",
+    "VectorStoreLike",
 ]
 
 if PandasRelationalDataProvider is not None:

--- a/tests/test_semantic_backend_pgvector.py
+++ b/tests/test_semantic_backend_pgvector.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import pytest
+
+from fetchgraph.semantic_backend import (
+    PgVectorSemanticBackend,
+    PgVectorSemanticSource,
+    VectorStoreLike,
+)
+
+
+@dataclass
+class FakeDocument:
+    metadata: dict
+
+
+class FakeVectorStore(VectorStoreLike):
+    def __init__(self, results: Sequence[Tuple[FakeDocument, float]]):
+        self._results = list(results)
+        self.queries: List[Tuple[str, int]] = []
+
+    def similarity_search_with_score(self, query: str, k: int = 4, **kwargs: object):
+        self.queries.append((query, k))
+        return self._results[:k]
+
+
+def _backend_with_results(results: Sequence[Tuple[FakeDocument, float]]) -> PgVectorSemanticBackend:
+    store = FakeVectorStore(results)
+    source = PgVectorSemanticSource(
+        entity="product",
+        vector_store=store,
+        metadata_entity_key="entity",
+        metadata_field_key="field",
+        id_metadata_keys=("id", "pk"),
+        score_kind="distance",
+    )
+    return PgVectorSemanticBackend({"product": source})
+
+
+def test_pgvector_backend_filters_and_sorts_by_similarity():
+    backend = _backend_with_results(
+        [
+            (FakeDocument({"id": 1, "entity": "product", "field": "name"}), 0.05),
+            (FakeDocument({"id": 2, "entity": "product", "field": "description"}), 0.3),
+            (FakeDocument({"id": 3, "entity": "other"}), 0.01),
+        ]
+    )
+
+    matches = backend.search("product", fields=["name", "description"], query="red", top_k=5)
+
+    assert [m.id for m in matches] == [1, 2]
+    assert matches[0].score > matches[1].score
+
+
+def test_pgvector_backend_honors_field_filter():
+    backend = _backend_with_results(
+        [
+            (FakeDocument({"id": 1, "entity": "product", "field": "name"}), 0.2),
+            (FakeDocument({"id": 2, "entity": "product", "field": "description"}), 0.1),
+        ]
+    )
+
+    matches = backend.search("product", fields=["description"], query="info", top_k=3)
+
+    assert [m.id for m in matches] == [2]
+
+
+def test_pgvector_backend_supports_similarity_scores():
+    store = FakeVectorStore(
+        [
+            (FakeDocument({"pk": "row-1", "entity": "product"}), 0.8),
+            (FakeDocument({"pk": "row-2", "entity": "product"}), 0.6),
+        ]
+    )
+    backend = PgVectorSemanticBackend(
+        {
+            "product": PgVectorSemanticSource(
+                entity="product",
+                vector_store=store,
+                metadata_entity_key="entity",
+                metadata_field_key="field",
+                id_metadata_keys=("pk",),
+                score_kind="similarity",
+            )
+        }
+    )
+
+    matches = backend.search("product", fields=None, query="search", top_k=2)
+
+    assert [m.id for m in matches] == ["row-1", "row-2"]
+    assert matches[0].score == 0.8
+
+
+def test_pgvector_backend_missing_entity():
+    backend = _backend_with_results([])
+
+    with pytest.raises(KeyError):
+        backend.search("unknown", fields=None, query="test")


### PR DESCRIPTION
## Summary
- add a pgvector semantic backend that works with LangChain-style vector stores
- expose the new backend from the public package surface and document usage
- cover pgvector search behavior with targeted unit tests

## Testing
- `pytest` *(fails: pandas dependency unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a26de844832fa0730a5e0bb85d0f)