### PR TITLE
Add logging and artifacts support for demo QA

### DIFF
--- a/examples/demo_qa/chat_repl.py
+++ b/examples/demo_qa/chat_repl.py
@@ -1,29 +1,34 @@
 from __future__ import annotations
 
+import datetime
 import json
 import sys
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 from fetchgraph.core import create_generic_agent
 from fetchgraph.core.models import TaskProfile
+from fetchgraph.utils import set_run_id
 
 from .provider_factory import build_provider
 
 
 @dataclass
 class RunArtifacts:
+    run_id: str
+    run_dir: Path
     plan: str | None = None
     context: Dict[str, object] | None = None
     answer: str | None = None
+    error: str | None = None
 
 
-def build_agent(llm, provider) -> tuple[object, RunArtifacts]:
-    artifacts = RunArtifacts()
-
+def build_agent(llm, provider) -> Callable[[str, str, Path], RunArtifacts]:
     def saver(feature_name: str, parsed: object) -> None:
-        artifacts.answer = str(parsed)
+        # Placeholder to satisfy BaseGraphAgent.saver; artifacts captured elsewhere.
+        return None
 
     task_profile = TaskProfile(
         task_name="Demo QA",
@@ -42,29 +47,66 @@ def build_agent(llm, provider) -> tuple[object, RunArtifacts]:
         task_profile=task_profile,
     )
 
-    def run_question(question: str) -> str:
+    def run_question(question: str, run_id: str, run_dir: Path) -> RunArtifacts:
+        set_run_id(run_id)
+        artifacts = RunArtifacts(run_id=run_id, run_dir=run_dir)
         plan = agent._plan(question)  # type: ignore[attr-defined]
         artifacts.plan = json.dumps(plan.model_dump(), ensure_ascii=False, indent=2)
         try:
             ctx = agent._fetch(question, plan)  # type: ignore[attr-defined]
             artifacts.context = {k: v.text for k, v in (ctx or {}).items()} if ctx else {}
         except Exception as exc:  # pragma: no cover - demo fallback
+            artifacts.error = str(exc)
             artifacts.context = {"error": str(exc)}
             ctx = None
         draft = agent._synthesize(question, ctx, plan)  # type: ignore[attr-defined]
         parsed = agent.domain_parser(draft)
-        saver(question, parsed)
-        return str(parsed)
+        artifacts.answer = str(parsed)
+        return artifacts
 
-    return run_question, artifacts
+    return run_question
 
 
-def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = False) -> None:
+def _save_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _save_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _save_artifacts(artifacts: RunArtifacts) -> None:
+    artifacts.run_dir.mkdir(parents=True, exist_ok=True)
+    if artifacts.plan is not None:
+        _save_text(artifacts.run_dir / "plan.json", artifacts.plan)
+    if artifacts.context is not None:
+        _save_json(artifacts.run_dir / "context.json", artifacts.context)
+    if artifacts.answer is not None:
+        _save_text(artifacts.run_dir / "answer.txt", artifacts.answer)
+    if artifacts.error is not None:
+        _save_text(artifacts.run_dir / "error.txt", artifacts.error)
+
+
+def start_repl(
+    data_dir: Path,
+    schema_path: Path,
+    llm,
+    enable_semantic: bool = False,
+    log_file: Optional[Path] = None,
+) -> None:
     provider, _ = build_provider(data_dir, schema_path, enable_semantic=enable_semantic)
-    runner, artifacts = build_agent(llm, provider)
+    runner = build_agent(llm, provider)
 
-    plan_debug = False
+    runs_root = data_dir / ".runs" / "runs"
+    runs_root.mkdir(parents=True, exist_ok=True)
+
+    plan_debug_mode = "off"
+    last_artifacts: RunArtifacts | None = None
+
     print("Type your question (or /help). Ctrl+D to exit.")
+    print(f"Artifacts root: {runs_root}")
+    if log_file:
+        print(f"Log file: {log_file}")
     while True:
         try:
             line = input("demo-qa> ").strip()
@@ -76,28 +118,61 @@ def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = F
         if line == "/exit":
             break
         if line == "/help":
-            print("Commands: /schema, /plan on|off, /ctx, /exit")
+            print("Commands: /schema, /plan on|off|once, /ctx, /run, /logs, /exit")
             continue
         if line.startswith("/plan"):
             _, _, arg = line.partition(" ")
-            plan_debug = arg.strip() == "on"
-            print(f"Plan debug {'enabled' if plan_debug else 'disabled'}")
+            choice = arg.strip()
+            if choice in {"on", "off", "once"}:
+                plan_debug_mode = choice
+                print(f"Plan debug set to {plan_debug_mode}")
+            else:
+                print("Usage: /plan on|off|once")
             continue
         if line == "/ctx":
-            if artifacts.context:
-                print(json.dumps(artifacts.context, indent=2, ensure_ascii=False))
+            if last_artifacts and last_artifacts.context is not None:
+                print(json.dumps(last_artifacts.context, indent=2, ensure_ascii=False))
             else:
                 print("No context yet.")
             continue
         if line == "/schema":
             print(provider.describe())
             continue
