### PR TITLE
Handle qualifier labels and unknown qualifier policy

### DIFF
--- a/src/fetchgraph/schema/bind.py
+++ b/src/fetchgraph/schema/bind.py
@@ -76,8 +76,8 @@ def _bind_field(
     entity_index = schema.entity_index()
     relation_index = schema.relation_index()
 
-    def _normalize_label(value: str) -> str:
-        return " ".join(value.lower().split())
+    def _norm(value: str) -> str:
+        return " ".join(value.lower().replace("_", " ").split())
 
     if "." in field:
         alias, col = field.split(".", 1)
@@ -108,71 +108,58 @@ def _bind_field(
                 rel_alias = rel.name
                 target_entity = rel.to_entity
             else:
-                matching_relations = [
-                    r
-                    for r in schema.relations
-                    if r.to_entity == alias and r.from_entity == root_entity
+                normalized_alias = _norm(alias)
+                matching_entities = [
+                    ent
+                    for ent in schema.entities
+                    if _norm(ent.name) == normalized_alias
+                    or (ent.label is not None and _norm(ent.label) == normalized_alias)
                 ]
-                if len(matching_relations) == 1:
-                    rel = matching_relations[0]
-                    rel_alias = rel.name
-                    target_entity = rel.to_entity
-                    if rel_alias not in selectors_relations and policy.allow_auto_add_relations:
-                        selectors_relations.append(rel_alias)
-                        diagnostics.append(
-                            {
-                                "kind": "auto_add_relation",
-                                "relation": rel_alias,
-                                "reason": f"qualified field mapped entity '{alias}' to relation alias",
-                            }
-                        )
-                elif len(matching_relations) > 1:
-                    labels = [f"{r.name}.{col}" for r in matching_relations]
-                    if policy.ambiguity_strategy == "best":
-                        chosen_rel = sorted(matching_relations, key=lambda r: (r.name, r.to_entity))[0]
-                        rel_alias = chosen_rel.name
-                        target_entity = chosen_rel.to_entity
-                        diagnostics.append(
-                            {
-                                "kind": "ambiguous_field_best_effort",
-                                "field": field,
-                                "chosen": f"{rel_alias}.{col}",
-                                "candidates": labels,
-                            }
-                        )
+
+                if len(matching_entities) == 1:
+                    ent = matching_entities[0]
+                    relations_to_entity = [
+                        r for r in schema.relations if r.from_entity == root_entity and r.to_entity == ent.name
+                    ]
+                    if len(relations_to_entity) == 1:
+                        rel = relations_to_entity[0]
+                        rel_alias = rel.name
+                        target_entity = rel.to_entity
                         if rel_alias not in selectors_relations and policy.allow_auto_add_relations:
                             selectors_relations.append(rel_alias)
-                    else:
-                        raise AmbiguousField(field, labels)
-
-                if target_entity is None:
-                    normalized_alias = _normalize_label(alias)
-                    matching_entities = [
-                        ent
-                        for ent in schema.entities
-                        if _normalize_label(ent.name) == normalized_alias
-                        or (ent.label is not None and _normalize_label(ent.label) == normalized_alias)
-                    ]
-
-                    if len(matching_entities) == 1:
-                        ent = matching_entities[0]
-                        relations_to_entity = [
-                            r for r in schema.relations if r.from_entity == root_entity and r.to_entity == ent.name
-                        ]
-                        if len(relations_to_entity) == 1:
-                            rel = relations_to_entity[0]
-                            rel_alias = rel.name
-                            target_entity = rel.to_entity
-                            if rel_alias not in selectors_relations and policy.allow_auto_add_relations:
-                                selectors_relations.append(rel_alias)
                             diagnostics.append(
                                 {
-                                    "kind": "mapped_qualifier_label_to_relation",
-                                    "qualifier": alias,
+                                    "kind": "auto_add_relation",
                                     "relation": rel_alias,
-                                    "reason": "mapped qualifier label to relation",
+                                    "reason": f"qualified field mapped entity '{alias}' to relation alias",
                                 }
                             )
+                        diagnostics.append(
+                            {
+                                "kind": "mapped_qualifier_label_to_relation",
+                                "qualifier": alias,
+                                "relation": rel_alias,
+                                "reason": "mapped qualifier label to relation",
+                            }
+                        )
+                    elif len(relations_to_entity) > 1:
+                        labels = [f"{r.name}.{col}" for r in relations_to_entity]
+                        if policy.ambiguity_strategy == "best":
+                            chosen_rel = sorted(relations_to_entity, key=lambda r: (r.name, r.to_entity))[0]
+                            rel_alias = chosen_rel.name
+                            target_entity = chosen_rel.to_entity
+                            diagnostics.append(
+                                {
+                                    "kind": "ambiguous_field_best_effort",
+                                    "field": field,
+                                    "chosen": f"{rel_alias}.{col}",
+                                    "candidates": labels,
+                                }
+                            )
+                            if rel_alias not in selectors_relations and policy.allow_auto_add_relations:
+                                selectors_relations.append(rel_alias)
+                        else:
+                            raise AmbiguousField(field, labels)
 
         if target_entity is None:
             if policy.unknown_qualifier_strategy == "drop":
@@ -303,6 +290,31 @@ def _bind_filter(
             )
     elif op_type == "comparison":
         entity_hint = filt.get("entity")
+        field = filt.get("field")
+
+        if isinstance(entity_hint, str) and isinstance(field, str) and "." not in field:
+            bound, updated_relations = _bind_field(
+                f"{entity_hint}.{field}",
+                root_entity=root_entity,
+                declared_relations=declared_relations,
+                schema=schema,
+                policy=policy,
+                selectors_relations=updated_relations,
+                diagnostics=diagnostics,
+            )
+            filt["field"] = bound
+            filt.pop("entity", None)
+            diagnostics.append(
+                {
+                    "kind": "bound_entity_field",
+                    "from_entity": entity_hint,
+                    "from_field": field,
+                    "to": bound,
+                    "reason": "combined entity+field in filter",
+                }
+            )
+            return updated_relations
+
         if isinstance(entity_hint, str) and entity_hint and entity_hint != root_entity:
             relation_index = schema.relation_index()
             candidates = []
@@ -354,7 +366,6 @@ def _bind_filter(
                     }
                 )
 
-        field = filt.get("field")
         if isinstance(field, str):
             bound, updated_relations = _bind_field(
                 field,

--- a/src/fetchgraph/schema/policy.py
+++ b/src/fetchgraph/schema/policy.py
@@ -8,3 +8,4 @@ class ResolutionPolicy:
     allow_auto_add_relations: bool = True
     max_auto_join_depth: int = 1
     ambiguity_strategy: str = "ask"  # "ask" | "best"
+    unknown_qualifier_strategy: str = "infer"  # "error" | "infer" | "drop"

--- a/tests/test_schema_binding_qualifier_recovery.py
+++ b/tests/test_schema_binding_qualifier_recovery.py
@@ -1,0 +1,110 @@
+import pytest
+
+from fetchgraph.schema import (
+    ProviderSchema,
+    ResolutionPolicy,
+    UnknownRelation,
+    bind_selectors,
+)
+from fetchgraph.schema.types import EntityDescriptor, FieldDescriptor, RelationDescriptor
+
+
+@pytest.fixture
+def qualifier_schema():
+    return ProviderSchema(
+        entities=[
+            EntityDescriptor(
+                name="fbs",
+                fields=[
+                    FieldDescriptor(name="system_name"),
+                ],
+            ),
+            EntityDescriptor(
+                name="as",
+                label="system",
+                fields=[FieldDescriptor(name="system_name")],
+            ),
+        ],
+        relations=[RelationDescriptor(name="fbs_as", from_entity="fbs", to_entity="as")],
+    )
+
+
+def test_label_maps_to_relation(qualifier_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "relations": ["fbs_as"],
+        "select": [{"expr": "system.system_name"}],
+    }
+
+    bound, diag = bind_selectors(qualifier_schema, selectors)
+
+    assert bound["select"][0]["expr"] == "fbs_as.system_name"
+    assert any(d["kind"] == "mapped_qualifier_label_to_relation" for d in diag)
+
+
+def test_entity_name_maps_to_relation_and_auto_add(qualifier_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "select": [{"expr": "as.system_name"}],
+    }
+
+    bound, diag = bind_selectors(qualifier_schema, selectors)
+
+    assert "fbs_as" in bound.get("relations", [])
+    assert bound["select"][0]["expr"] == "fbs_as.system_name"
+    assert any(d["kind"] == "auto_add_relation" for d in diag)
+
+
+def test_unknown_qualifier_errors(qualifier_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "select": [{"expr": "unknown.system_name"}],
+    }
+
+    with pytest.raises(UnknownRelation):
+        bind_selectors(
+            qualifier_schema,
+            selectors,
+            policy=ResolutionPolicy(unknown_qualifier_strategy="error"),
+        )
+
+
+def test_unknown_qualifier_drops_to_root(qualifier_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "select": [{"expr": "unknown.system_name"}],
+    }
+
+    bound, diag = bind_selectors(
+        qualifier_schema,
+        selectors,
+        policy=ResolutionPolicy(unknown_qualifier_strategy="drop"),
+    )
+
+    assert bound["select"][0]["expr"] == "fbs.system_name"
+    assert any(d["kind"] == "ignored_unknown_qualifier" for d in diag)
+
+
+def test_filter_entity_field_combination(qualifier_schema):
+    selectors = {
+        "op": "query",
+        "root_entity": "fbs",
+        "relations": ["fbs_as"],
+        "filters": {
+            "type": "comparison",
+            "entity": "system",
+            "field": "system_name",
+            "op": "eq",
+            "value": "x",
+        },
+    }
+
+    bound, diag = bind_selectors(qualifier_schema, selectors)
+
+    assert "entity" not in bound["filters"]
+    assert bound["filters"]["field"] == "fbs_as.system_name"
+    assert any(d["kind"] == "bound_entity_field" for d in diag)


### PR DESCRIPTION
## Summary
- map qualified aliases to relations when they match entity names or labels
- add policy option to drop unknown qualifiers with diagnostics
- extend tests for qualifier mapping and drop behavior

## Testing
- pytest tests/test_schema_binding_v1.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941635a7450832faac97cbb3057d4eb)