### PR TITLE
Add BoundQuery noop binding layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,35 @@ operation:
 fetch_spec = ContextFetchSpec(provider="relational", selectors={"op": "schema"})
 ```
 
+### QuerySketch (schema-bound)
+
+The `$dsl: "fetchgraph.dsl.query_sketch@v0"` envelope lets the planner specify
+compact relational queries without manually qualifying field paths or listing
+relations. During `compile_selectors`, the schema-aware binder resolves
+unqualified fields to the appropriate entity, auto-inserts required relations,
+and rewrites field references to the `relation.field` form expected by
+providers.
+
+Minimal payload example (unqualified field on a joined entity):
+
+```json
+{
+  "$dsl": "fetchgraph.dsl.query_sketch@v0",
+  "payload": {"from": "fbs", "where": [["system_name", "contains", "ЕСП"]], "take": 10}
+}
+```
+
+After compilation, the native selectors include the join and fully qualified
+field (e.g., `relations: ["fbs_as"]`, `filters.field: "fbs_as.system_name"`).
+
+Known limitations:
+
+- No fuzzy matching, aliases, or type-checking yet; resolution is purely
+  schema-based.
+- Ambiguity defaults to deterministic selection with warnings; set
+  `ResolutionPolicy(ambiguity_strategy="ask")` to fail on ambiguous fields.
+- `max_auto_join_depth` defaults to 2.
+
 ## CSV semantic backend for Pandas providers
 
 `fetchgraph.relational.semantic.backend` ships a lightweight TF-IDF backend that turns a CSV

--- a/examples/query_sketch_auto_join/README.md
+++ b/examples/query_sketch_auto_join/README.md
@@ -1,0 +1,46 @@
+# QuerySketch auto-join example
+
+This example shows how the `$dsl: "fetchgraph.dsl.query_sketch@v0"` envelope can
+be used to reference fields on related entities without manually listing
+relations. When the selectors are compiled, the schema-aware binder finds the
+necessary join path, rewrites field references, and injects relations for the
+native relational providers.
+
+## Sample plan snippet
+
+```json
+{
+  "context_plan": [
+    {
+      "provider": "rel",
+      "selectors": {
+        "$dsl": "fetchgraph.dsl.query_sketch@v0",
+        "payload": {
+          "from": "fbs",
+          "where": [["system_name", "contains", "ЕСП"]],
+          "take": 10
+        }
+      }
+    }
+  ]
+}
+```
+
+After `compile_plan_selectors` runs (automatically in the planning pipeline),
+the selector for provider `rel` will look like:
+
+```json
+{
+  "op": "query",
+  "root_entity": "fbs",
+  "relations": ["fbs_as"],
+  "filters": {"op": "contains", "field": "fbs_as.system_name", "value": "ЕСП"},
+  "limit": 10,
+  "offset": 0,
+  "case_sensitivity": false
+}
+```
+
+Notice how `system_name` was resolved onto the related `as` entity and
+automatically qualified with the `fbs_as` relation while keeping the query
+otherwise unchanged.

--- a/examples/query_sketch_auto_join/plan.json
+++ b/examples/query_sketch_auto_join/plan.json
@@ -1,0 +1,15 @@
+{
+  "context_plan": [
+    {
+      "provider": "rel",
+      "selectors": {
+        "$dsl": "fetchgraph.dsl.query_sketch@v0",
+        "payload": {
+          "from": "fbs",
+          "where": [["system_name", "contains", "ЕСП"]],
+          "take": 10
+        }
+      }
+    }
+  ]
+}

--- a/src/fetchgraph/core/context.py
+++ b/src/fetchgraph/core/context.py
@@ -638,6 +638,7 @@ class BaseGraphAgent:
                 len(merged),
             )
             plan = plan.model_copy(update={"context_plan": merged})
+            plan = compile_plan_selectors(plan, self.providers)
             # fetch again
             ctx = self._fetch(feature_name, plan)
             iters += 1

--- a/src/fetchgraph/core/context.py
+++ b/src/fetchgraph/core/context.py
@@ -26,6 +26,7 @@ from .protocols import (
     Verifier,
 )
 from .selector_dialects import compile_selectors
+from ..plan_compile import compile_plan_selectors
 from .utils import load_pkg_text, render_prompt
 
 logger = logging.getLogger(__name__)
@@ -453,6 +454,7 @@ class BaseGraphAgent:
             plan = self.plan_parser(plan_raw)
         else:
             plan = Plan.model_validate_json(plan_raw.text)
+        plan = compile_plan_selectors(plan, self.providers)
         elapsed = time.perf_counter() - t0
         logger.info(
             "Planning finished for feature_name=%r in %.3fs "

--- a/src/fetchgraph/core/protocols.py
+++ b/src/fetchgraph/core/protocols.py
@@ -6,8 +6,11 @@ from .models import ProviderInfo, RawLLMOutput
 
 if TYPE_CHECKING:
     from ..relational.types import SelectorsDict
+    from ..relational.models import EntityDescriptor, RelationDescriptor
 else:
     SelectorsDict = Dict[str, Any]
+    EntityDescriptor = Any
+    RelationDescriptor = Any
 
 
 class LLMInvoke(Protocol):
@@ -57,6 +60,9 @@ class SupportsFilter(Protocol):
 
 @runtime_checkable
 class SupportsDescribe(Protocol):
+    entities: List[EntityDescriptor]
+    relations: List[RelationDescriptor]
+
     def describe(self) -> ProviderInfo:
         """Describe the provider, including selector expectations.
 

--- a/src/fetchgraph/core/selector_dialects.py
+++ b/src/fetchgraph/core/selector_dialects.py
@@ -17,7 +17,7 @@ from .models import ProviderInfo
 QUERY_SKETCH_DSL_ID = "fetchgraph.dsl.query_sketch@v0"
 
 
-def _compile_query_sketch(provider: ContextProvider, payload: Any) -> Dict[str, Any]:
+def _compile_query_sketch(provider: SupportsDescribe, payload: Any) -> Dict[str, Any]:
     if payload is None:
         raise ValueError("Selector dialect fetchgraph.dsl.query_sketch@v0 requires 'payload'")
 
@@ -58,7 +58,7 @@ def _compile_query_sketch(provider: ContextProvider, payload: Any) -> Dict[str, 
     return compiled.model_dump()
 
 
-_COMPILERS: Dict[str, Callable[[ContextProvider, Any], Dict[str, Any]]] = {
+_COMPILERS: Dict[str, Callable[[SupportsDescribe, Any], Dict[str, Any]]] = {
     QUERY_SKETCH_DSL_ID: _compile_query_sketch,
 }
 

--- a/src/fetchgraph/core/selector_dialects.py
+++ b/src/fetchgraph/core/selector_dialects.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict
 
-from ..dsl import compile_relational_query, parse_and_normalize
+from ..dsl import (
+    SchemaRegistry,
+    bind_query_sketch,
+    compile_relational_query,
+    normalized_from_bound,
+    parse_and_normalize,
+)
+from ..dsl.resolution_policy import ResolutionPolicy
 from .protocols import ContextProvider, SupportsDescribe
 from .models import ProviderInfo
 
@@ -10,7 +17,7 @@ from .models import ProviderInfo
 QUERY_SKETCH_DSL_ID = "fetchgraph.dsl.query_sketch@v0"
 
 
-def _compile_query_sketch(payload: Any) -> Dict[str, Any]:
+def _compile_query_sketch(provider: SupportsDescribe, payload: Any) -> Dict[str, Any]:
     if payload is None:
         raise ValueError("Selector dialect fetchgraph.dsl.query_sketch@v0 requires 'payload'")
 
@@ -22,11 +29,21 @@ def _compile_query_sketch(payload: Any) -> Dict[str, Any]:
             "Selector dialect fetchgraph.dsl.query_sketch@v0 parse errors: " + summary
         )
 
-    compiled = compile_relational_query(sketch)
+    registry = SchemaRegistry(provider.entities, provider.relations)
+    bound, bind_diags = bind_query_sketch(sketch, registry, ResolutionPolicy())
+    if diagnostics.has_errors() or bind_diags.has_errors():
+        errors = diagnostics.errors() + bind_diags.errors()
+        summary = "; ".join(f"{err.code}: {err.message}" for err in errors)
+        raise ValueError(
+            "Selector dialect fetchgraph.dsl.query_sketch@v0 errors: " + summary
+        )
+
+    sketch2 = normalized_from_bound(bound)
+    compiled = compile_relational_query(sketch2)
     return compiled.model_dump()
 
 
-_COMPILERS: Dict[str, Callable[[Any], Dict[str, Any]]] = {
+_COMPILERS: Dict[str, Callable[[SupportsDescribe, Any], Dict[str, Any]]] = {
     QUERY_SKETCH_DSL_ID: _compile_query_sketch,
 }
 
@@ -73,7 +90,7 @@ def compile_selectors(provider: ContextProvider, selectors: Dict[str, Any]) -> D
         )
 
     payload = selectors.get("payload")
-    return compiler(payload)
+    return compiler(provider, payload)
 
 
 __all__ = ["compile_selectors", "QUERY_SKETCH_DSL_ID"]

--- a/src/fetchgraph/dsl/__init__.py
+++ b/src/fetchgraph/dsl/__init__.py
@@ -1,11 +1,13 @@
 from .ast import Clause, NormalizedQuerySketch, QuerySketch, WhereExpr
 from .bind_noop import bound_from_normalized, normalized_from_bound
+from .bind_schema import bind_query_sketch
 from .bound import BoundClause, BoundQuery, BoundWhereExpr, FieldRef, JoinPath
 from .compile import compile_relational_query, compile_relational_selectors
 from .diagnostics import Diagnostic, Diagnostics, Severity
 from .normalize import DslSpec, normalize_query_sketch, parse_and_normalize
 from .parser import parse_query_sketch
 from .schema_registry import FieldCandidate, SchemaRegistry
+from .resolution_policy import ResolutionPolicy
 
 __all__ = [
     "Clause",
@@ -19,6 +21,7 @@ __all__ = [
     "BoundQuery",
     "FieldCandidate",
     "SchemaRegistry",
+    "ResolutionPolicy",
     "Diagnostic",
     "Diagnostics",
     "Severity",
@@ -26,6 +29,7 @@ __all__ = [
     "parse_query_sketch",
     "normalize_query_sketch",
     "parse_and_normalize",
+    "bind_query_sketch",
     "bound_from_normalized",
     "normalized_from_bound",
     "compile_relational_query",

--- a/src/fetchgraph/dsl/__init__.py
+++ b/src/fetchgraph/dsl/__init__.py
@@ -5,6 +5,7 @@ from .compile import compile_relational_query, compile_relational_selectors
 from .diagnostics import Diagnostic, Diagnostics, Severity
 from .normalize import DslSpec, normalize_query_sketch, parse_and_normalize
 from .parser import parse_query_sketch
+from .schema_registry import FieldCandidate, SchemaRegistry
 
 __all__ = [
     "Clause",
@@ -16,6 +17,8 @@ __all__ = [
     "BoundClause",
     "BoundWhereExpr",
     "BoundQuery",
+    "FieldCandidate",
+    "SchemaRegistry",
     "Diagnostic",
     "Diagnostics",
     "Severity",

--- a/src/fetchgraph/dsl/__init__.py
+++ b/src/fetchgraph/dsl/__init__.py
@@ -1,4 +1,6 @@
 from .ast import Clause, NormalizedQuerySketch, QuerySketch, WhereExpr
+from .bind_noop import bound_from_normalized, normalized_from_bound
+from .bound import BoundClause, BoundQuery, BoundWhereExpr, FieldRef, JoinPath
 from .compile import compile_relational_query, compile_relational_selectors
 from .diagnostics import Diagnostic, Diagnostics, Severity
 from .normalize import DslSpec, normalize_query_sketch, parse_and_normalize
@@ -9,6 +11,11 @@ __all__ = [
     "WhereExpr",
     "QuerySketch",
     "NormalizedQuerySketch",
+    "JoinPath",
+    "FieldRef",
+    "BoundClause",
+    "BoundWhereExpr",
+    "BoundQuery",
     "Diagnostic",
     "Diagnostics",
     "Severity",
@@ -16,6 +23,8 @@ __all__ = [
     "parse_query_sketch",
     "normalize_query_sketch",
     "parse_and_normalize",
+    "bound_from_normalized",
+    "normalized_from_bound",
     "compile_relational_query",
     "compile_relational_selectors",
 ]

--- a/src/fetchgraph/dsl/bind_noop.py
+++ b/src/fetchgraph/dsl/bind_noop.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import List
+
+from .ast import Clause, ClauseOrGroup, NormalizedQuerySketch, WhereExpr
+from .bound import BoundClause, BoundQuery, BoundWhereExpr, JoinPath, parse_field_ref
+
+
+def bound_from_normalized(sketch: NormalizedQuerySketch) -> BoundQuery:
+    def convert_clause_or_group(item: ClauseOrGroup) -> BoundClause | BoundWhereExpr:
+        if isinstance(item, Clause):
+            return BoundClause(
+                field=parse_field_ref(item.path),
+                op=item.op,
+                value=item.value,
+                join_path=JoinPath([]),
+            )
+        return convert_where(item)
+
+    def convert_where(expr: WhereExpr) -> BoundWhereExpr:
+        converted_all: List[BoundClause | BoundWhereExpr] = [
+            convert_clause_or_group(item) for item in expr.all
+        ]
+        converted_any: List[BoundClause | BoundWhereExpr] = [
+            convert_clause_or_group(item) for item in expr.any
+        ]
+        converted_not = (
+            convert_clause_or_group(expr.not_) if expr.not_ is not None else None
+        )
+        return BoundWhereExpr(all=converted_all, any=converted_any, not_=converted_not)
+
+    bound_where = convert_where(sketch.where)
+    bound_get = [parse_field_ref(field) for field in sketch.get]
+
+    return BoundQuery(
+        from_=sketch.from_,
+        where=bound_where,
+        get=bound_get,
+        with_=list(sketch.with_),
+        take=sketch.take,
+        meta={},
+    )
+
+
+def normalized_from_bound(bound: BoundQuery) -> NormalizedQuerySketch:
+    def convert_clause_or_group(
+        item: BoundClause | BoundWhereExpr,
+    ) -> ClauseOrGroup:
+        if isinstance(item, BoundClause):
+            return Clause(path=item.field.raw, op=item.op, value=item.value)
+        return convert_where(item)
+
+    def convert_where(expr: BoundWhereExpr) -> WhereExpr:
+        converted_all: List[ClauseOrGroup] = [
+            convert_clause_or_group(item) for item in expr.all
+        ]
+        converted_any: List[ClauseOrGroup] = [
+            convert_clause_or_group(item) for item in expr.any
+        ]
+        converted_not = (
+            convert_clause_or_group(expr.not_) if expr.not_ is not None else None
+        )
+        return WhereExpr(all=converted_all, any=converted_any, not_=converted_not)
+
+    normalized_where = convert_where(bound.where)
+    normalized_get = [field.raw for field in bound.get]
+
+    return NormalizedQuerySketch(
+        from_=bound.from_,
+        where=normalized_where,
+        get=normalized_get,
+        with_=list(bound.with_),
+        take=bound.take,
+    )

--- a/src/fetchgraph/dsl/bind_schema.py
+++ b/src/fetchgraph/dsl/bind_schema.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Tuple
 
 from .ast import NormalizedQuerySketch
 from .bind_noop import bound_from_normalized
-from .bound import BoundClause, BoundWhereExpr, FieldRef, JoinPath, parse_field_ref
+from .bound import BoundClause, BoundQuery, BoundWhereExpr, FieldRef, JoinPath, parse_field_ref
 from .diagnostics import Diagnostics, Severity
 from .resolution_policy import ResolutionPolicy
 from .schema_registry import FieldCandidate, SchemaRegistry, _normalize_name

--- a/src/fetchgraph/dsl/bind_schema.py
+++ b/src/fetchgraph/dsl/bind_schema.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+from .ast import NormalizedQuerySketch
+from .bind_noop import bound_from_normalized
+from .bound import BoundClause, BoundWhereExpr, FieldRef, JoinPath, parse_field_ref
+from .diagnostics import Diagnostics, Severity
+from .resolution_policy import ResolutionPolicy
+from .schema_registry import FieldCandidate, SchemaRegistry, _normalize_name
+
+
+@dataclass
+class _ResolutionResult:
+    field_ref: FieldRef
+    join_path: Tuple[str, ...]
+    reason: str
+
+
+_DEF_REASON_ROOT = "root"
+_DEF_REASON_DECLARED = "declared"
+_DEF_REASON_AUTO = "auto"
+
+
+def bind_query_sketch(
+    sketch: NormalizedQuerySketch,
+    registry: SchemaRegistry,
+    policy: ResolutionPolicy,
+) -> tuple[BoundQuery, Diagnostics]:
+    bound = bound_from_normalized(sketch)
+    diagnostics = Diagnostics()
+
+    bindings: List[dict] = []
+
+    def record_binding(input_raw: str, result: _ResolutionResult, entity: str) -> None:
+        bindings.append(
+            {
+                "input": input_raw,
+                "output": result.field_ref.raw,
+                "entity": entity,
+                "join_path": list(result.join_path),
+                "reason": result.reason,
+            }
+        )
+
+    def add_relations(join_path: Iterable[str]) -> None:
+        if not policy.allow_auto_add_relations:
+            return
+        for rel in join_path:
+            if rel not in bound.with_:
+                bound.with_.append(rel)
+
+    def rewrite_field(field_ref: FieldRef, join_path: Tuple[str, ...], column_name: str, entity_name: str) -> FieldRef:
+        if join_path:
+            qualifier = join_path[-1]
+            raw = f"{qualifier}.{column_name}"
+        else:
+            qualifier = None
+            raw = column_name
+        updated = parse_field_ref(raw)
+        updated.entity = entity_name
+        field_ref.raw = updated.raw
+        field_ref.qualifier = updated.qualifier
+        field_ref.field = updated.field
+        field_ref.entity = updated.entity
+        return field_ref
+
+    def resolve_qualified(field_ref: FieldRef, qualifier: str) -> _ResolutionResult | None:
+        norm_qualifier = _normalize_name(qualifier)
+        if norm_qualifier in registry.relations_by_name:
+            relation = registry.relations_by_name[norm_qualifier]
+            paths = registry.find_paths(bound.from_, relation.from_entity, max_depth=policy.max_auto_join_depth)
+            if not paths:
+                diagnostics.add(
+                    code="DSL_BIND_RELATION_PATH_NOT_FOUND",
+                    message=f"No path from root {bound.from_!r} to relation source {relation.from_entity!r}",
+                    path=field_ref.raw,
+                    severity=Severity.ERROR,
+                )
+                return None
+            join_path = paths[0] + (relation.name,)
+            if not registry.has_field(relation.to_entity, field_ref.field):
+                diagnostics.add(
+                    code="DSL_BIND_FIELD_NOT_FOUND",
+                    message=f"Field {field_ref.field!r} not found on entity {relation.to_entity!r}",
+                    path=field_ref.raw,
+                    severity=Severity.ERROR,
+                )
+                return None
+            column = registry.field(relation.to_entity, field_ref.field)
+            rewrite_field(field_ref, join_path, column.name, registry.entity(relation.to_entity).name)
+            return _ResolutionResult(field_ref=field_ref, join_path=join_path, reason=_DEF_REASON_DECLARED)
+
+        if not registry.has_entity(qualifier):
+            diagnostics.add(
+                code="DSL_BIND_UNKNOWN_QUALIFIER",
+                message=f"Unknown qualifier {qualifier!r}",
+                path=field_ref.raw,
+                severity=Severity.ERROR,
+            )
+            return None
+
+        paths = registry.find_paths(bound.from_, qualifier, max_depth=policy.max_auto_join_depth)
+        if not paths:
+            diagnostics.add(
+                code="DSL_BIND_RELATION_PATH_NOT_FOUND",
+                message=f"No path from root {bound.from_!r} to entity {qualifier!r}",
+                path=field_ref.raw,
+                severity=Severity.ERROR,
+            )
+            return None
+
+        join_path = paths[0]
+        if not registry.has_field(qualifier, field_ref.field):
+            diagnostics.add(
+                code="DSL_BIND_FIELD_NOT_FOUND",
+                message=f"Field {field_ref.field!r} not found on entity {qualifier!r}",
+                path=field_ref.raw,
+                severity=Severity.ERROR,
+            )
+            return None
+        column = registry.field(qualifier, field_ref.field)
+        entity_name = registry.entity(qualifier).name
+        rewrite_field(field_ref, join_path, column.name, entity_name)
+        return _ResolutionResult(field_ref=field_ref, join_path=join_path, reason=_reason_for_path(join_path))
+
+    def choose_best_candidate(field_ref: FieldRef) -> FieldCandidate | None:
+        declared_with = bound.with_ if policy.prefer_declared_relations else None
+        candidates = registry.field_candidates(
+            bound.from_,
+            field_ref.field,
+            max_depth=policy.max_auto_join_depth,
+            declared_with=declared_with,
+        )
+        if not candidates:
+            diagnostics.add(
+                code="DSL_BIND_FIELD_NOT_FOUND",
+                message=f"Field {field_ref.field!r} not found on root or reachable entities",
+                path=field_ref.raw,
+                severity=Severity.ERROR,
+            )
+            return None
+
+        best = candidates[0]
+        if len(candidates) > 1:
+            best_priority = _priority_key(best, declared_with)
+            competing = [c for c in candidates if _priority_key(c, declared_with) == best_priority]
+            if len(competing) > 1:
+                message = (
+                    f"Ambiguous field {field_ref.field!r}: candidates on "
+                    + ", ".join(f"{c.entity} via {'/'.join(c.join_path) or 'root'}" for c in competing)
+                )
+                severity = Severity.ERROR if policy.ambiguity_strategy == "ask" else Severity.WARNING
+                diagnostics.add(
+                    code="DSL_BIND_AMBIGUOUS_FIELD",
+                    message=message,
+                    path=field_ref.raw,
+                    severity=severity,
+                )
+                if policy.ambiguity_strategy == "ask":
+                    return None
+                best = competing[0]
+        return best
+
+    def resolve_unqualified(field_ref: FieldRef) -> _ResolutionResult | None:
+        candidate = choose_best_candidate(field_ref)
+        if candidate is None:
+            return None
+
+        reason = _reason_for_path(candidate.join_path)
+        column = registry.field(candidate.entity, candidate.field)
+        rewrite_field(field_ref, candidate.join_path, column.name, registry.entity(candidate.entity).name)
+        return _ResolutionResult(field_ref=field_ref, join_path=candidate.join_path, reason=reason)
+
+    def _reason_for_path(join_path: Tuple[str, ...]) -> str:
+        if not join_path:
+            return _DEF_REASON_ROOT
+        declared_norm = tuple(_normalize_name(r) for r in bound.with_)
+        normalized_path = tuple(_normalize_name(r) for r in join_path)
+        if declared_norm and normalized_path[: len(declared_norm)] == declared_norm:
+            return _DEF_REASON_DECLARED
+        return _DEF_REASON_AUTO
+
+    def process_field(field_ref: FieldRef, location: str) -> _ResolutionResult | None:
+        input_raw = field_ref.raw
+        if field_ref.raw == "*":
+            return None
+
+        if field_ref.qualifier is not None:
+            result = resolve_qualified(field_ref, field_ref.qualifier)
+        else:
+            result = resolve_unqualified(field_ref)
+
+        if result is None:
+            return None
+
+        add_relations(result.join_path)
+        record_binding(input_raw, result, field_ref.entity or "")
+        return result
+
+    def process_clause(clause: BoundClause, location: str) -> None:
+        result = process_field(clause.field, location)
+        if result is not None:
+            clause.join_path = JoinPath(list(result.join_path))
+
+    def walk_where(expr: BoundWhereExpr, path_prefix: str) -> None:
+        for idx, item in enumerate(expr.all):
+            if isinstance(item, BoundClause):
+                process_clause(item, f"{path_prefix}.all[{idx}]")
+            else:
+                walk_where(item, f"{path_prefix}.all[{idx}]")
+        for idx, item in enumerate(expr.any):
+            if isinstance(item, BoundClause):
+                process_clause(item, f"{path_prefix}.any[{idx}]")
+            else:
+                walk_where(item, f"{path_prefix}.any[{idx}]")
+        if expr.not_ is not None:
+            if isinstance(expr.not_, BoundClause):
+                process_clause(expr.not_, f"{path_prefix}.not")
+            else:
+                walk_where(expr.not_, f"{path_prefix}.not")
+
+    for idx, field in enumerate(bound.get):
+        process_field(field, f"get[{idx}]")
+
+    walk_where(bound.where, "where")
+
+    if bindings:
+        bound.meta.setdefault("bindings", bindings)
+
+    return bound, diagnostics
+
+
+def _candidate_key(candidate: FieldCandidate, declared_with: List[str] | None) -> tuple:
+    declared_norm = tuple(_normalize_name(r) for r in declared_with) if declared_with else tuple()
+    normalized_path = tuple(_normalize_name(r) for r in candidate.join_path)
+    declared_first = 0 if declared_norm and normalized_path[: len(declared_norm)] == declared_norm else 1
+    return (
+        len(candidate.join_path),
+        declared_first,
+        candidate.join_path,
+        candidate.entity,
+        candidate.field,
+    )
+
+
+def _priority_key(candidate: FieldCandidate, declared_with: List[str] | None) -> tuple[int, int]:
+    declared_norm = tuple(_normalize_name(r) for r in declared_with) if declared_with else tuple()
+    normalized_path = tuple(_normalize_name(r) for r in candidate.join_path)
+    declared_first = 0 if declared_norm and normalized_path[: len(declared_norm)] == declared_norm else 1
+    return (len(candidate.join_path), declared_first)

--- a/src/fetchgraph/dsl/bound.py
+++ b/src/fetchgraph/dsl/bound.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field as dataclass_field
 from typing import Any, List, Optional, Union
 
 
@@ -22,7 +22,7 @@ class BoundClause:
     field: FieldRef
     op: str
     value: Any
-    join_path: JoinPath = field(default_factory=lambda: JoinPath([]))
+    join_path: JoinPath = dataclass_field(default_factory=lambda: JoinPath([]))
 
 
 BoundClauseOrGroup = Union[BoundClause, "BoundWhereExpr"]
@@ -30,8 +30,8 @@ BoundClauseOrGroup = Union[BoundClause, "BoundWhereExpr"]
 
 @dataclass
 class BoundWhereExpr:
-    all: List[BoundClauseOrGroup] = field(default_factory=list)
-    any: List[BoundClauseOrGroup] = field(default_factory=list)
+    all: List[BoundClauseOrGroup] = dataclass_field(default_factory=list)
+    any: List[BoundClauseOrGroup] = dataclass_field(default_factory=list)
     not_: Optional[BoundClauseOrGroup] = None
 
 
@@ -42,7 +42,7 @@ class BoundQuery:
     get: List[FieldRef]
     with_: List[str]
     take: int
-    meta: dict = field(default_factory=dict)
+    meta: dict = dataclass_field(default_factory=dict)
 
 
 def parse_field_ref(raw: str) -> FieldRef:

--- a/src/fetchgraph/dsl/bound.py
+++ b/src/fetchgraph/dsl/bound.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Union
+
+
+@dataclass
+class JoinPath:
+    relations: List[str]
+
+
+@dataclass
+class FieldRef:
+    raw: str
+    qualifier: Optional[str]
+    field: str
+    entity: Optional[str] = None
+
+
+@dataclass
+class BoundClause:
+    field: FieldRef
+    op: str
+    value: Any
+    join_path: JoinPath = field(default_factory=lambda: JoinPath([]))
+
+
+BoundClauseOrGroup = Union[BoundClause, "BoundWhereExpr"]
+
+
+@dataclass
+class BoundWhereExpr:
+    all: List[BoundClauseOrGroup] = field(default_factory=list)
+    any: List[BoundClauseOrGroup] = field(default_factory=list)
+    not_: Optional[BoundClauseOrGroup] = None
+
+
+@dataclass
+class BoundQuery:
+    from_: str
+    where: BoundWhereExpr
+    get: List[FieldRef]
+    with_: List[str]
+    take: int
+    meta: dict = field(default_factory=dict)
+
+
+def parse_field_ref(raw: str) -> FieldRef:
+    if "." in raw:
+        qualifier, rest = raw.split(".", 1)
+        return FieldRef(raw=raw, qualifier=qualifier, field=rest)
+    return FieldRef(raw=raw, qualifier=None, field=raw)

--- a/src/fetchgraph/dsl/resolution_policy.py
+++ b/src/fetchgraph/dsl/resolution_policy.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ResolutionPolicy:
+    max_auto_join_depth: int = 2
+    allow_auto_add_relations: bool = True
+    ambiguity_strategy: str = "best"
+    prefer_declared_relations: bool = True

--- a/src/fetchgraph/dsl/schema_registry.py
+++ b/src/fetchgraph/dsl/schema_registry.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from ..relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor
+
+
+def _normalize_name(value: Any) -> str:
+    s = str(value)
+    s = s.strip()
+    s = s.lower()
+    s = " ".join(s.split())
+    return s
+
+
+@dataclass(frozen=True)
+class FieldCandidate:
+    entity: str
+    field: str
+    field_type: str
+    join_path: Tuple[str, ...]
+
+
+class SchemaRegistry:
+    entity_by_name: Dict[str, EntityDescriptor]
+    fields_by_entity: Dict[str, Dict[str, ColumnDescriptor]]
+    relations_by_name: Dict[str, RelationDescriptor]
+    adj: Dict[str, List[RelationDescriptor]]
+
+    def __init__(self, entities: List[EntityDescriptor], relations: List[RelationDescriptor]):
+        self.entity_by_name = {}
+        self.fields_by_entity = {}
+        self.relations_by_name = {}
+        self.adj = {}
+
+        for entity in entities:
+            norm_name = _normalize_name(entity.name)
+            if norm_name in self.entity_by_name:
+                raise ValueError(f"Duplicate entity name: {entity.name}")
+            self.entity_by_name[norm_name] = entity
+            field_map: Dict[str, ColumnDescriptor] = {}
+            for column in entity.columns:
+                norm_field = _normalize_name(column.name)
+                if norm_field not in field_map:
+                    field_map[norm_field] = column
+            self.fields_by_entity[norm_name] = field_map
+
+        sorted_relations = sorted(relations, key=lambda r: r.name)
+        for relation in sorted_relations:
+            norm_name = _normalize_name(relation.name)
+            if norm_name in self.relations_by_name:
+                raise ValueError(f"Duplicate relation name: {relation.name}")
+
+            from_norm = _normalize_name(relation.from_entity)
+            to_norm = _normalize_name(relation.to_entity)
+            if from_norm not in self.entity_by_name or to_norm not in self.entity_by_name:
+                raise ValueError(
+                    f"Relation {relation.name} references unknown entities: "
+                    f"{relation.from_entity} -> {relation.to_entity}"
+                )
+
+            self.relations_by_name[norm_name] = relation
+            self.adj.setdefault(from_norm, []).append(relation)
+
+    def has_entity(self, name: str) -> bool:
+        norm_name = _normalize_name(name)
+        return norm_name in self.entity_by_name
+
+    def entity(self, name: str) -> EntityDescriptor:
+        norm_name = _normalize_name(name)
+        if norm_name not in self.entity_by_name:
+            raise KeyError(name)
+        return self.entity_by_name[norm_name]
+
+    def has_field(self, entity: str, field: str) -> bool:
+        norm_entity = _normalize_name(entity)
+        norm_field = _normalize_name(field)
+        if norm_entity not in self.fields_by_entity:
+            return False
+        return norm_field in self.fields_by_entity[norm_entity]
+
+    def field(self, entity: str, field: str) -> ColumnDescriptor:
+        norm_entity = _normalize_name(entity)
+        norm_field = _normalize_name(field)
+        if norm_entity not in self.fields_by_entity:
+            raise KeyError(entity)
+        if norm_field not in self.fields_by_entity[norm_entity]:
+            raise KeyError(field)
+        return self.fields_by_entity[norm_entity][norm_field]
+
+    def find_entities_with_field(self, field: str) -> List[str]:
+        norm_field = _normalize_name(field)
+        matches = []
+        for norm_entity, fields in self.fields_by_entity.items():
+            if norm_field in fields:
+                matches.append(self.entity_by_name[norm_entity].name)
+        return sorted(matches)
+
+    def find_paths(self, root: str, target: str, *, max_depth: int) -> List[Tuple[str, ...]]:
+        norm_root = _normalize_name(root)
+        norm_target = _normalize_name(target)
+        if norm_root not in self.entity_by_name:
+            raise KeyError(root)
+        if norm_target not in self.entity_by_name:
+            raise KeyError(target)
+        if max_depth < 0:
+            return []
+
+        queue = deque([(norm_root, tuple())])
+        best_depth: Dict[str, int] = {norm_root: 0}
+        paths: List[Tuple[str, ...]] = []
+        min_target_depth: int | None = None
+
+        while queue:
+            current_entity, path = queue.popleft()
+            depth = len(path)
+
+            if min_target_depth is not None and depth >= min_target_depth:
+                continue
+
+            for relation in self.adj.get(current_entity, []):
+                next_entity = _normalize_name(relation.to_entity)
+                new_path = path + (relation.name,)
+                new_depth = depth + 1
+
+                if new_depth > max_depth:
+                    continue
+
+                if min_target_depth is not None and new_depth > min_target_depth:
+                    continue
+
+                current_best = best_depth.get(next_entity)
+                if current_best is None or new_depth < current_best:
+                    best_depth[next_entity] = new_depth
+                    queue.append((next_entity, new_path))
+                elif new_depth == current_best:
+                    queue.append((next_entity, new_path))
+
+                if next_entity == norm_target:
+                    min_target_depth = new_depth if min_target_depth is None else min(min_target_depth, new_depth)
+                    paths.append(new_path)
+
+        if min_target_depth is None:
+            return []
+
+        shortest_paths = [p for p in paths if len(p) == min_target_depth]
+        return sorted(shortest_paths)
+
+    def field_candidates(
+        self,
+        root: str,
+        field: str,
+        *,
+        max_depth: int,
+        declared_with: List[str] | None = None,
+    ) -> List[FieldCandidate]:
+        norm_root = _normalize_name(root)
+        norm_field = _normalize_name(field)
+
+        if norm_root not in self.entity_by_name:
+            raise KeyError(root)
+        if max_depth < 0:
+            return []
+
+        declared_norm = tuple(_normalize_name(r) for r in declared_with) if declared_with else None
+        candidates: List[FieldCandidate] = []
+
+        root_fields = self.fields_by_entity.get(norm_root, {})
+        if norm_field in root_fields:
+            column = root_fields[norm_field]
+            candidates.append(
+                FieldCandidate(
+                    entity=self.entity_by_name[norm_root].name,
+                    field=column.name,
+                    field_type=column.type,
+                    join_path=tuple(),
+                )
+            )
+
+        for norm_entity, fields in self.fields_by_entity.items():
+            if norm_entity == norm_root:
+                continue
+            if norm_field not in fields:
+                continue
+
+            paths = self.find_paths(self.entity_by_name[norm_root].name, self.entity_by_name[norm_entity].name, max_depth=max_depth)
+            if not paths:
+                continue
+
+            path = paths[0]
+            column = fields[norm_field]
+            candidates.append(
+                FieldCandidate(
+                    entity=self.entity_by_name[norm_entity].name,
+                    field=column.name,
+                    field_type=column.type,
+                    join_path=path,
+                )
+            )
+
+        def sort_key(candidate: FieldCandidate):
+            join_path = candidate.join_path
+            declared_first = 0
+            if declared_norm is not None:
+                normalized_path = tuple(_normalize_name(r) for r in join_path)
+                declared_first = 0 if normalized_path[: len(declared_norm)] == declared_norm else 1
+            return (
+                len(join_path),
+                declared_first,
+                join_path,
+                candidate.entity,
+                candidate.field,
+            )
+
+        candidates.sort(key=sort_key)
+        return candidates

--- a/src/fetchgraph/dsl/schema_registry.py
+++ b/src/fetchgraph/dsl/schema_registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Deque, Dict, List, Tuple
 
 from ..relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor
 
@@ -112,7 +112,7 @@ class SchemaRegistry:
         if norm_root == norm_target:
             return [tuple()]
 
-        queue = deque([(norm_root, tuple())])
+        queue: Deque[Tuple[str, Tuple[str, ...]]] = deque([(norm_root, tuple())])
         best_depth: Dict[str, int] = {norm_root: 0}
         paths: List[Tuple[str, ...]] = []
         min_target_depth: int | None = None

--- a/src/fetchgraph/dsl/schema_registry.py
+++ b/src/fetchgraph/dsl/schema_registry.py
@@ -191,11 +191,25 @@ class SchemaRegistry:
             if norm_field not in fields:
                 continue
 
-            paths = self.find_paths(self.entity_by_name[norm_root].name, self.entity_by_name[norm_entity].name, max_depth=max_depth)
+            paths = self.find_paths(
+                self.entity_by_name[norm_root].name,
+                self.entity_by_name[norm_entity].name,
+                max_depth=max_depth,
+            )
             if not paths:
                 continue
 
-            path = paths[0]
+            declared_set = {_normalize_name(r) for r in declared_with} if declared_with else None
+
+            def path_key(p: Tuple[str, ...]) -> tuple[int, Tuple[str, ...]]:
+                if declared_set:
+                    normalized_path = {_normalize_name(r) for r in p}
+                    declared_first = 0 if normalized_path.issubset(declared_set) else 1
+                else:
+                    declared_first = 1
+                return (declared_first, p)
+
+            path = sorted(paths, key=path_key)[0]
             column = fields[norm_field]
             candidates.append(
                 FieldCandidate(

--- a/src/fetchgraph/plan_compile.py
+++ b/src/fetchgraph/plan_compile.py
@@ -43,6 +43,24 @@ def _validate_compiled(provider: ContextProvider, compiled: Dict[str, Any]) -> N
                 )
     elif op == "schema":
         SchemaRequest.model_validate(compiled)
+        if entity_names:
+            requested_entities = compiled.get("entities") or []
+            missing_entities = [e for e in requested_entities if e not in entity_names]
+            if missing_entities:
+                raise ValueError(
+                    "Unknown entities: "
+                    + ", ".join(sorted(missing_entities))
+                    + f"; known entities: {sorted(entity_names)}"
+                )
+        if relation_names:
+            requested_relations = compiled.get("relations") or []
+            missing_relations = [r for r in requested_relations if r not in relation_names]
+            if missing_relations:
+                raise ValueError(
+                    "Unknown relations: "
+                    + ", ".join(sorted(missing_relations))
+                    + f"; known relations: {sorted(relation_names)}"
+                )
     elif op == "semantic_only":
         SemanticOnlyRequest.model_validate(compiled)
         if entity_names:

--- a/src/fetchgraph/plan_compile.py
+++ b/src/fetchgraph/plan_compile.py
@@ -15,17 +15,42 @@ from .core.selector_dialects import compile_selectors
 from .relational.models import RelationalQuery, SchemaRequest, SemanticOnlyRequest
 
 
-def _validate_compiled(compiled: Dict[str, Any]) -> None:
+def _validate_compiled(provider: ContextProvider, compiled: Dict[str, Any]) -> None:
     """Validate compiled selectors using provider schemas when possible."""
 
     op = compiled.get("op") if isinstance(compiled, dict) else None
 
+    entity_names = {e.name for e in getattr(provider, "entities", []) or []}
+    relation_names = {r.name for r in getattr(provider, "relations", []) or []}
+
     if op == "query":
         RelationalQuery.model_validate(compiled)
+        if entity_names:
+            root = compiled.get("root_entity")
+            if root not in entity_names:
+                raise ValueError(
+                    f"Unknown root_entity {root!r}; known entities: {sorted(entity_names)}"
+                )
+        if relation_names:
+            missing_relations = [
+                rel for rel in compiled.get("relations") or [] if rel not in relation_names
+            ]
+            if missing_relations:
+                raise ValueError(
+                    "Unknown relations: "
+                    + ", ".join(sorted(missing_relations))
+                    + f"; known relations: {sorted(relation_names)}"
+                )
     elif op == "schema":
         SchemaRequest.model_validate(compiled)
     elif op == "semantic_only":
         SemanticOnlyRequest.model_validate(compiled)
+        if entity_names:
+            entity = compiled.get("entity")
+            if entity not in entity_names:
+                raise ValueError(
+                    f"Unknown entity {entity!r}; known entities: {sorted(entity_names)}"
+                )
 
 
 def compile_plan_selectors(
@@ -54,7 +79,7 @@ def compile_plan_selectors(
             )
 
         compiled = compile_selectors(provider, spec.selectors or {})
-        _validate_compiled(compiled)
+        _validate_compiled(provider, compiled)
 
         compiled_specs.append(spec.model_copy(update={"selectors": compiled}))
 

--- a/src/fetchgraph/plan_compile.py
+++ b/src/fetchgraph/plan_compile.py
@@ -1,0 +1,64 @@
+"""Compile and validate selectors inside a parsed plan.
+
+The planner may emit selector envelopes that rely on the $dsl mechanism. This
+module compiles them into provider-native selectors immediately after parsing
+to catch schema or validation errors early.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .core.models import Plan
+from .core.protocols import ContextProvider
+from .core.selector_dialects import compile_selectors
+from .relational.models import RelationalQuery, SchemaRequest, SemanticOnlyRequest
+
+
+def _validate_compiled(compiled: Dict[str, Any]) -> None:
+    """Validate compiled selectors using provider schemas when possible."""
+
+    op = compiled.get("op") if isinstance(compiled, dict) else None
+
+    if op == "query":
+        RelationalQuery.model_validate(compiled)
+    elif op == "schema":
+        SchemaRequest.model_validate(compiled)
+    elif op == "semantic_only":
+        SemanticOnlyRequest.model_validate(compiled)
+
+
+def compile_plan_selectors(
+    plan: Plan, providers: Mapping[str, ContextProvider]
+) -> Plan:
+    """Compile all selector envelopes inside a parsed plan.
+
+    Parameters
+    ----------
+    plan:
+        Parsed plan produced by :class:`PlanParser`.
+    providers:
+        Mapping from provider keys to provider instances capable of selector
+        compilation.
+    """
+
+    if not plan.context_plan:
+        return plan
+
+    compiled_specs = []
+    for spec in plan.context_plan:
+        provider = providers.get(spec.provider)
+        if provider is None:
+            raise ValueError(
+                f"Provider {spec.provider!r} is missing; cannot compile selectors"
+            )
+
+        compiled = compile_selectors(provider, spec.selectors or {})
+        _validate_compiled(compiled)
+
+        compiled_specs.append(spec.model_copy(update={"selectors": compiled}))
+
+    return plan.model_copy(update={"context_plan": compiled_specs})
+
+
+__all__ = ["compile_plan_selectors"]

--- a/src/fetchgraph/relational/providers/pandas_provider.py
+++ b/src/fetchgraph/relational/providers/pandas_provider.py
@@ -442,7 +442,7 @@ class PandasRelationalDataProvider(RelationalDataProvider):
         if not select:
             return df
         cols: List[str] = []
-        alias_map: Dict[Hashable, Hashable] = {}
+        alias_map: Dict[str, str] = {}
         for expr in select:
             if "." in expr.expr:
                 ent, fld = expr.expr.split(".", 1)

--- a/src/fetchgraph/relational/providers/pandas_provider.py
+++ b/src/fetchgraph/relational/providers/pandas_provider.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Hashable, List, Mapping, MutableMapping, Optional,
 
 import pandas as pd  # type: ignore[import]
 from pandas.api import types as pdt
-from pandas._typing import Renamer
 from difflib import SequenceMatcher
 
 from .base import RelationalDataProvider
@@ -454,7 +453,7 @@ class PandasRelationalDataProvider(RelationalDataProvider):
                 alias_map[col] = expr.alias
         selected = df[cols].copy()
         if alias_map:
-            selected = selected.rename(columns=cast(Renamer, alias_map))
+            selected = selected.rename(columns=alias_map)
         return selected
 
     def _handle_query(self, req: RelationalQuery):

--- a/tests/dsl/test_bind_schema_auto_join.py
+++ b/tests/dsl/test_bind_schema_auto_join.py
@@ -1,0 +1,110 @@
+from fetchgraph.dsl import Clause, NormalizedQuerySketch, SchemaRegistry, WhereExpr, bind_query_sketch
+from fetchgraph.dsl.resolution_policy import ResolutionPolicy
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+
+
+def make_registry(
+    include_root_field: bool = False,
+    include_env_direct: bool = False,
+    include_as_name: bool = False,
+) -> SchemaRegistry:
+    entities = [
+        EntityDescriptor(
+            name="fbs",
+            columns=[
+                ColumnDescriptor(name="id"),
+                *( [ColumnDescriptor(name="system_name")] if include_root_field else []),
+            ],
+        ),
+        EntityDescriptor(
+            name="as",
+            columns=[
+                ColumnDescriptor(name="id"),
+                ColumnDescriptor(name="system_name"),
+                *( [ColumnDescriptor(name="name")] if include_as_name else []),
+            ],
+        ),
+        EntityDescriptor(
+            name="env",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="name")],
+        ),
+    ]
+
+    relations = [
+        RelationDescriptor(
+            name="fbs_as",
+            from_entity="fbs",
+            to_entity="as",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+        ),
+        RelationDescriptor(
+            name="as_env",
+            from_entity="as",
+            to_entity="env",
+            join=RelationJoin(from_entity="as", from_column="id", to_entity="env", to_column="id"),
+        ),
+    ]
+
+    if include_env_direct:
+        relations.append(
+            RelationDescriptor(
+                name="fbs_env",
+                from_entity="fbs",
+                to_entity="env",
+                join=RelationJoin(from_entity="fbs", from_column="id", to_entity="env", to_column="id"),
+            )
+        )
+
+    return SchemaRegistry(entities, relations)
+
+
+def make_sketch(path: str) -> NormalizedQuerySketch:
+    return NormalizedQuerySketch(
+        from_="fbs",
+        where=WhereExpr(all=[Clause(path=path, op="contains", value="ЕСП")]),
+        get=["*"],
+        with_=[],
+        take=10,
+    )
+
+
+def test_auto_join_for_unqualified_field():
+    registry = make_registry(include_root_field=False)
+    sketch = make_sketch("system_name")
+
+    bound, diags = bind_query_sketch(sketch, registry, ResolutionPolicy())
+
+    assert not diags.has_errors()
+    assert bound.with_ == ["fbs_as"]
+    clause = bound.where.all[0]
+    assert clause.field.raw == "fbs_as.system_name"
+
+
+def test_multi_hop_auto_join_adds_all_relations():
+    registry = make_registry(include_root_field=False)
+    sketch = NormalizedQuerySketch(
+        from_="fbs",
+        where=WhereExpr(all=[Clause(path="name", op="is", value="prod")]),
+        get=["*"],
+        with_=[],
+        take=5,
+    )
+
+    bound, diags = bind_query_sketch(sketch, registry, ResolutionPolicy())
+
+    assert not diags.has_errors()
+    assert bound.with_ == ["fbs_as", "as_env"]
+    clause = bound.where.all[0]
+    assert clause.field.raw == "as_env.name"
+
+
+def test_ambiguity_with_ask_strategy_reports_error():
+    registry = make_registry(
+        include_root_field=False, include_env_direct=True, include_as_name=True
+    )
+    sketch = make_sketch("name")
+
+    _, diags = bind_query_sketch(sketch, registry, ResolutionPolicy(ambiguity_strategy="ask"))
+
+    assert diags.has_errors()
+    assert any(err.code == "DSL_BIND_AMBIGUOUS_FIELD" for err in diags.errors())

--- a/tests/dsl/test_bind_schema_auto_join.py
+++ b/tests/dsl/test_bind_schema_auto_join.py
@@ -1,4 +1,11 @@
-from fetchgraph.dsl import Clause, NormalizedQuerySketch, SchemaRegistry, WhereExpr, bind_query_sketch
+from fetchgraph.dsl import (
+    BoundClause,
+    Clause,
+    NormalizedQuerySketch,
+    SchemaRegistry,
+    WhereExpr,
+    bind_query_sketch,
+)
 from fetchgraph.dsl.resolution_policy import ResolutionPolicy
 from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
 
@@ -77,6 +84,7 @@ def test_auto_join_for_unqualified_field():
     assert not diags.has_errors()
     assert bound.with_ == ["fbs_as"]
     clause = bound.where.all[0]
+    assert isinstance(clause, BoundClause)
     assert clause.field.raw == "fbs_as.system_name"
 
 
@@ -95,6 +103,7 @@ def test_multi_hop_auto_join_adds_all_relations():
     assert not diags.has_errors()
     assert bound.with_ == ["fbs_as", "as_env"]
     clause = bound.where.all[0]
+    assert isinstance(clause, BoundClause)
     assert clause.field.raw == "as_env.name"
 
 

--- a/tests/dsl/test_bound_query_roundtrip.py
+++ b/tests/dsl/test_bound_query_roundtrip.py
@@ -25,7 +25,9 @@ def test_bound_roundtrip_simple_where_and_get():
     assert bound.get[0].raw == "bc_guid"
     assert bound.get[1].qualifier == "fbs_as"
     assert bound.get[1].field == "system_name"
-    assert bound.where.all[0].field.raw == "system_name"
+    first_clause = bound.where.all[0]
+    assert isinstance(first_clause, BoundClause)
+    assert first_clause.field.raw == "system_name"
 
     assert restored == sketch
 

--- a/tests/dsl/test_bound_query_roundtrip.py
+++ b/tests/dsl/test_bound_query_roundtrip.py
@@ -1,4 +1,5 @@
 from fetchgraph.dsl import (
+    BoundClause,
     BoundWhereExpr,
     Clause,
     NormalizedQuerySketch,
@@ -54,5 +55,8 @@ def test_bound_roundtrip_nested_groups():
 
     assert isinstance(bound.where.all[1], BoundWhereExpr)
     assert restored == sketch
+    assert isinstance(bound.where.all[1], BoundWhereExpr)
+    assert isinstance(bound.where.all[1].any[0], BoundClause)
     assert bound.where.all[1].any[0].field.raw == "b.c"
+    assert isinstance(bound.where.not_, BoundClause)
     assert bound.where.not_.field.raw == "x.y.z"

--- a/tests/dsl/test_bound_query_roundtrip.py
+++ b/tests/dsl/test_bound_query_roundtrip.py
@@ -1,0 +1,58 @@
+from fetchgraph.dsl import (
+    BoundWhereExpr,
+    Clause,
+    NormalizedQuerySketch,
+    WhereExpr,
+    bound_from_normalized,
+    compile_relational_selectors,
+    normalized_from_bound,
+)
+
+
+def test_bound_roundtrip_simple_where_and_get():
+    sketch = NormalizedQuerySketch(
+        from_="fbs",
+        where=WhereExpr(all=[Clause(path="system_name", op="contains", value="ЕСП")]),
+        get=["bc_guid", "fbs_as.system_name"],
+        with_=[],
+        take=100,
+    )
+
+    bound = bound_from_normalized(sketch)
+    restored = normalized_from_bound(bound)
+
+    assert bound.get[0].raw == "bc_guid"
+    assert bound.get[1].qualifier == "fbs_as"
+    assert bound.get[1].field == "system_name"
+    assert bound.where.all[0].field.raw == "system_name"
+
+    assert restored == sketch
+
+    selectors_original = compile_relational_selectors(sketch)
+    selectors_roundtrip = compile_relational_selectors(restored)
+
+    assert selectors_roundtrip == selectors_original
+
+
+def test_bound_roundtrip_nested_groups():
+    sketch = NormalizedQuerySketch(
+        from_="root",
+        where=WhereExpr(
+            all=[
+                Clause(path="a", op="is", value=1),
+                WhereExpr(any=[Clause(path="b.c", op="is", value="x")]),
+            ],
+            not_=Clause(path="x.y.z", op="contains", value="q"),
+        ),
+        get=["field"],
+        with_=[],
+        take=0,
+    )
+
+    bound = bound_from_normalized(sketch)
+    restored = normalized_from_bound(bound)
+
+    assert isinstance(bound.where.all[1], BoundWhereExpr)
+    assert restored == sketch
+    assert bound.where.all[1].any[0].field.raw == "b.c"
+    assert bound.where.not_.field.raw == "x.y.z"

--- a/tests/dsl/test_schema_registry_paths.py
+++ b/tests/dsl/test_schema_registry_paths.py
@@ -1,0 +1,57 @@
+from fetchgraph.dsl import SchemaRegistry
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+
+
+def make_registry() -> SchemaRegistry:
+    fbs = EntityDescriptor(
+        name="fbs",
+        columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="name")],
+    )
+    as_ = EntityDescriptor(
+        name="as",
+        columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name")],
+    )
+    env = EntityDescriptor(
+        name="env",
+        columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="name")],
+    )
+
+    fbs_as = RelationDescriptor(
+        name="fbs_as",
+        from_entity="fbs",
+        to_entity="as",
+        join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+    )
+    as_env = RelationDescriptor(
+        name="as_env",
+        from_entity="as",
+        to_entity="env",
+        join=RelationJoin(from_entity="as", from_column="id", to_entity="env", to_column="id"),
+    )
+
+    return SchemaRegistry(entities=[fbs, as_, env], relations=[fbs_as, as_env])
+
+
+def test_root_to_root_returns_empty_path():
+    registry = make_registry()
+    assert registry.find_paths("fbs", "fbs", max_depth=0) == [()]
+
+
+def test_paths_are_bidirectional_and_deterministic():
+    registry = make_registry()
+
+    forward = registry.find_paths("fbs", "as", max_depth=1)
+    backward = registry.find_paths("as", "fbs", max_depth=1)
+
+    assert forward == [("fbs_as",)]
+    assert backward == [("fbs_as",)]
+
+    assert forward == registry.find_paths("fbs", "as", max_depth=1)
+    assert backward == registry.find_paths("as", "fbs", max_depth=1)
+
+
+def test_two_hop_paths_ordered():
+    registry = make_registry()
+    paths = registry.find_paths("fbs", "env", max_depth=2)
+    assert paths == [("fbs_as", "as_env")]
+    assert paths == registry.find_paths("fbs", "env", max_depth=2)

--- a/tests/test_context_refetch_compiles_dsl.py
+++ b/tests/test_context_refetch_compiles_dsl.py
@@ -2,11 +2,17 @@ import json
 
 import pytest
 
-from fetchgraph.core.context import BaseGraphAgent
+from fetchgraph.core.context import BaseGraphAgent, ContextPacker
 from fetchgraph.core.models import ContextFetchSpec, Plan, RefetchDecision
 from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID
 from fetchgraph.plan_compile import compile_plan_selectors as real_compile_plan_selectors
-from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.models import (
+    ColumnDescriptor,
+    EntityDescriptor,
+    QueryResult,
+    RelationDescriptor,
+    RelationJoin,
+)
 from fetchgraph.relational.providers.base import RelationalDataProvider
 
 
@@ -18,7 +24,7 @@ class DummyProvider(RelationalDataProvider):
         raise NotImplementedError
 
     def _handle_query(self, req):  # pragma: no cover - not used
-        return {"rows": []}
+        return QueryResult(rows=[])
 
 
 @pytest.fixture
@@ -60,7 +66,7 @@ def test_refetch_merges_and_compiles_dsl(monkeypatch, provider):
         saver=lambda feature, parsed: None,
         providers={"rel": provider},
         verifiers=[],
-        packer=type("Packer", (), {"pack": lambda self, items: items})(),
+        packer=ContextPacker(max_tokens=1000, summarizer_llm=lambda text: text),
         llm_refetch=None,
     )
 

--- a/tests/test_context_refetch_compiles_dsl.py
+++ b/tests/test_context_refetch_compiles_dsl.py
@@ -1,0 +1,97 @@
+import json
+
+import pytest
+
+from fetchgraph.core.context import BaseGraphAgent
+from fetchgraph.core.models import ContextFetchSpec, Plan, RefetchDecision
+from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID
+from fetchgraph.plan_compile import compile_plan_selectors as real_compile_plan_selectors
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.providers.base import RelationalDataProvider
+
+
+class DummyProvider(RelationalDataProvider):
+    def _handle_schema(self):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def _handle_semantic_only(self, req):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def _handle_query(self, req):  # pragma: no cover - not used
+        return {"rows": []}
+
+
+@pytest.fixture
+def provider() -> DummyProvider:
+    entities = [
+        EntityDescriptor(
+            name="fbs",
+            columns=[ColumnDescriptor(name="id")],
+        ),
+        EntityDescriptor(
+            name="as",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name")],
+        ),
+    ]
+    relations = [
+        RelationDescriptor(
+            name="fbs_as",
+            from_entity="fbs",
+            to_entity="as",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+        )
+    ]
+    return DummyProvider("rel", entities, relations)
+
+
+def test_refetch_merges_and_compiles_dsl(monkeypatch, provider):
+    calls = {"compile": 0, "fetched_selectors": None}
+
+    def compile_spy(plan, providers):
+        calls["compile"] += 1
+        return real_compile_plan_selectors(plan, providers)
+
+    monkeypatch.setattr("fetchgraph.core.context.compile_plan_selectors", compile_spy)
+
+    agent = BaseGraphAgent(
+        llm_plan=lambda feature, ctx: json.dumps({"context_plan": []}),
+        llm_synth=lambda feature, ctx, plan: "",
+        domain_parser=lambda raw: raw,
+        saver=lambda feature, parsed: None,
+        providers={"rel": provider},
+        verifiers=[],
+        packer=type("Packer", (), {"pack": lambda self, items: items})(),
+        llm_refetch=None,
+    )
+
+    def fake_refetch(feature_name, ctx_text, plan):
+        decision = RefetchDecision(
+            stop=False,
+            add_specs=[
+                ContextFetchSpec(
+                    provider="rel",
+                    selectors={
+                        "$dsl": QUERY_SKETCH_DSL_ID,
+                        "payload": {"from": "fbs", "where": [["system_name", "contains", "ЕСП"]], "take": 5},
+                    },
+                )
+            ],
+        )
+        return decision.model_dump_json()
+
+    agent.llm_refetch = fake_refetch
+    agent.max_refetch_iters = 1
+
+    def fake_fetch(feature_name, plan):
+        calls["fetched_selectors"] = plan.context_plan[0].selectors
+        return {}
+
+    monkeypatch.setattr(agent, "_fetch", fake_fetch)
+
+    ctx, updated_plan = agent._assess_refetch_loop("feature", {}, Plan())
+
+    assert calls["compile"] == 1
+    assert calls["fetched_selectors"]["op"] == "query"
+    assert calls["fetched_selectors"]["relations"] == ["fbs_as"]
+    assert ctx == {}
+    assert updated_plan.context_plan[0].selectors["filters"]["field"] == "fbs_as.system_name"

--- a/tests/test_dsl_schema_registry.py
+++ b/tests/test_dsl_schema_registry.py
@@ -1,0 +1,72 @@
+from fetchgraph.dsl import FieldCandidate, SchemaRegistry
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+
+
+def build_registry() -> SchemaRegistry:
+    fbs = EntityDescriptor(
+        name="fbs",
+        columns=[
+            ColumnDescriptor(name="id", type="uuid"),
+            ColumnDescriptor(name="bc_name", type="text"),
+        ],
+    )
+    as_ = EntityDescriptor(
+        name="as",
+        columns=[
+            ColumnDescriptor(name="id", type="uuid"),
+            ColumnDescriptor(name="system_name", type="text"),
+        ],
+    )
+    env = EntityDescriptor(
+        name="env",
+        columns=[
+            ColumnDescriptor(name="id", type="uuid"),
+            ColumnDescriptor(name="name", type="text"),
+        ],
+    )
+
+    fbs_as = RelationDescriptor(
+        name="fbs_as",
+        from_entity="fbs",
+        to_entity="as",
+        join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+    )
+    as_env = RelationDescriptor(
+        name="as_env",
+        from_entity="as",
+        to_entity="env",
+        join=RelationJoin(from_entity="as", from_column="id", to_entity="env", to_column="id"),
+    )
+
+    return SchemaRegistry(entities=[fbs, as_, env], relations=[fbs_as, as_env])
+
+
+def test_find_entities_with_field():
+    registry = build_registry()
+    assert registry.find_entities_with_field("system_name") == ["as"]
+
+
+def test_find_paths_direct_and_limited_depth():
+    registry = build_registry()
+    assert registry.find_paths("fbs", "as", max_depth=1) == [("fbs_as",)]
+    assert registry.find_paths("fbs", "env", max_depth=1) == []
+
+
+def test_find_paths_two_hop():
+    registry = build_registry()
+    assert registry.find_paths("fbs", "env", max_depth=2) == [("fbs_as", "as_env")]
+
+
+def test_field_candidates_deterministic_and_paths():
+    registry = build_registry()
+    candidates_first = registry.field_candidates(root="fbs", field="system_name", max_depth=2)
+    candidates_second = registry.field_candidates(root="fbs", field="system_name", max_depth=2)
+
+    assert candidates_first == candidates_second
+    assert len(candidates_first) == 1
+
+    candidate = candidates_first[0]
+    assert candidate.entity == "as"
+    assert candidate.field == "system_name"
+    assert candidate.field_type == "text"
+    assert candidate.join_path == ("fbs_as",)

--- a/tests/test_plan_compile.py
+++ b/tests/test_plan_compile.py
@@ -1,0 +1,79 @@
+import pytest
+
+from fetchgraph.core.models import ContextFetchSpec, Plan
+from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID
+from fetchgraph.plan_compile import compile_plan_selectors
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.providers.base import RelationalDataProvider
+
+
+class DummyProvider(RelationalDataProvider):
+    def _handle_schema(self):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+    def _handle_semantic_only(self, req):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+    def _handle_query(self, req):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+
+def make_provider():
+    entities = [
+        EntityDescriptor(
+            name="fbs",
+            columns=[ColumnDescriptor(name="id")],
+        ),
+        EntityDescriptor(
+            name="as",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name")],
+        ),
+    ]
+    relations = [
+        RelationDescriptor(
+            name="fbs_as",
+            from_entity="fbs",
+            to_entity="as",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+        )
+    ]
+    return DummyProvider("rel", entities, relations)
+
+
+def test_compile_plan_selectors_compiles_dsl_and_validates():
+    provider = make_provider()
+    plan = Plan(
+        context_plan=[
+            ContextFetchSpec(
+                provider="rel",
+                selectors={
+                    "$dsl": QUERY_SKETCH_DSL_ID,
+                    "payload": {
+                        "from": "fbs",
+                        "where": [["system_name", "contains", "%ЕСП%"]],
+                        "take": 100,
+                    },
+                },
+            )
+        ]
+    )
+
+    compiled = compile_plan_selectors(plan, {"rel": provider})
+
+    selectors = compiled.context_plan[0].selectors
+    assert selectors["op"] == "query"
+    assert selectors["root_entity"] == "fbs"
+    assert selectors["relations"] == ["fbs_as"]
+    assert selectors["filters"]["field"] == "fbs_as.system_name"
+
+
+def test_compile_plan_selectors_rejects_conflicting_selectors():
+    provider = make_provider()
+    plan = Plan(
+        context_plan=[
+            ContextFetchSpec(provider="rel", selectors={"op": "query", "$dsl": QUERY_SKETCH_DSL_ID})
+        ]
+    )
+
+    with pytest.raises(ValueError):
+        compile_plan_selectors(plan, {"rel": provider})

--- a/tests/test_plan_compile.py
+++ b/tests/test_plan_compile.py
@@ -40,7 +40,7 @@ def make_provider():
     return DummyProvider("rel", entities, relations)
 
 
-def test_compile_plan_selectors_compiles_dsl_and_validates():
+def test_compile_plan_selectors_compiles_dsl_envelope():
     provider = make_provider()
     plan = Plan(
         context_plan=[
@@ -50,7 +50,7 @@ def test_compile_plan_selectors_compiles_dsl_and_validates():
                     "$dsl": QUERY_SKETCH_DSL_ID,
                     "payload": {
                         "from": "fbs",
-                        "where": [["system_name", "contains", "%ЕСП%"]],
+                        "where": [["system_name", "ЕСП"]],
                         "take": 100,
                     },
                 },
@@ -72,6 +72,43 @@ def test_compile_plan_selectors_rejects_conflicting_selectors():
     plan = Plan(
         context_plan=[
             ContextFetchSpec(provider="rel", selectors={"op": "query", "$dsl": QUERY_SKETCH_DSL_ID})
+        ]
+    )
+
+    with pytest.raises(ValueError):
+        compile_plan_selectors(plan, {"rel": provider})
+
+
+def test_compile_plan_selectors_rejects_unknown_root_entity():
+    provider = make_provider()
+    plan = Plan(
+        context_plan=[
+            ContextFetchSpec(
+                provider="rel",
+                selectors={
+                    "op": "query",
+                    "root_entity": "NOPE",
+                },
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError):
+        compile_plan_selectors(plan, {"rel": provider})
+
+
+def test_compile_plan_selectors_rejects_unknown_relation():
+    provider = make_provider()
+    plan = Plan(
+        context_plan=[
+            ContextFetchSpec(
+                provider="rel",
+                selectors={
+                    "op": "query",
+                    "root_entity": "fbs",
+                    "relations": ["NOPE_REL"],
+                },
+            )
         ]
     )
 

--- a/tests/test_plan_compile_selectors.py
+++ b/tests/test_plan_compile_selectors.py
@@ -3,7 +3,13 @@ import pytest
 from fetchgraph.core.models import ContextFetchSpec, Plan
 from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID
 from fetchgraph.plan_compile import compile_plan_selectors
-from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.models import (
+    ColumnDescriptor,
+    EntityDescriptor,
+    QueryResult,
+    RelationDescriptor,
+    RelationJoin,
+)
 from fetchgraph.relational.providers.base import RelationalDataProvider
 
 
@@ -15,7 +21,7 @@ class DummyProvider(RelationalDataProvider):
         raise NotImplementedError
 
     def _handle_query(self, req):  # pragma: no cover - not used
-        return {"ok": True, "selectors": req.model_dump()}
+        return QueryResult(rows=[])
 
 
 def make_provider(include_root_field: bool = False) -> DummyProvider:

--- a/tests/test_query_sketch_binding.py
+++ b/tests/test_query_sketch_binding.py
@@ -1,0 +1,116 @@
+import pytest
+
+from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID, compile_selectors
+from fetchgraph.dsl import Clause, NormalizedQuerySketch, SchemaRegistry, WhereExpr, bind_query_sketch
+from fetchgraph.dsl.resolution_policy import ResolutionPolicy
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.providers.base import RelationalDataProvider
+
+
+class DummyProvider(RelationalDataProvider):
+    def _handle_schema(self):  # pragma: no cover - not used in these tests
+        raise NotImplementedError
+
+    def _handle_semantic_only(self, req):  # pragma: no cover - not used in these tests
+        raise NotImplementedError
+
+    def _handle_query(self, req):  # pragma: no cover - not used in these tests
+        raise NotImplementedError
+
+
+def make_entities(*, include_root_system: bool = True):
+    return [
+        EntityDescriptor(
+            name="fbs",
+            columns=[
+                ColumnDescriptor(name="id"),
+                *( [ColumnDescriptor(name="system_name")] if include_root_system else [] ),
+                ColumnDescriptor(name="status"),
+            ],
+        ),
+        EntityDescriptor(
+            name="as",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name")],
+        ),
+        EntityDescriptor(
+            name="env",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name"), ColumnDescriptor(name="name")],
+        ),
+    ]
+
+
+def make_relations():
+    return [
+        RelationDescriptor(
+            name="fbs_as",
+            from_entity="fbs",
+            to_entity="as",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+        ),
+        RelationDescriptor(
+            name="as_env",
+            from_entity="as",
+            to_entity="env",
+            join=RelationJoin(from_entity="as", from_column="id", to_entity="env", to_column="id"),
+        ),
+        RelationDescriptor(
+            name="fbs_env",
+            from_entity="fbs",
+            to_entity="env",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="env", to_column="id"),
+        ),
+    ]
+
+
+def test_auto_join_field_resolution_adds_with_and_rewrites_path():
+    entities = make_entities(include_root_system=False)
+    relations = [make_relations()[0]]
+    provider = DummyProvider("rel", entities, relations)
+
+    selectors = {
+        "$dsl": QUERY_SKETCH_DSL_ID,
+        "payload": {"from": "fbs", "where": [["system_name", "ЕСП"]], "take": 10},
+    }
+
+    compiled = compile_selectors(provider, selectors)
+
+    assert compiled["relations"] == ["fbs_as"]
+    assert compiled["filters"]["field"] == "fbs_as.system_name"
+
+
+def test_root_field_wins_over_joined_field():
+    entities = make_entities(include_root_system=True)
+    relations = [make_relations()[0]]
+    provider = DummyProvider("rel", entities, relations)
+
+    selectors = {
+        "$dsl": QUERY_SKETCH_DSL_ID,
+        "payload": {"from": "fbs", "where": [["system_name", "ЕСП"]], "take": 10},
+    }
+
+    compiled = compile_selectors(provider, selectors)
+
+    assert compiled["relations"] == []
+    assert compiled["filters"]["field"] == "system_name"
+
+
+def test_ambiguous_field_ask_strategy_errors():
+    entities = make_entities(include_root_system=False)
+    relations = make_relations()
+    registry = SchemaRegistry(entities, relations)
+
+    sketch = NormalizedQuerySketch(
+        from_="fbs",
+        where=WhereExpr(all=[Clause(path="system_name", op="is", value="x")]),
+        get=["*"],
+        with_=[],
+        take=10,
+    )
+
+    with pytest.raises(ValueError) as exc:
+        _, diags = bind_query_sketch(sketch, registry, ResolutionPolicy(ambiguity_strategy="ask"))
+        if diags.has_errors():
+            codes = ", ".join(d.code for d in diags.errors())
+            raise ValueError(codes)
+
+    assert "DSL_BIND_AMBIGUOUS_FIELD" in str(exc.value)

--- a/tests/test_selector_dialects.py
+++ b/tests/test_selector_dialects.py
@@ -15,7 +15,7 @@ from fetchgraph.core.selector_dialects import (
     compile_selectors,
 )
 from fetchgraph.core.protocols import ContextProvider, SupportsDescribe
-from fetchgraph.relational.models import ComparisonFilter, EntityDescriptor, QueryResult
+from fetchgraph.relational.models import ColumnDescriptor, ComparisonFilter, EntityDescriptor, QueryResult
 from fetchgraph.relational.providers.base import RelationalDataProvider
 
 
@@ -31,7 +31,11 @@ class DummyRelationalProvider(RelationalDataProvider):
 
 
 def test_selector_dialect_query_sketch_compiles_object_payload_to_relational_query():
-    provider = DummyRelationalProvider("rel", [EntityDescriptor(name="streams")], [])
+    provider = DummyRelationalProvider(
+        "rel",
+        [EntityDescriptor(name="streams", columns=[ColumnDescriptor(name="status")])],
+        [],
+    )
     selectors = {
         "$dsl": QUERY_SKETCH_DSL_ID,
         "payload": {"from": "streams", "where": [["status", "active"]], "take": 5},
@@ -52,6 +56,8 @@ class RecordingProvider(ContextProvider, SupportsDescribe):
 
     def __init__(self):
         self.last_selectors: dict[str, Any] = {}
+        self.entities = [EntityDescriptor(name="streams", columns=[ColumnDescriptor(name="status")])]
+        self.relations = []
 
     def fetch(self, feature_name: str, selectors=None, **kwargs):
         self.last_selectors = selectors or {}

--- a/tests/test_selector_dialects.py
+++ b/tests/test_selector_dialects.py
@@ -153,6 +153,8 @@ def test_compile_selectors_requires_string_dsl_id():
 
 class DescribingWithoutDialect(ContextProvider, SupportsDescribe):
     name = "no_dialect"
+    entities = []
+    relations = []
 
     def fetch(self, feature_name: str, selectors=None, **kwargs):  # pragma: no cover
         return {}

--- a/tests/test_selector_dialects_query_sketch.py
+++ b/tests/test_selector_dialects_query_sketch.py
@@ -1,0 +1,74 @@
+import pytest
+
+from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID, compile_selectors
+from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.providers.base import RelationalDataProvider
+
+
+class DummyProvider(RelationalDataProvider):
+    def _handle_schema(self):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def _handle_semantic_only(self, req):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def _handle_query(self, req):  # pragma: no cover - not used
+        return {"ok": True, "selectors": req.model_dump()}
+
+
+def make_provider(include_root_field: bool = False) -> DummyProvider:
+    entities = [
+        EntityDescriptor(
+            name="fbs",
+            columns=[
+                ColumnDescriptor(name="id"),
+                *( [ColumnDescriptor(name="system_name")] if include_root_field else []),
+            ],
+        ),
+        EntityDescriptor(
+            name="as",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="system_name")],
+        ),
+        EntityDescriptor(
+            name="env",
+            columns=[ColumnDescriptor(name="id"), ColumnDescriptor(name="name")],
+        ),
+    ]
+    relations = [
+        RelationDescriptor(
+            name="fbs_as",
+            from_entity="fbs",
+            to_entity="as",
+            join=RelationJoin(from_entity="fbs", from_column="id", to_entity="as", to_column="id"),
+        ),
+        RelationDescriptor(
+            name="as_env",
+            from_entity="as",
+            to_entity="env",
+            join=RelationJoin(from_entity="as", from_column="id", to_entity="env", to_column="id"),
+        ),
+    ]
+
+    return DummyProvider("rel", entities, relations)
+
+
+def test_query_sketch_compiles_and_adds_relations():
+    provider = make_provider()
+    selectors = {
+        "$dsl": QUERY_SKETCH_DSL_ID,
+        "payload": {"from": "fbs", "where": [["system_name", "contains", "ЕСП"]], "take": 10},
+    }
+
+    compiled = compile_selectors(provider, selectors)
+
+    assert compiled["op"] == "query"
+    assert compiled["relations"] == ["fbs_as"]
+    assert compiled["filters"]["field"] == "fbs_as.system_name"
+
+
+def test_native_and_dsl_envelope_conflict():
+    provider = make_provider()
+    selectors = {"op": "query", "$dsl": QUERY_SKETCH_DSL_ID}
+
+    with pytest.raises(ValueError):
+        compile_selectors(provider, selectors)

--- a/tests/test_selector_dialects_query_sketch.py
+++ b/tests/test_selector_dialects_query_sketch.py
@@ -1,7 +1,13 @@
 import pytest
 
 from fetchgraph.core.selector_dialects import QUERY_SKETCH_DSL_ID, compile_selectors
-from fetchgraph.relational.models import ColumnDescriptor, EntityDescriptor, RelationDescriptor, RelationJoin
+from fetchgraph.relational.models import (
+    ColumnDescriptor,
+    EntityDescriptor,
+    QueryResult,
+    RelationDescriptor,
+    RelationJoin,
+)
 from fetchgraph.relational.providers.base import RelationalDataProvider
 
 
@@ -13,7 +19,7 @@ class DummyProvider(RelationalDataProvider):
         raise NotImplementedError
 
     def _handle_query(self, req):  # pragma: no cover - not used
-        return {"ok": True, "selectors": req.model_dump()}
+        return QueryResult(rows=[])
 
 
 def make_provider(include_root_field: bool = False) -> DummyProvider:


### PR DESCRIPTION
## Summary
- add bound query dataclasses and parsing utilities for noop binding
- provide conversions between normalized queries and bound queries
- add roundtrip tests to ensure compile outputs remain unchanged

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fff4dd9f8832fa5dff917a001a21c)