### PR TITLE
Improve demo QA CLI UX and diagnostics

### DIFF
--- a/examples/demo_qa/chat_repl.py
+++ b/examples/demo_qa/chat_repl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from dataclasses import dataclass
@@ -8,8 +9,10 @@ from typing import Dict
 
 from fetchgraph.core import create_generic_agent
 from fetchgraph.core.models import TaskProfile
+from fetchgraph.relational.schema import SchemaConfig
 
 from .provider_factory import build_provider
+from .settings import DemoQASettings, LLMSettings
 
 
 @dataclass
@@ -59,12 +62,61 @@ def build_agent(llm, provider) -> tuple[object, RunArtifacts]:
     return run_question, artifacts
 
 
-def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = False) -> None:
-    provider, _ = build_provider(data_dir, schema_path, enable_semantic=enable_semantic)
+def _maybe_load_readline():
+    spec = importlib.util.find_spec("readline")
+    if spec is None:
+        return None
+    return importlib.import_module("readline")
+
+
+def _format_llm_diag(llm_settings: LLMSettings) -> str:
+    endpoint = llm_settings.base_url or "api.openai.com (default)"
+    timeout = f", timeout={llm_settings.timeout_s}s" if llm_settings.timeout_s is not None else ""
+    retries = f", retries={llm_settings.retries}" if llm_settings.retries is not None else ""
+    return (
+        f"LLM endpoint: {endpoint} | plan_model={llm_settings.plan_model} (T={llm_settings.plan_temperature}), "
+        f"synth_model={llm_settings.synth_model} (T={llm_settings.synth_temperature}){timeout}{retries}"
+    )
+
+
+def _format_embedding_diag(data_dir: Path, schema: SchemaConfig, enable_semantic: bool) -> str:
+    if not enable_semantic:
+        return "Embeddings: disabled (semantic search is off)"
+
+    sources: list[str] = []
+    for ent in schema.entities:
+        if not ent.semantic_text_fields or not ent.source:
+            continue
+        embed_path = (data_dir / ent.source).with_suffix(".embeddings.json")
+        sources.append(f"{ent.name} → {embed_path}")
+
+    if not sources:
+        return "Embeddings: enabled but no semantic_text_fields found in schema"
+    return "Embeddings: " + "; ".join(sources)
+
+
+def start_repl(
+    data_dir: Path,
+    schema_path: Path,
+    llm,
+    settings: DemoQASettings,
+    enable_semantic: bool = False,
+) -> None:
+    provider, schema = build_provider(data_dir, schema_path, enable_semantic=enable_semantic)
     runner, artifacts = build_agent(llm, provider)
 
+    readline = _maybe_load_readline()
+    history_enabled = readline is not None
+    if history_enabled:
+        readline.set_history_length(1000)
+
     plan_debug = False
-    print("Type your question (or /help). Ctrl+D to exit.")
+    print(_format_llm_diag(settings.llm))
+    print(_format_embedding_diag(data_dir, schema, enable_semantic))
+    hint = "Type your question (or /help). Ctrl+D or /exit to quit."
+    if history_enabled:
+        hint += " Use ↑/↓ to edit previous input."
+    print(hint)
     while True:
         try:
             line = input("demo-qa> ").strip()
@@ -92,6 +144,9 @@ def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = F
         if line == "/schema":
             print(provider.describe())
             continue
+
+        if history_enabled and not line.startswith("/"):
+            readline.add_history(line)
 
         answer = runner(line)
         if plan_debug and artifacts.plan:

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -46,7 +46,7 @@ def main() -> None:
 
         llm = build_llm(settings)
 
-        start_repl(args.data, args.schema, llm, enable_semantic=args.enable_semantic)
+        start_repl(args.data, args.schema, llm, settings=settings, enable_semantic=args.enable_semantic)
         return
 
 


### PR DESCRIPTION
## Summary
- add readline-backed input history so chat prompts can be recalled and edited with arrow keys
- show startup diagnostics for LLM endpoint/models and semantic embeddings locations plus clearer exit hints
- pass configuration into the REPL to surface settings in the diagnostics output

## Testing
- python -m compileall examples/demo_qa

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945cc2fb05c832fb99e755a30277b35)