### PR TITLE
Fix type hints in relational composite tests

### DIFF
--- a/tests/test_relational_composite_cross_provider.py
+++ b/tests/test_relational_composite_cross_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal, cast
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -21,8 +23,8 @@ from fetchgraph.relational.providers.pandas import PandasRelationalDataProvider
 
 def _build_block_system_composite(
     *,
-    join_type: str = "inner",
-    cardinality: str = "1_to_many",
+    join_type: Literal["inner", "left", "right", "outer"] = "inner",
+    cardinality: Literal["1_to_1", "1_to_many", "many_to_1", "many_to_many"] = "1_to_many",
     block_df=None,
     system_df=None,
     **kwargs,
@@ -199,7 +201,8 @@ def test_cross_join_1_to_1():
 def test_cross_join_1_to_1_cardinality_violation():
     right_df = pd.DataFrame({"id": [1, 1], "label": ["X", "Y"]})
     composite = _build_one_to_one_composite()
-    composite.children["right"].frames["right"] = right_df
+    right_provider = cast(PandasRelationalDataProvider, composite.children["right"])
+    right_provider.frames["right"] = right_df
     query = RelationalQuery(root_entity="left", relations=["left_right"])
 
     with pytest.raises(ValueError, match="Cardinality 1_to_1 violated"):
@@ -208,7 +211,8 @@ def test_cross_join_1_to_1_cardinality_violation():
 
 def test_cross_join_many_to_1_cardinality_violation():
     composite = _build_employee_department_composite()
-    composite.children["departments"].frames["department"] = pd.DataFrame(
+    dept_provider = cast(PandasRelationalDataProvider, composite.children["departments"])
+    dept_provider.frames["department"] = pd.DataFrame(
         {"id": [10, 10, 11], "title": ["Eng", "Ops", "HR"]}
     )
     query = RelationalQuery(root_entity="employee", relations=["employee_department"])
@@ -255,7 +259,8 @@ def test_cross_join_handles_right_batch_overflow_for_1_to_many():
 
 def test_cross_join_raises_on_right_batch_overflow_for_1_to_1_or_many_to_1():
     composite = _build_one_to_one_composite()
-    composite.children["right"].frames["right"] = pd.DataFrame(
+    right_provider = cast(PandasRelationalDataProvider, composite.children["right"])
+    right_provider.frames["right"] = pd.DataFrame(
         {"id": [1, 1, 2], "label": ["X", "Y", "Z"]}
     )
     query = RelationalQuery(root_entity="left", relations=["left_right"])


### PR DESCRIPTION
## Summary
- update test helpers to use literal types for relation joins and cardinalities
- cast composite children to pandas providers when mutating frames in tests

## Testing
- python -m pytest tests/test_relational_composite_cross_provider.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414416a864832fba9d15274a721dfd)