### PR TITLE
Include pandas provider in __all__ unconditionally

### DIFF
--- a/src/fetchgraph/__init__.py
+++ b/src/fetchgraph/__init__.py
@@ -123,8 +123,4 @@ _FETCHGRAPH_EXPORTS = (
     "VectorStoreLike",
 )
 
-__all__ = (
-    _FETCHGRAPH_EXPORTS + ("PandasRelationalDataProvider",)
-    if PandasRelationalDataProvider is not None
-    else _FETCHGRAPH_EXPORTS
-)
+__all__ = _FETCHGRAPH_EXPORTS + ("PandasRelationalDataProvider",)

--- a/src/fetchgraph/relational/__init__.py
+++ b/src/fetchgraph/relational/__init__.py
@@ -83,9 +83,4 @@ _RELATIONAL_EXPORTS = (
     "VectorStoreLike",
 )
 
-__all__ = (
-    _RELATIONAL_EXPORTS
-    + ("PandasRelationalDataProvider",)
-    if PandasRelationalDataProvider is not None
-    else _RELATIONAL_EXPORTS
-)
+__all__ = _RELATIONAL_EXPORTS + ("PandasRelationalDataProvider",)

--- a/src/fetchgraph/relational/providers/__init__.py
+++ b/src/fetchgraph/relational/providers/__init__.py
@@ -15,8 +15,4 @@ _PROVIDER_EXPORTS = (
     "SqlRelationalDataProvider",
 )
 
-__all__ = (
-    _PROVIDER_EXPORTS + ("PandasRelationalDataProvider",)
-    if PandasRelationalDataProvider is not None
-    else _PROVIDER_EXPORTS
-)
+__all__ = _PROVIDER_EXPORTS + ("PandasRelationalDataProvider",)


### PR DESCRIPTION
## Summary
- remove conditional __all__ concatenation in fetchgraph and relational packages
- always include PandasRelationalDataProvider in exported symbols

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eef175200832f86e00bfcce1210b9)