### PR TITLE
Add default case sensitivity for pandas filter helper

### DIFF
--- a/src/fetchgraph/relational_pandas.py
+++ b/src/fetchgraph/relational_pandas.py
@@ -217,7 +217,7 @@ class PandasRelationalDataProvider(RelationalDataProvider):
         root_entity: str,
         clause: Optional[FilterClause],
         *,
-        case_sensitive: bool,
+        case_sensitive: bool = False,
     ) -> pd.DataFrame:
         if clause is None:
             return df


### PR DESCRIPTION
## Summary
- add a default for the case sensitivity flag in `_apply_filters` to prevent errors when the helper is called without explicitly providing the parameter

## Testing
- python -m pytest tests/test_relational_pandas.py -k test_apply_filters_handles_dataframe_column *(skipped: pandas not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330363d4ec832faf97c2475aa4d645)