### PR TITLE
Add test covering DataFrame column handling in apply_filters

### DIFF
--- a/tests/test_relational_pandas.py
+++ b/tests/test_relational_pandas.py
@@ -117,6 +117,22 @@ def test_filters_with_logical_clause():
     assert ids == [103]
 
 
+def test_apply_filters_handles_dataframe_column():
+    provider = _make_provider()
+    original_resolve = provider._resolve_column
+
+    def resolve_as_list(df, root_entity, field, entity=None):
+        # Simulate a column resolution that returns a list-like, causing df[col] to be a DataFrame.
+        return [original_resolve(df, root_entity, field, entity)]
+
+    provider._resolve_column = resolve_as_list  # type: ignore[method-assign]
+
+    clause = ComparisonFilter(entity="order", field="status", op="=", value="pending")
+    filtered = provider._apply_filters(provider._get_frame("order"), "order", clause)
+
+    assert filtered["status"].tolist() == ["pending", "pending"]
+
+
 def test_group_by_with_aggregations():
     provider = _make_provider()
     req = RelationalQuery(


### PR DESCRIPTION
## Summary
- add a pandas provider test to verify _apply_filters handles DataFrame column selections by squeezing to a Series

## Testing
- pytest tests/test_relational_pandas.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b7232b70832faea9f65c65f6b9e6)