+        if line == "/run":
+            if last_artifacts:
+                print(f"run_id={last_artifacts.run_id} at {last_artifacts.run_dir}")
+            else:
+                print("No runs yet.")
+            continue
+        if line == "/logs":
+            if log_file:
+                print(f"Logs: {log_file}\nTail: tail -f {log_file}")
+            else:
+                print("Logging to stderr only (no file configured).")
+            continue
 
-        answer = runner(line)
-        if plan_debug and artifacts.plan:
-            print("--- PLAN ---")
-            print(artifacts.plan)
-        print(answer)
+        run_id = uuid.uuid4().hex[:8]
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_dir = runs_root / f"{timestamp}_{run_id}"
+
+        artifacts: RunArtifacts | None = None
+        try:
+            artifacts = runner(line, run_id, run_dir)
+            last_artifacts = artifacts
+            _save_artifacts(artifacts)
+            if plan_debug_mode in {"on", "once"} and artifacts.plan:
+                print("--- PLAN ---")
+                print(artifacts.plan)
+            print(artifacts.answer or "")
+        except Exception as exc:  # pragma: no cover - REPL resilience
+            error_artifacts = artifacts or RunArtifacts(run_id=run_id, run_dir=run_dir)
+            error_artifacts.error = error_artifacts.error or str(exc)
+            last_artifacts = error_artifacts
+            _save_artifacts(error_artifacts)
+            print(f"Error during run {run_id}: {exc}", file=sys.stderr)
+        finally:
+            if plan_debug_mode == "once":
+                plan_debug_mode = "off"
 
 
 __all__ = ["start_repl"]

--- a/examples/demo_qa/logging_config.py
+++ b/examples/demo_qa/logging_config.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from fetchgraph.utils import RunContextFilter, set_run_id
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting logic
+        payload = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "run_id": getattr(record, "run_id", "-"),
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _make_formatter(jsonl: bool) -> logging.Formatter:
+    if jsonl:
+        return JsonFormatter()
+    return logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s [run=%(run_id)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def configure_logging(
+    *,
+    level: str = "INFO",
+    log_dir: Path | None,
+    to_stderr: bool = False,
+    jsonl: bool = False,
+    run_id: str | None = None,
+) -> Path | None:
+    """Configure logging for demo_qa CLI."""
+    if run_id:
+        set_run_id(run_id)
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    handlers: list[logging.Handler] = []
+    formatter = _make_formatter(jsonl)
+    context_filter = RunContextFilter()
+    log_file: Path | None = None
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        suffix = "jsonl" if jsonl else "log"
+        log_file = log_dir / f"demo_qa_{timestamp}.{suffix}"
+        file_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=5_000_000,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(formatter)
+        file_handler.addFilter(context_filter)
+        handlers.append(file_handler)
+
+    if to_stderr:
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setFormatter(formatter)
+        stream_handler.addFilter(context_filter)
+        handlers.append(stream_handler)
+
+    if not handlers:
+        # Avoid silent drop due to NullHandler in library.
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setFormatter(formatter)
+        stream_handler.addFilter(context_filter)
+        handlers.append(stream_handler)
+
+    for handler in handlers:
+        root.addHandler(handler)
+
+    return log_file
+
+
+__all__ = ["configure_logging"]

--- a/src/fetchgraph/core/context.py
+++ b/src/fetchgraph/core/context.py
@@ -450,6 +450,13 @@ class BaseGraphAgent:
             len(plan.context_plan or []),
         )
         logger.debug(
+            "Plan built for feature_name=%r (providers=%s, steps=%d)",
+            feature_name,
+            plan.required_context,
+            len(plan.context_plan or []),
+        )
+        logger.debug("Plan JSON for feature_name=%r: %s", feature_name, plan.model_dump_json())
+        logger.debug(
             "Raw plan text for feature_name=%r (chars=%d)",
             feature_name,
             len(plan_raw.text),

--- a/src/fetchgraph/utils/__init__.py
+++ b/src/fetchgraph/utils/__init__.py
@@ -1,0 +1,3 @@
+from .log_context import RunContextFilter, get_run_id, set_run_id
+
+__all__ = ["RunContextFilter", "get_run_id", "set_run_id"]

--- a/src/fetchgraph/utils/log_context.py
+++ b/src/fetchgraph/utils/log_context.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+_run_id_var: ContextVar[str | None] = ContextVar("fetchgraph_run_id", default=None)
+
+
+def set_run_id(run_id: str | None) -> None:
+    _run_id_var.set(run_id)
+
+
+def get_run_id(default: str | None = None) -> str | None:
+    return _run_id_var.get(default)
+
+
+class RunContextFilter(logging.Filter):
+    """Populate logging records with run_id from context vars."""
+
+    def __init__(self, default: str = "-") -> None:
+        super().__init__()
+        self.default = default
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple filter
+        record.run_id = get_run_id(self.default) or self.default  # type: ignore[attr-defined]
+        return True


### PR DESCRIPTION
## Summary
- add configurable logging for demo QA, including run_id-aware file/stderr handlers and JSONL option
- extend chat CLI/REPL to generate run-scoped artifacts, expose helper commands, and track run_ids
- log built plans from the core agent for easier troubleshooting

## Testing
- python -m compileall src examples

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945be57d56c832fbdf67eb2eaf5fa21)