### PR TITLE
Add alias support for group by specs

### DIFF
--- a/src/fetchgraph/relational/models.py
+++ b/src/fetchgraph/relational/models.py
@@ -109,6 +109,7 @@ class GroupBySpec(BaseModel):
 
     entity: Optional[str] = None
     field: str
+    alias: Optional[str] = None
 
 
 class RelationalQuery(BaseModel):

--- a/src/fetchgraph/relational/providers/composite.py
+++ b/src/fetchgraph/relational/providers/composite.py
@@ -818,7 +818,7 @@ class CompositeRelationalProvider(RelationalDataProvider):
             for key, state in group_state.items():
                 data: Dict[str, Any] = {}
                 for idx, grp in enumerate(req.group_by):
-                    col_name = grp.alias or grp.field if hasattr(grp, "alias") else grp.field
+                    col_name = grp.alias or grp.field
                     if grp.entity and grp.entity != req.root_entity:
                         raise NotImplementedError(
                             "Cross-provider aggregations: group_by on non-root entities is not supported"

--- a/src/fetchgraph/relational/providers/sql.py
+++ b/src/fetchgraph/relational/providers/sql.py
@@ -431,7 +431,7 @@ class SqlRelationalDataProvider(RelationalDataProvider):
         for g in req.group_by:
             ent, fld = self._resolve_field(req.root_entity, g.field, g.entity)
             col_ref = self._column_ref(self._lookup_alias(ent, index), fld)
-            alias = self._select_alias(ent, fld, req.root_entity)
+            alias = g.alias or self._select_alias(ent, fld, req.root_entity)
             select_parts.append(f"{col_ref} AS {self._quote_ident(alias)}")
             group_cols.append(col_ref)
 

--- a/tests/test_relational_pandas.py
+++ b/tests/test_relational_pandas.py
@@ -173,6 +173,20 @@ def test_group_by_with_aggregations():
     assert totals == {"Alice": 320, "Bob": 80}
 
 
+def test_group_by_uses_alias_when_provided():
+    provider = _make_provider()
+    req = RelationalQuery(
+        root_entity="order",
+        relations=["order_customer"],
+        group_by=[GroupBySpec(entity="customer", field="name", alias="customer_name")],
+    )
+
+    res = provider.fetch("demo", selectors=req.model_dump())
+
+    totals = {row.data["customer_name"]: row.data["count"] for row in res.rows}
+    assert totals == {"Alice": 2, "Bob": 1}
+
+
 def test_semantic_filter_respects_threshold():
     backend = FakeSemanticBackend(
         [


### PR DESCRIPTION
## Summary
- add alias support to GroupBySpec to allow custom group column names
- propagate group-by aliases through SQL, pandas, and composite providers
- add regression test covering alias output for pandas provider

## Testing
- pytest tests/test_relational_pandas.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69413f9cba18832f8a4456232d1b853c)