### PR TITLE
Add deterministic schema binding for relational selectors

### DIFF
--- a/src/fetchgraph/core.py
+++ b/src/fetchgraph/core.py
@@ -25,6 +25,7 @@ from .protocols import (
     SupportsFilter,
     Verifier,
 )
+from .schema import ResolutionPolicy, bind_selectors, registry
 from .utils import load_pkg_text, render_prompt
 
 logger = logging.getLogger(__name__)
@@ -502,6 +503,38 @@ class BaseGraphAgent:
                 spec.selectors,
                 getattr(spec, "max_tokens", None),
             )
+            selectors_payload = spec.selectors or {}
+            should_bind = selectors_payload.get("op") == "query"
+            capabilities: List[str] = []
+            if should_bind:
+                if hasattr(prov, "entities") and hasattr(prov, "relations"):
+                    capabilities = ["schema", "row_query"]
+                    should_bind = True
+                elif isinstance(prov, SupportsDescribe):
+                    try:
+                        info = prov.describe()
+                        capabilities = info.capabilities or []
+                        should_bind = any(
+                            cap in capabilities for cap in ("schema", "row_query")
+                        )
+                    except Exception:
+                        should_bind = False
+
+            if should_bind:
+                try:
+                    schema = registry.get_or_describe(prov)
+                    bound_selectors, diag = bind_selectors(
+                        schema,
+                        selectors_payload,
+                        policy=ResolutionPolicy(),
+                        capabilities=capabilities,
+                    )
+                    spec.selectors = bound_selectors
+                    if diag:
+                        spec.meta.setdefault("diagnostics", []).extend(diag)
+                except Exception:
+                    logger.exception("Schema binding failed for provider %s", spec.provider)
+                    raise
             obj = prov.fetch(feature_name, selectors=spec.selectors)
             if spec.mode == "slice":
                 obj = _apply_provider_filter(prov, obj, spec.selectors)

--- a/src/fetchgraph/core.py
+++ b/src/fetchgraph/core.py
@@ -530,7 +530,9 @@ class BaseGraphAgent:
 
             if should_bind:
                 try:
-                    schema = self.schema_registry.get_or_describe(prov)
+                    schema = self.schema_registry.get_or_describe(
+                        prov, provider_key=spec.provider
+                    )
                     bound_selectors, diag = bind_selectors(
                         schema,
                         selectors_payload,
@@ -539,6 +541,7 @@ class BaseGraphAgent:
                     )
                     spec.selectors = bound_selectors
                     if diag:
+                        spec.meta = spec.meta or {}
                         spec.meta.setdefault("diagnostics", []).extend(diag)
                 except Exception:
                     logger.exception("Schema binding failed for provider %s", spec.provider)

--- a/src/fetchgraph/models.py
+++ b/src/fetchgraph/models.py
@@ -58,6 +58,7 @@ class ContextFetchSpec(BaseModel):
     mode: str = "full"
     selectors: Dict[str, Any] = Field(default_factory=dict)
     max_tokens: Optional[int] = None
+    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/fetchgraph/relational/base.py
+++ b/src/fetchgraph/relational/base.py
@@ -8,6 +8,7 @@ import re
 
 from ..core import ContextProvider, ProviderInfo, SupportsDescribe
 from ..json_types import SelectorsDict
