### PR TITLE
Fix pyright typing issues

### DIFF
--- a/src/fetchgraph/relational/providers/pandas_provider.py
+++ b/src/fetchgraph/relational/providers/pandas_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Pandas-backed relational provider for in-memory datasets."""
 
-from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, cast
+from typing import Any, Dict, Hashable, List, Mapping, Optional, Set, Tuple, cast
 
 import pandas as pd  # type: ignore[import]
 from pandas.api import types as pdt
@@ -371,7 +371,9 @@ class PandasRelationalDataProvider(RelationalDataProvider):
         right_df = self._get_frame(right_entity).copy()
         right_df["__merge_key"] = right_df[right_field]
         right_alias = relation.name or right_entity
-        rename_map = {col: f"{right_alias}__{col}" for col in right_df.columns if col != "__merge_key"}
+        rename_map: Dict[Hashable, Hashable] = {
+            col: f"{right_alias}__{col}" for col in right_df.columns if col != "__merge_key"
+        }
         right_df = right_df.rename(columns=rename_map)
 
         if right_alias != right_entity and right_entity in referenced_entities:

--- a/tests/test_relational_composite_cross_provider.py
+++ b/tests/test_relational_composite_cross_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -21,8 +23,8 @@ from fetchgraph.relational import (
 
 def _build_block_system_composite(
     *,
-    join_type: str = "inner",
-    cardinality: str = "1_to_many",
+    join_type: Literal["inner", "left", "right", "outer"] = "inner",
+    cardinality: Literal["1_to_1", "1_to_many", "many_to_1", "many_to_many"] = "1_to_many",
     block_df=None,
     system_df=None,
     **kwargs,
@@ -199,7 +201,9 @@ def test_cross_join_1_to_1():
 def test_cross_join_1_to_1_cardinality_violation():
     right_df = pd.DataFrame({"id": [1, 1], "label": ["X", "Y"]})
     composite = _build_one_to_one_composite()
-    composite.children["right"].frames["right"] = right_df
+    right_provider = composite.children["right"]
+    assert isinstance(right_provider, PandasRelationalDataProvider)
+    right_provider.frames["right"] = right_df
     query = RelationalQuery(root_entity="left", relations=["left_right"])
 
     with pytest.raises(ValueError, match="Cardinality 1_to_1 violated"):
@@ -208,7 +212,9 @@ def test_cross_join_1_to_1_cardinality_violation():
 
 def test_cross_join_many_to_1_cardinality_violation():
     composite = _build_employee_department_composite()
-    composite.children["departments"].frames["department"] = pd.DataFrame(
+    departments_provider = composite.children["departments"]
+    assert isinstance(departments_provider, PandasRelationalDataProvider)
+    departments_provider.frames["department"] = pd.DataFrame(
         {"id": [10, 10, 11], "title": ["Eng", "Ops", "HR"]}
     )
     query = RelationalQuery(root_entity="employee", relations=["employee_department"])
@@ -255,7 +261,9 @@ def test_cross_join_handles_right_batch_overflow_for_1_to_many():
 
 def test_cross_join_raises_on_right_batch_overflow_for_1_to_1_or_many_to_1():
     composite = _build_one_to_one_composite()
-    composite.children["right"].frames["right"] = pd.DataFrame(
+    right_provider = composite.children["right"]
+    assert isinstance(right_provider, PandasRelationalDataProvider)
+    right_provider.frames["right"] = pd.DataFrame(
         {"id": [1, 1, 2], "label": ["X", "Y", "Z"]}
     )
     query = RelationalQuery(root_entity="left", relations=["left_right"])


### PR DESCRIPTION
## Summary
- align pandas provider column rename mapping with pyright expectations
- update composite provider tests with precise literal types and provider narrowing

## Testing
- pyright (fails: environment interruption)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eed7fbe00832f84b6129d2f84f754)