### PR TITLE
Add DSL relational compiler

### DIFF
--- a/src/fetchgraph/dsl/README.md
+++ b/src/fetchgraph/dsl/README.md
@@ -7,7 +7,12 @@ AST, and normalizes keys, operators, and defaults according to `spec.yaml`.
 ## Usage
 
 ```python
-from fetchgraph.dsl import parse_query_sketch, normalize_query_sketch, parse_and_normalize
+from fetchgraph.dsl import (
+    compile_relational_query,
+    normalize_query_sketch,
+    parse_and_normalize,
+    parse_query_sketch,
+)
 
 raw = "{ from: streams, where: [[\"status\", \"active\"]] }"
 parsed, parse_diags = parse_query_sketch(raw)
@@ -24,6 +29,17 @@ normalized.get      # defaults to ["*"]
 normalized.with_    # defaults to []
 normalized.take     # defaults from spec (200)
 normalized.where    # WhereExpr with all/any/not
+```
+
+After normalization you can compile the sketch into a `RelationalQuery` selectors dict
+ready for providers:
+
+```python
+sketch, diags = parse_and_normalize(raw)
+compiled = compile_relational_query(sketch)
+compiled.select  # [] when get is omitted or contains "*"
+compiled.filters
+compiled.relations
 ```
 
 Diagnostics collect warnings and errors encountered during parsing or normalization.

--- a/src/fetchgraph/dsl/__init__.py
+++ b/src/fetchgraph/dsl/__init__.py
@@ -1,4 +1,5 @@
 from .ast import Clause, NormalizedQuerySketch, QuerySketch, WhereExpr
+from .compile import compile_relational_query, compile_relational_selectors
 from .diagnostics import Diagnostic, Diagnostics, Severity
 from .normalize import DslSpec, normalize_query_sketch, parse_and_normalize
 from .parser import parse_query_sketch
@@ -15,4 +16,6 @@ __all__ = [
     "parse_query_sketch",
     "normalize_query_sketch",
     "parse_and_normalize",
+    "compile_relational_query",
+    "compile_relational_selectors",
 ]