+from ..schema.types import ProviderSchema
 from .models import (
     QueryResult,
     RelationalQuery,
@@ -35,6 +36,9 @@ class RelationalDataProvider(ContextProvider, SupportsDescribe):
         self.name = name
         self.entities = entities
         self.relations = relations
+
+    def describe_schema(self) -> ProviderSchema:
+        return ProviderSchema.from_relational(self.entities, self.relations)
 
     @staticmethod
     def _normalize_string(value: Any) -> str:

--- a/src/fetchgraph/schema/__init__.py
+++ b/src/fetchgraph/schema/__init__.py
@@ -2,7 +2,13 @@
 
 from .types import ProviderSchema, EntityDescriptor, FieldDescriptor, RelationDescriptor
 from .policy import ResolutionPolicy
-from .bind import bind_selectors, UnknownField, UnknownRelation, AmbiguousField
+from .bind import (
+    AmbiguousField,
+    RelationNotFromRoot,
+    UnknownField,
+    UnknownRelation,
+    bind_selectors,
+)
 from .registry import SchemaRegistry, registry
 
 __all__ = [
@@ -15,6 +21,7 @@ __all__ = [
     "UnknownField",
     "UnknownRelation",
     "AmbiguousField",
+    "RelationNotFromRoot",
     "SchemaRegistry",
     "registry",
 ]

--- a/src/fetchgraph/schema/__init__.py
+++ b/src/fetchgraph/schema/__init__.py
@@ -1,0 +1,20 @@
+"""Schema registry and binding helpers for relational providers."""
+
+from .types import ProviderSchema, EntityDescriptor, FieldDescriptor, RelationDescriptor
+from .policy import ResolutionPolicy
+from .bind import bind_selectors, UnknownField, UnknownRelation, AmbiguousField
+from .registry import SchemaRegistry, registry
+
+__all__ = [
+    "ProviderSchema",
+    "EntityDescriptor",
+    "FieldDescriptor",
+    "RelationDescriptor",
+    "ResolutionPolicy",
+    "bind_selectors",
+    "UnknownField",
+    "UnknownRelation",
+    "AmbiguousField",
+    "SchemaRegistry",
+    "registry",
+]

--- a/src/fetchgraph/schema/bind.py
+++ b/src/fetchgraph/schema/bind.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .policy import ResolutionPolicy
+from .types import ProviderSchema
+
+
+class UnknownRelation(Exception):
+    def __init__(self, relation: str):
+        super().__init__(f"Unknown relation alias: {relation}")
+        self.relation = relation
+
+
+class UnknownField(Exception):
+    def __init__(self, field: str, *, root_entity: str, candidates: Optional[List[str]] = None):
+        msg = f"Unknown field '{field}' for root '{root_entity}'"
+        if candidates:
+            msg += f" (candidates: {', '.join(candidates)})"
+        super().__init__(msg)
+        self.field = field
+        self.root_entity = root_entity
+        self.candidates = candidates or []
+
+
+class AmbiguousField(Exception):
+    def __init__(self, field: str, candidates: List[str]):
+        msg = f"Ambiguous field '{field}' candidates: {', '.join(candidates)}"
+        super().__init__(msg)
+        self.field = field
+        self.candidates = candidates
+
+
+@dataclass
+class _Candidate:
+    source: str  # root | declared | auto_add
+    relation_alias: Optional[str]
+    entity_name: str
+    field_name: str
+
+    def label(self) -> str:
+        alias = self.relation_alias or self.entity_name
+        return f"{alias}.{self.field_name}"
+
+
+def _pick_best_candidate(candidates: List[_Candidate]) -> _Candidate:
+    priority = {"root": 0, "declared": 1, "auto_add": 2}
+    best_pri = min(priority[c.source] for c in candidates)
+    best = [c for c in candidates if priority[c.source] == best_pri]
+    best.sort(key=lambda c: (c.entity_name if c.source == "root" else (c.relation_alias or c.entity_name), c.field_name))
+    return best[0]
+
+
+def _bind_field(
+    field: str,
+    *,
+    root_entity: str,
+    declared_relations: List[str],
+    schema: ProviderSchema,
+    policy: ResolutionPolicy,
+    selectors_relations: List[str],
+    diagnostics: List[Dict[str, Any]],
+) -> Tuple[str, List[str]]:
+    entity_index = schema.entity_index()
+    relation_index = schema.relation_index()
+
+    if "." in field:
+        alias, col = field.split(".", 1)
+        if alias == root_entity:
+            target_entity = root_entity
+        elif alias in declared_relations:
+            rel = relation_index.get(alias)
+            if rel is None:
+                raise UnknownRelation(alias)
+            target_entity = rel.to_entity
+        else:
+            raise UnknownRelation(alias)
+        entity = entity_index.get(target_entity)
+        if entity is None or col not in entity.field_names():
+            raise UnknownField(field, root_entity=root_entity)
+        return f"{alias}.{col}", selectors_relations
+
+    # Unqualified field
+    candidates: List[_Candidate] = []
+
+    root_entity_desc = entity_index.get(root_entity)
+    if root_entity_desc and field in root_entity_desc.field_names():
+        candidates.append(
+            _Candidate(
+                source="root",
+                relation_alias=root_entity,
+                entity_name=root_entity,
+                field_name=field,
+            )
+        )
+
+    for rel_alias in declared_relations:
+        rel = relation_index.get(rel_alias)
+        if rel is None:
+            raise UnknownRelation(rel_alias)
+        target_entity = entity_index.get(rel.to_entity)
+        if target_entity and field in target_entity.field_names():
+            candidates.append(
+                _Candidate(
+                    source="declared",
+                    relation_alias=rel_alias,
+                    entity_name=rel.to_entity,
+                    field_name=field,
+                )
+            )
+
+    if not candidates and policy.allow_auto_add_relations and policy.max_auto_join_depth >= 1:
+        for rel in schema.relations:
+            if rel.from_entity != root_entity:
+                continue
+            target_entity = entity_index.get(rel.to_entity)
+            if target_entity and field in target_entity.field_names():
+                candidates.append(
+                    _Candidate(
+                        source="auto_add",
+                        relation_alias=rel.name,
+                        entity_name=rel.to_entity,
+                        field_name=field,
+                    )
+                )
+
+    if not candidates:
+        raise UnknownField(field, root_entity=root_entity)
+
+    if len(candidates) > 1:
+        labels = [c.label() for c in candidates]
+        if policy.ambiguity_strategy == "best":
+            chosen = _pick_best_candidate(candidates)
+            diagnostics.append(
+                {
+                    "kind": "ambiguous_field_best_effort",
+                    "field": field,
+                    "chosen": chosen.label(),
+                    "candidates": labels,
+                }
+            )
+            if chosen.source == "auto_add" and chosen.relation_alias not in selectors_relations:
+                selectors_relations.append(chosen.relation_alias or chosen.entity_name)
+            return chosen.label(), selectors_relations
+        raise AmbiguousField(field, labels)
+
+    chosen = candidates[0]
+    if chosen.source == "auto_add" and chosen.relation_alias not in selectors_relations:
+        selectors_relations.append(chosen.relation_alias or chosen.entity_name)
+        diagnostics.append(
+            {
+                "kind": "auto_add_relation",
+                "relation": chosen.relation_alias,
+                "reason": f"field {field} found on to_entity {chosen.entity_name}",
+            }
+        )
+    return chosen.label(), selectors_relations
+
+
+def _bind_filter(
+    filt: Dict[str, Any],
+    *,
+    root_entity: str,
+    declared_relations: List[str],
+    schema: ProviderSchema,
+    policy: ResolutionPolicy,
+    selectors_relations: List[str],
+    diagnostics: List[Dict[str, Any]],
+) -> List[str]:
+    op_type = filt.get("type")
+    updated_relations = selectors_relations
+    if op_type == "logical":
+        clauses = filt.get("clauses", [])
+        for clause in clauses:
+            updated_relations = _bind_filter(
+                clause,
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=updated_relations,
+                diagnostics=diagnostics,
+            )
+    elif op_type == "comparison":
+        field = filt.get("field")
+        if isinstance(field, str):
+            bound, updated_relations = _bind_field(
+                field,
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=selectors_relations,
+                diagnostics=diagnostics,
+            )
+            filt["field"] = bound
+    return updated_relations
+
+
+def bind_selectors(
+    schema: ProviderSchema,
+    selectors: Dict[str, Any],
+    policy: Optional[ResolutionPolicy] = None,
+    capabilities: Optional[Iterable[str]] = None,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Bind selectors to provider schema (v1).
+
+    Returns a tuple of (updated selectors, diagnostics).
+    """
+
+    policy = policy or ResolutionPolicy()
+    if selectors.get("op") != "query":
+        return selectors, []
+
+    updated = copy.deepcopy(selectors)
+    diagnostics: List[Dict[str, Any]] = []
+
+    root_entity = updated.get("root_entity")
+    declared_relations: List[str] = list(updated.get("relations", []) or [])
+    if not root_entity:
+        return updated, diagnostics
+
+    # Bind select expressions
+    for sel in updated.get("select", []) or []:
+        expr = sel.get("expr") if isinstance(sel, dict) else None
+        if isinstance(expr, str):
+            bound, declared_relations = _bind_field(
+                expr,
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=declared_relations,
+                diagnostics=diagnostics,
+            )
+            if bound != expr:
+                diagnostics.append(
+                    {
+                        "kind": "bound_field",
+                        "from": expr,
+                        "to": bound,
+                        "reason": "resolved against schema",
+                    }
+                )
+            sel["expr"] = bound
+
+    filt = updated.get("filters")
+    if isinstance(filt, dict):
+        declared_relations = _bind_filter(
+            filt,
+            root_entity=root_entity,
+            declared_relations=declared_relations,
+            schema=schema,
+            policy=policy,
+            selectors_relations=declared_relations,
+            diagnostics=diagnostics,
+        )
+
+    for grp in updated.get("group_by", []) or []:
+        field = grp.get("field") if isinstance(grp, dict) else None
+        if isinstance(field, str):
+            bound, declared_relations = _bind_field(
+                field,
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=declared_relations,
+                diagnostics=diagnostics,
+            )
+            if bound != field:
+                diagnostics.append(
+                    {
+                        "kind": "bound_field",
+                        "from": field,
+                        "to": bound,
+                        "reason": "resolved against schema",
+                    }
+                )
+            grp["field"] = bound
+
+    for agg in updated.get("aggregations", []) or []:
+        field = agg.get("field") if isinstance(agg, dict) else None
+        if isinstance(field, str):
+            bound, declared_relations = _bind_field(
+                field,
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=declared_relations,
+                diagnostics=diagnostics,
+            )
+            if bound != field:
+                diagnostics.append(
+                    {
+                        "kind": "bound_field",
+                        "from": field,
+                        "to": bound,
+                        "reason": "resolved against schema",
+                    }
+                )
+            agg["field"] = bound
+
+    updated["relations"] = declared_relations
+    return updated, diagnostics

--- a/src/fetchgraph/schema/policy.py
+++ b/src/fetchgraph/schema/policy.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ResolutionPolicy:
+    allow_auto_add_relations: bool = True
+    max_auto_join_depth: int = 1
+    ambiguity_strategy: str = "ask"  # "ask" | "best"

--- a/src/fetchgraph/schema/registry.py
+++ b/src/fetchgraph/schema/registry.py
@@ -30,8 +30,8 @@ class SchemaRegistry:
 
         return None
 
-    def get_or_describe(self, provider: object) -> ProviderSchema:
-        name = getattr(provider, "name", provider.__class__.__name__)
+    def get_or_describe(self, provider: object, *, provider_key: Optional[str] = None) -> ProviderSchema:
+        name = provider_key or getattr(provider, "name", provider.__class__.__name__)
         cached = self.get(name)
         if cached:
             return cached

--- a/src/fetchgraph/schema/registry.py
+++ b/src/fetchgraph/schema/registry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .types import ProviderSchema
+
+
+class SchemaRegistry:
+    """In-memory schema registry for providers."""
+
+    def __init__(self):
+        self._cache: Dict[str, ProviderSchema] = {}
+
+    def register(self, provider_name: str, schema: ProviderSchema) -> None:
+        self._cache[provider_name] = schema
+
+    def get(self, provider_name: str) -> Optional[ProviderSchema]:
+        return self._cache.get(provider_name)
+
+    def get_or_describe(self, provider: object) -> ProviderSchema:
+        name = getattr(provider, "name", provider.__class__.__name__)
+        cached = self.get(name)
+        if cached:
+            return cached
+
+        schema: Optional[ProviderSchema] = None
+        describe_schema = getattr(provider, "describe_schema", None)
+        if callable(describe_schema):
+            schema = describe_schema()
+        elif hasattr(provider, "entities") and hasattr(provider, "relations"):
+            from .types import ProviderSchema as PS  # local import to avoid cycles
+
+            schema = PS.from_relational(getattr(provider, "entities"), getattr(provider, "relations"))
+        else:
+            fetch = getattr(provider, "fetch", None)
+            if callable(fetch):
+                res = fetch("", selectors={"op": "schema"})
+                entities = getattr(res, "entities", None)
+                relations = getattr(res, "relations", None)
+                if entities is not None and relations is not None:
+                    from .types import ProviderSchema as PS  # local import to avoid cycles
+
+                    schema = PS.from_relational(entities, relations)
+
+        if schema is None:
+            raise ValueError(f"Provider {name!r} cannot describe schema")
+
+        self.register(name, schema)
+        return schema
+
+
+registry = SchemaRegistry()
+
+__all__ = ["SchemaRegistry", "registry"]

--- a/src/fetchgraph/schema/types.py
+++ b/src/fetchgraph/schema/types.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class FieldDescriptor:
+    name: str
+    type: Optional[str] = None
+    role: Optional[str] = None
+    semantic: bool = False
+
+
+@dataclass
+class EntityDescriptor:
+    name: str
+    label: Optional[str] = None
+    fields: List[FieldDescriptor] = field(default_factory=list)
+
+    def field_names(self) -> List[str]:
+        return [f.name for f in self.fields]
+
+
+@dataclass
+class RelationDescriptor:
+    name: str
+    from_entity: str
+    to_entity: str
+    from_field: Optional[str] = None
+    to_field: Optional[str] = None
+    cardinality: Optional[str] = None
+
+
+@dataclass
+class ProviderSchema:
+    entities: List[EntityDescriptor] = field(default_factory=list)
+    relations: List[RelationDescriptor] = field(default_factory=list)
+
+    def entity_index(self) -> dict[str, EntityDescriptor]:
+        return {e.name: e for e in self.entities}
+
+    def relation_index(self) -> dict[str, RelationDescriptor]:
+        return {r.name: r for r in self.relations}
+
+    @classmethod
+    def from_relational(
+        cls,
+        entities: Iterable[object],
+        relations: Iterable[object],
+    ) -> "ProviderSchema":
+        """Build :class:`ProviderSchema` from relational descriptors.
+
+        The relational descriptors are expected to resemble
+        ``fetchgraph.relational.models.EntityDescriptor`` and
+        ``RelationDescriptor`` objects (with ``columns`` and ``join`` fields).
+        Only the attributes used for schema binding are accessed.
+        """
+
+        ent_list: List[EntityDescriptor] = []
+        for ent in entities:
+            cols = getattr(ent, "columns", []) or []
+            fields: List[FieldDescriptor] = []
+            for col in cols:
+                fields.append(
+                    FieldDescriptor(
+                        name=getattr(col, "name", ""),
+                        type=getattr(col, "type", None),
+                        role=getattr(col, "role", None),
+                        semantic=bool(getattr(col, "semantic", False)),
+                    )
+                )
+            ent_list.append(
+                EntityDescriptor(
+                    name=getattr(ent, "name", ""),
+                    label=getattr(ent, "label", None),
+                    fields=fields,
+                )
+            )
+
+        rel_list: List[RelationDescriptor] = []
+        for rel in relations:
+            join = getattr(rel, "join", None)
+            rel_list.append(
+                RelationDescriptor(
+                    name=getattr(rel, "name", ""),
+                    from_entity=getattr(rel, "from_entity", ""),
+                    to_entity=getattr(rel, "to_entity", ""),
+                    from_field=getattr(join, "from_column", None) if join else None,
+                    to_field=getattr(join, "to_column", None) if join else None,
+                    cardinality=getattr(rel, "cardinality", None),
+                )
+            )
+
+        return cls(entities=ent_list, relations=rel_list)

--- a/tests/test_schema_binding_v1.py
+++ b/tests/test_schema_binding_v1.py
@@ -1,0 +1,130 @@
+import pytest
+
+from fetchgraph.schema import (
+    AmbiguousField,
+    ProviderSchema,
+    ResolutionPolicy,
+    UnknownField,
+    UnknownRelation,
+    bind_selectors,
+)
+from fetchgraph.schema.registry import SchemaRegistry
+from fetchgraph.schema.types import EntityDescriptor, FieldDescriptor, RelationDescriptor
+
+
+class DummyProvider:
+    def __init__(self, schema: ProviderSchema):
+        self.schema = schema
+        self.describe_calls = 0
+        self.name = "dummy"
+
+    def describe_schema(self):
+        self.describe_calls += 1
+        return self.schema
+
+
+@pytest.fixture
+def simple_schema():
+    return ProviderSchema(
+        entities=[
+            EntityDescriptor(
+                name="fbs",
+                fields=[FieldDescriptor(name="bc_guid"), FieldDescriptor(name="system_name"), FieldDescriptor(name="root_only")],
+            ),
+            EntityDescriptor(
+                name="as",
+                fields=[FieldDescriptor(name="system_name"), FieldDescriptor(name="extra")],
+            ),
+        ],
+        relations=[
+            RelationDescriptor(name="fbs_as", from_entity="fbs", to_entity="as"),
+        ],
+    )
+
+
+def test_registry_caches_describe(simple_schema):
+    prov = DummyProvider(simple_schema)
+    local_registry = SchemaRegistry()
+
+    first = local_registry.get_or_describe(prov)
+    second = local_registry.get_or_describe(prov)
+
+    assert first is second
+    assert prov.describe_calls == 1
+
+
+def test_qualified_field_ok(simple_schema):
+    selectors = {"op": "query", "root_entity": "fbs", "select": [{"expr": "fbs.bc_guid"}]}
+    bound, diag = bind_selectors(simple_schema, selectors)
+    assert bound["select"][0]["expr"] == "fbs.bc_guid"
+    assert diag == []
+
+
+def test_qualified_field_bad_relation(simple_schema):
+    selectors = {"op": "query", "root_entity": "fbs", "relations": ["unknown"], "select": [{"expr": "unknown.field"}]}
+    with pytest.raises(UnknownRelation):
+        bind_selectors(simple_schema, selectors)
+
+
+def test_unqualified_resolves_root(simple_schema):
+    selectors = {"op": "query", "root_entity": "fbs", "select": [{"expr": "bc_guid"}]}
+    bound, diag = bind_selectors(simple_schema, selectors)
+    assert bound["select"][0]["expr"] == "fbs.bc_guid"
+    assert any(d["kind"] == "bound_field" for d in diag)
+
+
+def test_unqualified_resolves_declared_relation(simple_schema):
+    schema = ProviderSchema(
+        entities=[
+            EntityDescriptor(
+                name="fbs",
+                fields=[FieldDescriptor(name="bc_guid"), FieldDescriptor(name="root_only")],
+            ),
+            EntityDescriptor(
+                name="as",
+                fields=[FieldDescriptor(name="system_name"), FieldDescriptor(name="extra")],
+            ),
+        ],
+        relations=[RelationDescriptor(name="fbs_as", from_entity="fbs", to_entity="as")],
+    )
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "relations": ["fbs_as"],
+        "select": [{"expr": "system_name"}],
+    }
+    bound, _ = bind_selectors(schema, selectors)
+    assert bound["select"][0]["expr"] == "fbs_as.system_name"
+
+
+def test_unqualified_triggers_auto_add(simple_schema):
+    selectors = {"op": "query", "root_entity": "fbs", "select": [{"expr": "extra"}]}
+    bound, diag = bind_selectors(simple_schema, selectors)
+    assert "fbs_as" in bound.get("relations", [])
+    assert bound["select"][0]["expr"] == "fbs_as.extra"
+    assert any(d["kind"] == "auto_add_relation" for d in diag)
+
+
+def test_ambiguity_ask(simple_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "relations": ["fbs_as"],
+        "select": [{"expr": "system_name"}],
+    }
+    with pytest.raises(AmbiguousField) as exc:
+        bind_selectors(simple_schema, selectors)
+    assert "fbs.system_name" in exc.value.candidates
+    assert "fbs_as.system_name" in exc.value.candidates
+
+
+def test_ambiguity_best(simple_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "relations": ["fbs_as"],
+        "select": [{"expr": "system_name"}],
+    }
+    bound, diag = bind_selectors(simple_schema, selectors, policy=ResolutionPolicy(ambiguity_strategy="best"))
+    assert bound["select"][0]["expr"] == "fbs.system_name"
+    assert any(d["kind"] == "ambiguous_field_best_effort" for d in diag)


### PR DESCRIPTION
## Summary
- add schema types, registry, and deterministic binding logic for relational selectors
- integrate binding into fetch pipeline with policy-driven resolution and diagnostics
- cover registry caching and binding behaviors with unit tests

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414548d928832f856d5b20e394a4a2)