### PR TITLE
Preserve auto examples when schema config empty

### DIFF
--- a/src/fetchgraph/relational_base.py
+++ b/src/fetchgraph/relational_base.py
@@ -251,7 +251,7 @@ class RelationalDataProvider(ContextProvider, SupportsDescribe):
             ))
 
         # если в SchemaConfig заданы кастомные examples — переопределяем
-        if schema_config and schema_config.examples is not None:
+        if schema_config and schema_config.examples:
             examples = schema_config.examples
 
         return ProviderInfo(


### PR DESCRIPTION
## Summary
- keep auto-generated examples unless schema config provides custom entries

## Testing
- python -m pytest *(fails: missing pandas dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329f7bfaa0832f83a4b6df09fd88c8)