--- a/src/fetchgraph/dsl/compile.py
+++ b/src/fetchgraph/dsl/compile.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional, Tuple, Union
+
+from .ast import Clause, ClauseOrGroup, NormalizedQuerySketch
+from fetchgraph.relational.models import (
+    ComparisonFilter,
+    FilterClause,
+    LogicalFilter,
+    RelationalQuery,
+    SelectExpr,
+)
+
+
+_MappedComparison = Tuple[str, Any]
+
+
+def _map_op(op: str, value: Any) -> Union[FilterClause, List[_MappedComparison], _MappedComparison]:
+    """Map DSL operator to provider operator or filter.
+
+    Returns either a tuple representing comparison operator/value or a list of such tuples
+    for compound operations. Between is converted to two comparisons combined later.
+    """
+
+    op = op.lower()
+    if op == "is":
+        return "=", value
+    if op == "before":
+        return "<", value
+    if op == "after":
+        return ">", value
+    if op == "contains":
+        return "ilike", value
+    if op == "between":
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise ValueError("between operator expects a list or tuple with exactly two values")
+        return [(">=", value[0]), ("<=", value[1])]
+
+    if op in {"=", "!=", "<", ">", "<=", ">=", "in", "not_in", "like", "ilike"}:
+        return op, value
+
+    raise ValueError(f"Unsupported operator: {op}")
+
+
+def _compile_clause(clause: Clause) -> FilterClause:
+    mapped = _map_op(clause.op, clause.value)
+
+    if isinstance(mapped, LogicalFilter):
+        return mapped
+
+    if isinstance(mapped, list):
+        compiled = [
+            ComparisonFilter(entity=None, field=clause.path, op=op, value=val)
+            for op, val in mapped
+        ]
+        if len(compiled) == 1:
+            return compiled[0]
+        return LogicalFilter(op="and", clauses=compiled)
+
+    op, value = mapped
+    return ComparisonFilter(entity=None, field=clause.path, op=op, value=value)
+
+
+def _invert_not_clause(clause: Clause) -> Clause:
+    if clause.op == "=":
+        return Clause(path=clause.path, op="!=", value=clause.value)
+    if clause.op == "in":
+        return Clause(path=clause.path, op="not_in", value=clause.value)
+    if clause.op == "!=":
+        return Clause(path=clause.path, op="=", value=clause.value)
+    raise ValueError(f"NOT for op {clause.op} not supported yet")
+
+
+def _compile_where(expr: ClauseOrGroup) -> FilterClause:
+    if isinstance(expr, Clause):
+        return _compile_clause(expr)
+
+    compiled_all: List[FilterClause] = [_compile_where(item) for item in expr.all]
+    compiled_any: List[FilterClause] = [_compile_where(item) for item in expr.any]
+
+    all_filter: Optional[FilterClause] = None
+    any_filter: Optional[FilterClause] = None
+
+    if compiled_all:
+        all_filter = compiled_all[0] if len(compiled_all) == 1 else LogicalFilter(op="and", clauses=compiled_all)
+
+    if compiled_any:
+        any_filter = compiled_any[0] if len(compiled_any) == 1 else LogicalFilter(op="or", clauses=compiled_any)
+
+    not_filter: Optional[FilterClause] = None
+    if expr.not_ is not None:
+        if not isinstance(expr.not_, Clause):
+            raise ValueError("NOT is only supported for simple comparisons")
+        inverted = _invert_not_clause(expr.not_)
+        not_filter = _compile_clause(inverted)
+
+    clauses: List[FilterClause] = []
+    if all_filter is not None:
+        clauses.append(all_filter)
+    if any_filter is not None:
+        clauses.append(any_filter)
+    if not_filter is not None:
+        clauses.append(not_filter)
+
+    if not clauses:
+        raise ValueError("Empty where expression")
+    if len(clauses) == 1:
+        return clauses[0]
+    return LogicalFilter(op="and", clauses=clauses)
+
+
+def _collect_paths(expr: ClauseOrGroup) -> Iterable[str]:
+    if isinstance(expr, Clause):
+        yield expr.path
+        return
+
+    for item in expr.all:
+        yield from _collect_paths(item)
+    for item in expr.any:
+        yield from _collect_paths(item)
+    if expr.not_ is not None:
+        yield from _collect_paths(expr.not_)
+
+
+def _infer_relations(sketch: NormalizedQuerySketch) -> List[str]:
+    relations = set(sketch.with_)
+
+    def process_path(path: str) -> None:
+        if "." not in path:
+            return
+        parts = path.split(".")
+        if len(parts) == 2:
+            rel, _ = parts
+            if rel != sketch.from_:
+                relations.add(rel)
+            return
+        raise ValueError(f"Multi-hop dotted paths are not supported yet: {path}")
+
+    for path in _collect_paths(sketch.where):
+        process_path(path)
+    for field in sketch.get:
+        process_path(field)
+
+    return sorted(relations)
+
+
+def compile_relational_query(sketch: NormalizedQuerySketch) -> RelationalQuery:
+    filters: Optional[FilterClause] = None
+    if sketch.where.all or sketch.where.any or sketch.where.not_ is not None:
+        filters = _compile_where(sketch.where)
+
+    select: List[SelectExpr] = []
+    if sketch.get and "*" not in sketch.get:
+        select = [SelectExpr(expr=field) for field in sketch.get]
+
+    relations = _infer_relations(sketch)
+
+    return RelationalQuery(
+        root_entity=sketch.from_,
+        select=select,
+        filters=filters,
+        relations=relations,
+        limit=sketch.take,
+        offset=0,
+        case_sensitivity=False,
+    )
+
+
+def compile_relational_selectors(sketch: NormalizedQuerySketch) -> dict:
+    return compile_relational_query(sketch).model_dump()

