### PR TITLE
Fix remaining limit tracking for cross-provider pagination

### DIFF
--- a/src/fetchgraph/relational/providers/composite_provider.py
+++ b/src/fetchgraph/relational/providers/composite_provider.py
@@ -259,12 +259,14 @@ class CompositeRelationalProvider(RelationalDataProvider):
                 left_rows, req, cross_relation, root_provider_name, feature_name, **kwargs
             )
 
+            batch_start_len = len(all_rows)
             for row in joined_rows:
                 if remaining is not None and len(all_rows) >= remaining:
                     break
                 all_rows.append(row)
             if remaining is not None:
-                remaining = remaining - len(all_rows)
+                added = len(all_rows) - batch_start_len
+                remaining = remaining - added
                 if remaining <= 0:
                     break
             # NOTE: offset and limit are applied to the root-entity rows prior to


### PR DESCRIPTION
## Summary
- track remaining rows using batch additions to avoid premature pagination cutoff during cross-provider joins

## Testing
- pytest -q (fails: missing dependency pydantic-settings for demo QA tests)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c78213c0832fbfe2d7d73d6dbd04)