--- a/src/fetchgraph/dsl/compile.py
+++ b/src/fetchgraph/dsl/compile.py
@@ -31,12 +31,35 @@ def _map_op(op: str, value: Any) -> Union[List[_MappedComparison], _MappedCompar
         return ">", value
     if op == "contains":
         return "ilike", value
+    if op == "starts":
+        return "starts", value
+    if op == "ends":
+        return "ends", value
+    if op in {"similar", "related"}:
+        return "ilike", value
     if op == "between":
         if not isinstance(value, (list, tuple)) or len(value) != 2:
             raise ValueError("between operator expects a list or tuple with exactly two values")
         return [(">=", value[0]), ("<=", value[1])]
 
-    if op in {"=", "!=", "<", ">", "<=", ">=", "in", "not_in", "like", "ilike"}:
+    if op in {
+        "=",
+        "!=",
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "in",
+        "not_in",
+        "like",
+        "ilike",
+        "not_like",
+        "not_ilike",
+        "starts",
+        "ends",
+        "not_starts",
+        "not_ends",
+    }:
         return op, value
 
     raise ValueError(f"Unsupported operator: {op}")
@@ -84,6 +107,10 @@ def _negate_mapped(path: str, mapped: Union[List[_MappedComparison], _MappedComp
         "<": ">=",
         ">=": "<",
         "<=": ">",
+        "like": "not_like",
+        "ilike": "not_ilike",
+        "starts": "not_starts",
+        "ends": "not_ends",
     }
 
     if op not in inverted_ops:

--- a/src/fetchgraph/dsl/normalize.py
+++ b/src/fetchgraph/dsl/normalize.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import difflib
+import importlib
+import importlib.util
 import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-import yaml
+_yaml_spec = importlib.util.find_spec("yaml")
+yaml = importlib.import_module("yaml") if _yaml_spec is not None else None
 
 from .ast import Clause, ClauseOrGroup, NormalizedQuerySketch, QuerySketch, WhereExpr
 from .diagnostics import Diagnostics, Severity

--- a/src/fetchgraph/relational/models.py
+++ b/src/fetchgraph/relational/models.py
@@ -58,18 +58,34 @@ class SelectExpr(BaseModel):
     alias: Optional[str] = None
 
 
-class ComparisonOp(str):
-    """Symbolic comparison operator alias."""
-
-
 class ComparisonFilter(BaseModel):
     """Basic comparison filter."""
 
     type: Literal["comparison"] = "comparison"
     entity: Optional[str] = None
     field: str
-    op: str
+    op: "ComparisonOp"
     value: Any
+
+
+ComparisonOp = Literal[
+    "=",
+    "!=",
+    "<",
+    ">",
+    "<=",
+    ">=",
+    "in",
+    "not_in",
+    "like",
+    "ilike",
+    "not_like",
+    "not_ilike",
+    "starts",
+    "ends",
+    "not_starts",
+    "not_ends",
+]
 
 
 class LogicalFilter(BaseModel):

--- a/tests/test_dsl_compile.py
+++ b/tests/test_dsl_compile.py
@@ -1,0 +1,51 @@
+import pytest
+
+from fetchgraph.dsl import compile_relational_query, parse_and_normalize
+from fetchgraph.relational.models import ComparisonFilter, LogicalFilter
+
+
+def test_is_operator_maps_to_equals():
+    sketch, _ = parse_and_normalize("{from: streams, where: [[participant, 'АС ЕСП']]}")
+    compiled = compile_relational_query(sketch)
+
+    assert compiled.filters is not None
+    assert compiled.filters.model_dump() == ComparisonFilter(
+        entity=None, field="participant", op="=", value="АС ЕСП"
+    ).model_dump()
+
+
+def test_between_operator_expands_to_range():
+    sketch, _ = parse_and_normalize("{from: streams, where: [[date, [\"2020-01-01\", \"2020-02-01\"]]]}")
+    compiled = compile_relational_query(sketch)
+
+    assert compiled.filters is not None
+    assert compiled.filters.model_dump() == LogicalFilter(
+        op="and",
+        clauses=[
+            ComparisonFilter(entity=None, field="date", op=">=", value="2020-01-01"),
+            ComparisonFilter(entity=None, field="date", op="<=", value="2020-02-01"),
+        ],
+    ).model_dump()
+
+
+def test_not_operator_inverts_simple_clause():
+    sketch, _ = parse_and_normalize({"from": "streams", "where": {"not": ["is_test", True]}})
+    compiled = compile_relational_query(sketch)
+
+    assert compiled.filters is not None
+    assert compiled.filters.model_dump() == ComparisonFilter(
+        entity=None, field="is_test", op="!=", value=True
+    ).model_dump()
+
+
+def test_relations_inferred_from_dotted_get():
+    sketch, _ = parse_and_normalize({"from": "streams", "get": ["participant_details.name"]})
+    compiled = compile_relational_query(sketch)
+
+    assert "participant_details" in compiled.relations
+
+
+def test_multi_hop_dotted_path_raises():
+    sketch, _ = parse_and_normalize({"from": "streams", "get": ["a.b.c"]})
+    with pytest.raises(ValueError):
+        compile_relational_query(sketch)

--- a/tests/test_dsl_compile_ops.py
+++ b/tests/test_dsl_compile_ops.py
@@ -1,0 +1,48 @@
+from fetchgraph.dsl import compile_relational_query, parse_and_normalize
+from fetchgraph.relational.models import ComparisonFilter
+
+
+def test_compile_string_edge_ops():
+    sketch, _ = parse_and_normalize({"from": "people", "where": [["name", "starts", "Al"]]})
+    compiled = compile_relational_query(sketch)
+
+    assert compiled.filters is not None
+    assert compiled.filters.model_dump() == ComparisonFilter(
+        entity=None, field="name", op="starts", value="Al"
+    ).model_dump()
+
+    sketch_ends, _ = parse_and_normalize({"from": "people", "where": [["name", "ends", "ce"]]})
+    compiled_ends = compile_relational_query(sketch_ends)
+
+    assert compiled_ends.filters is not None
+    assert compiled_ends.filters.model_dump() == ComparisonFilter(
+        entity=None, field="name", op="ends", value="ce"
+    ).model_dump()
+
+
+def test_compile_not_contains_maps_to_not_ilike():
+    sketch, _ = parse_and_normalize({"from": "people", "where": {"not": ["name", "contains", "x"]}})
+    compiled = compile_relational_query(sketch)
+
+    assert compiled.filters is not None
+    assert compiled.filters.model_dump() == ComparisonFilter(
+        entity=None, field="name", op="not_ilike", value="x"
+    ).model_dump()
+
+
+def test_compile_similar_and_related_fallback_to_ilike():
+    sketch_similar, _ = parse_and_normalize({"from": "people", "where": [["name", "similar", "foo"]]})
+    compiled_similar = compile_relational_query(sketch_similar)
+
+    assert compiled_similar.filters is not None
+    assert compiled_similar.filters.model_dump() == ComparisonFilter(
+        entity=None, field="name", op="ilike", value="foo"
+    ).model_dump()
+
+    sketch_related, _ = parse_and_normalize({"from": "people", "where": [["name", "related", "foo"]]})
+    compiled_related = compile_relational_query(sketch_related)
+
+    assert compiled_related.filters is not None
+    assert compiled_related.filters.model_dump() == ComparisonFilter(
+        entity=None, field="name", op="ilike", value="foo"
+    ).model_dump()

--- a/tests/test_relational_string_ops.py
+++ b/tests/test_relational_string_ops.py
@@ -1,0 +1,104 @@
+import sqlite3
+
+import pandas as pd
+
+from fetchgraph.relational.models import (
+    ColumnDescriptor,
+    ComparisonFilter,
+    EntityDescriptor,
+    RelationalQuery,
+)
+from fetchgraph.relational.providers import PandasRelationalDataProvider, SqlRelationalDataProvider
+
+
+def _make_people_provider() -> PandasRelationalDataProvider:
+    people = pd.DataFrame({"id": [1, 2, 3, 4], "name": ["Alice", "Alfred", "Grace", "bob"]})
+    entities = [
+        EntityDescriptor(
+            name="person",
+            columns=[
+                ColumnDescriptor(name="id", role="primary_key"),
+                ColumnDescriptor(name="name"),
+            ],
+        )
+    ]
+    return PandasRelationalDataProvider(
+        name="people_rel",
+        entities=entities,
+        relations=[],
+        frames={"person": people},
+    )
+
+
+def _make_people_sql_provider() -> SqlRelationalDataProvider:
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE person (id INTEGER PRIMARY KEY, name TEXT)")
+    cur.executemany(
+        "INSERT INTO person (id, name) VALUES (?, ?)",
+        [(1, "Alice"), (2, "Alfred"), (3, "Grace"), (4, "bob")],
+    )
+    conn.commit()
+
+    entities = [
+        EntityDescriptor(
+            name="person",
+            columns=[
+                ColumnDescriptor(name="id", role="primary_key"),
+                ColumnDescriptor(name="name"),
+            ],
+        )
+    ]
+
+    return SqlRelationalDataProvider(
+        name="people_rel_sql",
+        entities=entities,
+        relations=[],
+        connection=conn,
+    )
+
+
+def test_string_ops_with_pandas_provider():
+    provider = _make_people_provider()
+    req = RelationalQuery(
+        root_entity="person",
+        filters=ComparisonFilter(field="name", op="starts", value="Al"),
+        limit=None,
+    )
+
+    res = provider.fetch("demo", selectors=req.model_dump())
+
+    assert [row.data["name"] for row in res.rows] == ["Alice", "Alfred"]
+
+    req_not = RelationalQuery(
+        root_entity="person",
+        filters=ComparisonFilter(field="name", op="not_ends", value="e"),
+        limit=None,
+    )
+
+    res_not = provider.fetch("demo", selectors=req_not.model_dump())
+
+    assert [row.data["name"] for row in res_not.rows] == ["Alfred", "bob"]
+
+
+def test_string_ops_with_sql_provider():
+    provider = _make_people_sql_provider()
+    req = RelationalQuery(
+        root_entity="person",
+        filters=ComparisonFilter(field="name", op="ends", value="ice"),
+        limit=None,
+    )
+
+    res = provider.fetch("demo", selectors=req.model_dump())
+
+    assert [row.data["name"] for row in res.rows] == ["Alice"]
+
+    req_not = RelationalQuery(
+        root_entity="person",
+        filters=ComparisonFilter(field="name", op="not_ilike", value="al"),
+        limit=None,
+    )
+
+    res_not = provider.fetch("demo", selectors=req_not.model_dump())
+
+    assert [row.data["name"] for row in res_not.rows] == ["Grace", "bob"]


### PR DESCRIPTION
## Summary
- add a DSL compiler that maps normalized sketches to relational queries
- map operators including between/not handling and infer dotted-path relations
- add unit tests for compilation and allow normalize fallback without PyYAML

## Testing
- pytest tests/test_dsl_compile.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1e987a9c832fae81f665028a1b2b)