### PR TITLE
Add demo QA batch runner and LLM cache

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -52,6 +52,26 @@ python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.y
 
 Флаг `--enable-semantic` строит семантический индекс, если передана модель эмбеддингов.
 
+## Batch-запуск
+
+Команда для пакетного прогона набора вопросов:
+
+```bash
+python -m examples.demo_qa.cli batch \
+  --data demo_data \
+  --schema demo_data/schema.yaml \
+  --config path/to/demo_qa.toml \
+  --cases cases.jsonl \
+  --out results.jsonl
+```
+
+Флаги:
+- `--artifacts-dir` — куда складывать артефакты (`plan.json`, `context.json`, `answer.txt`).
+- `--fail-on {error,mismatch,any}`, `--max-fails`, `--fail-fast` — управление выходным кодом и остановкой.
+- `--llm-cache {off,record,replay}` и `--llm-cache-file` — кэширование ответов LLM для офлайн-прогонов.
+
+Рядом с `results.jsonl` пишется `summary.json` с агрегатами, а в stdout выводится компактная таблица по кейсам.
+
 ## Local proxy
 
 Для OpenAI-совместимых серверов (например, LM Studio) укажите `base_url` с `.../v1` и

--- a/examples/demo_qa/chat_repl.py
+++ b/examples/demo_qa/chat_repl.py
@@ -2,66 +2,15 @@ from __future__ import annotations
 
 import json
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
 
-from fetchgraph.core import create_generic_agent
-from fetchgraph.core.models import TaskProfile
-
-from .provider_factory import build_provider
-
-
-@dataclass
-class RunArtifacts:
-    plan: str | None = None
-    context: Dict[str, object] | None = None
-    answer: str | None = None
-
-
-def build_agent(llm, provider) -> tuple[object, RunArtifacts]:
-    artifacts = RunArtifacts()
-
-    def saver(feature_name: str, parsed: object) -> None:
-        artifacts.answer = str(parsed)
-
-    task_profile = TaskProfile(
-        task_name="Demo QA",
-        goal="Answer analytics questions over the demo dataset",
-        output_format="Plain text answer",
-        focus_hints=[
-            "Prefer aggregates",
-            "Use concise answers",
-        ],
-    )
-
-    agent = create_generic_agent(
-        llm_invoke=llm,
-        providers={provider.name: provider},
-        saver=saver,
-        task_profile=task_profile,
-    )
-
-    def run_question(question: str) -> str:
-        plan = agent._plan(question)  # type: ignore[attr-defined]
-        artifacts.plan = json.dumps(plan.model_dump(), ensure_ascii=False, indent=2)
-        try:
-            ctx = agent._fetch(question, plan)  # type: ignore[attr-defined]
-            artifacts.context = {k: v.text for k, v in (ctx or {}).items()} if ctx else {}
-        except Exception as exc:  # pragma: no cover - demo fallback
-            artifacts.context = {"error": str(exc)}
-            ctx = None
-        draft = agent._synthesize(question, ctx, plan)  # type: ignore[attr-defined]
-        parsed = agent.domain_parser(draft)
-        saver(question, parsed)
-        return str(parsed)
-
-    return run_question, artifacts
+from .runner import AgentRunner, setup_runner
 
 
 def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = False) -> None:
-    provider, _ = build_provider(data_dir, schema_path, enable_semantic=enable_semantic)
-    runner, artifacts = build_agent(llm, provider)
+    runner: AgentRunner = setup_runner(data_dir, schema_path, llm, enable_semantic=enable_semantic)
+    artifacts = runner.artifacts
+    provider = next(iter(runner.agent.providers.values()))
 
     plan_debug = False
     print("Type your question (or /help). Ctrl+D to exit.")
@@ -93,10 +42,10 @@ def start_repl(data_dir: Path, schema_path: Path, llm, enable_semantic: bool = F
             print(provider.describe())
             continue
 
-        answer = runner(line)
-        if plan_debug and artifacts.plan:
+        answer = runner.run_question(line)
+        if plan_debug and artifacts.plan is not None:
             print("--- PLAN ---")
-            print(artifacts.plan)
+            print(json.dumps(artifacts.plan, indent=2, ensure_ascii=False))
         print(answer)
 
 

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -12,7 +13,70 @@ if str(SRC) not in sys.path:
 from .chat_repl import start_repl
 from .data_gen import generate_and_save
 from .llm.factory import build_llm
+from .llm.cache import apply_llm_cache
+from .runner import ensure_artifacts_root, load_cases, setup_runner
 from .settings import load_settings
+
+
+def _is_failure(status: str, fail_on: str) -> bool:
+    if status == "error":
+        return True
+    if fail_on in {"mismatch", "any"} and status == "mismatch":
+        return True
+    if fail_on == "any" and status == "skipped":
+        return True
+    return False
+
+
+def _build_summary(results, *, fail_on: str, artifacts_dir: str) -> dict:
+    import statistics
+
+    totals = {"ok": 0, "error": 0, "mismatch": 0, "skipped": 0}
+    durations = []
+    for res in results:
+        totals[res.status] = totals.get(res.status, 0) + 1
+        if res.timings.total_s is not None:
+            durations.append(res.timings.total_s)
+    avg = statistics.mean(durations) if durations else 0.0
+    median = statistics.median(durations) if durations else 0.0
+    failures = sum(1 for r in results if _is_failure(r.status, fail_on))
+    return {
+        "total": len(results),
+        "ok": totals.get("ok", 0),
+        "error": totals.get("error", 0),
+        "mismatch": totals.get("mismatch", 0),
+        "skipped": totals.get("skipped", 0),
+        "avg_total_s": avg,
+        "median_total_s": median,
+        "fail_on": fail_on,
+        "failures": failures,
+        "artifacts_dir": artifacts_dir,
+    }
+
+
+def _format_summary(summary: dict) -> str:
+    return (
+        "Summary: "
+        f"total={summary['total']}, "
+        f"ok={summary.get('ok', 0)}, "
+        f"mismatch={summary.get('mismatch', 0)}, "
+        f"error={summary.get('error', 0)}, "
+        f"skipped={summary.get('skipped', 0)}, "
+        f"avg={summary.get('avg_total_s', 0):.2f}s, "
+        f"median={summary.get('median_total_s', 0):.2f}s"
+    )
+
+
+def _cache_namespace(settings) -> str:
+    llm = settings.llm
+    payload = {
+        "base_url": llm.base_url,
+        "plan_model": llm.plan_model,
+        "synth_model": llm.synth_model,
+        "plan_temperature": llm.plan_temperature,
+        "synth_temperature": llm.synth_temperature,
+    }
+    return json.dumps(payload, sort_keys=True)
 
 
 def main() -> None:
@@ -30,6 +94,22 @@ def main() -> None:
     chat_p.add_argument("--schema", type=Path, required=True)
     chat_p.add_argument("--config", type=Path, default=None, help="Path to demo_qa.toml")
     chat_p.add_argument("--enable-semantic", action="store_true")
+    chat_p.add_argument("--llm-cache", choices=["off", "record", "replay"], default="off")
+    chat_p.add_argument("--llm-cache-file", type=Path, default=None)
+
+    batch_p = sub.add_parser("batch", help="Run batch QA cases")
+    batch_p.add_argument("--data", type=Path, required=True)
+    batch_p.add_argument("--schema", type=Path, required=True)
+    batch_p.add_argument("--cases", type=Path, required=True, help="Path to cases JSONL")
+    batch_p.add_argument("--out", type=Path, required=True, help="Path to results JSONL")
+    batch_p.add_argument("--config", type=Path, default=None, help="Path to demo_qa.toml")
+    batch_p.add_argument("--artifacts-dir", type=Path, default=None)
+    batch_p.add_argument("--enable-semantic", action="store_true")
+    batch_p.add_argument("--fail-fast", action="store_true", help="Stop on first failure")
+    batch_p.add_argument("--max-fails", type=int, default=None, help="Stop after N failures")
+    batch_p.add_argument("--fail-on", choices=["error", "mismatch", "any"], default="error")
+    batch_p.add_argument("--llm-cache", choices=["off", "record", "replay"], default="off")
+    batch_p.add_argument("--llm-cache-file", type=Path, default=None)
 
     args = parser.parse_args()
 
@@ -42,11 +122,83 @@ def main() -> None:
         try:
             settings = load_settings(config_path=args.config, data_dir=args.data)
         except Exception as exc:
-            raise SystemExit(f"Configuration error: {exc}")
+            print(f"Configuration error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
 
         llm = build_llm(settings)
+        cache_file = args.llm_cache_file or (args.data / ".runs" / "llm_cache.jsonl")
+        llm = apply_llm_cache(
+            llm,
+            mode=args.llm_cache,
+            path=cache_file if args.llm_cache != "off" else None,
+            namespace=_cache_namespace(settings),
+        )
 
         start_repl(args.data, args.schema, llm, enable_semantic=args.enable_semantic)
+        return
+
+    if args.command == "batch":
+        try:
+            settings = load_settings(config_path=args.config, data_dir=args.data)
+        except Exception as exc:
+            print(f"Configuration error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+
+        llm = build_llm(settings)
+        cache_file = args.llm_cache_file or (args.data / ".runs" / "llm_cache.jsonl")
+        llm = apply_llm_cache(
+            llm,
+            mode=args.llm_cache,
+            path=cache_file if args.llm_cache != "off" else None,
+            namespace=_cache_namespace(settings),
+        )
+
+        try:
+            cases = load_cases(args.cases)
+        except Exception as exc:
+            print(f"Cases error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+
+        artifacts_root = ensure_artifacts_root(args.artifacts_dir, data_dir=args.data)
+        runner = setup_runner(args.data, args.schema, llm, enable_semantic=args.enable_semantic)
+        results = []
+        failures = 0
+        if args.fail_fast and args.max_fails is None:
+            args.max_fails = 1
+
+        for case in cases:
+            res = runner.run_one(case, artifacts_root=artifacts_root)
+            results.append(res)
+
+            duration = f"{res.timings.total_s:.2f}s" if res.timings.total_s is not None else "-"
+            extra = ""
+            if res.status == "mismatch" and res.expected_check:
+                extra = res.expected_check.details or res.expected_check.mode
+            elif res.status == "error":
+                extra = res.error or ""
+            elif res.status == "skipped":
+                extra = "skipped"
+            print(f"{res.status.upper():<7} {res.id} {duration} {extra}".strip())
+
+            if _is_failure(res.status, args.fail_on):
+                failures += 1
+                if args.max_fails and failures >= args.max_fails:
+                    break
+
+        out_path: Path = args.out
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as f:
+            for res in results:
+                f.write(res.to_json() + "\n")
+
+        summary_path = out_path.with_name("summary.json")
+        summary = _build_summary(results, fail_on=args.fail_on, artifacts_dir=str(artifacts_root))
+        summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        print(_format_summary(summary))
+
+        if summary["failures"] > 0:
+            raise SystemExit(1)
         return
 
 

--- a/examples/demo_qa/llm/cache.py
+++ b/examples/demo_qa/llm/cache.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fetchgraph.core.protocols import LLMInvoke
+
+
+@dataclass
+class CacheEntry:
+    hash: str
+    sender: str
+    prompt: str
+    response: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "hash": self.hash,
+                "sender": self.sender,
+                "prompt": self.prompt,
+                "response": self.response,
+            },
+            ensure_ascii=False,
+        )
+
+
+class LLMCacheWrapper(LLMInvoke):
+    def __init__(self, llm: LLMInvoke, *, mode: str, path: Path, namespace: str = ""):
+        self.llm = llm
+        self.mode = mode
+        self.path = path
+        self.namespace = namespace or ""
+        self._cache: Dict[str, CacheEntry] = {}
+        self._load_existing()
+
+    def __call__(self, prompt: str, /, sender: str) -> str:  # type: ignore[override]
+        key = self._hash(sender, prompt)
+        if self.mode in {"record", "replay"} and key in self._cache:
+            return self._cache[key].response
+        if self.mode == "replay":
+            raise RuntimeError(f"LLM cache miss for sender={sender!r}.")
+        response = self.llm(prompt, sender=sender)
+        if self.mode == "record":
+            entry = CacheEntry(hash=key, sender=sender, prompt=prompt, response=response)
+            self._cache[key] = entry
+            self._append(entry)
+        return response
+
+    def _load_existing(self) -> None:
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict) or "hash" not in obj or "response" not in obj:
+                    continue
+                entry = CacheEntry(
+                    hash=str(obj["hash"]),
+                    sender=str(obj.get("sender", "")),
+                    prompt=str(obj.get("prompt", "")),
+                    response=str(obj["response"]),
+                )
+                self._cache[entry.hash] = entry
+
+    def _append(self, entry: CacheEntry) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(entry.to_json() + "\n")
+
+    def _hash(self, sender: str, prompt: str) -> str:
+        h = hashlib.sha256()
+        if self.namespace:
+            h.update(self.namespace.encode("utf-8"))
+            h.update(b"\n")
+        h.update(sender.encode("utf-8"))
+        h.update(b"\n")
+        h.update(prompt.encode("utf-8"))
+        return h.hexdigest()
+
+
+def apply_llm_cache(llm: LLMInvoke, *, mode: str, path: Optional[Path], namespace: str = "") -> LLMInvoke:
+    normalized_mode = mode.lower()
+    if normalized_mode not in {"record", "replay", "off"}:
+        raise ValueError("llm-cache mode must be one of: record, replay, off.")
+    if normalized_mode == "off":
+        return llm
+    if path is None:
+        raise ValueError("Cache file path must be provided when llm-cache is not 'off'.")
+    return LLMCacheWrapper(llm, mode=normalized_mode, path=path, namespace=namespace)
+
+
+__all__ = ["apply_llm_cache", "LLMCacheWrapper", "CacheEntry"]

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+import traceback
+from typing import Any, Dict, List, Optional
+
+from fetchgraph.core import BaseGraphAgent, TaskProfile, create_generic_agent
+from fetchgraph.core.models import Plan
+
+from .provider_factory import build_provider
+
+
+@dataclass
+class Timings:
+    plan_s: float | None = None
+    fetch_s: float | None = None
+    synth_s: float | None = None
+    total_s: float | None = None
+
+
+@dataclass
+class ExpectedCheck:
+    mode: str
+    expected: str
+    observed: str | None
+    passed: bool
+    details: str | None = None
+
+
+@dataclass
+class RunArtifacts:
+    plan: Dict[str, Any] | None = None
+    context: Dict[str, str] | None = None
+    raw_synth: str | None = None
+    answer: str | None = None
+
+
+@dataclass
+class RunResult:
+    id: str
+    question: str
+    answer: str | None
+    status: str
+    timings: Timings = field(default_factory=Timings)
+    expected_check: ExpectedCheck | None = None
+    error: str | None = None
+    plan_path: str | None = None
+    context_path: str | None = None
+    answer_path: str | None = None
+    raw_synth_path: str | None = None
+    tags: List[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        payload["timings"] = asdict(self.timings)
+        if self.expected_check is not None:
+            payload["expected_check"] = asdict(self.expected_check)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+@dataclass
+class CaseInput:
+    id: str
+    question: str
+    expected: str | None = None
+    expected_regex: str | None = None
+    expected_contains: str | None = None
+    tags: List[str] = field(default_factory=list)
+    skip: bool = False
+
+    @classmethod
+    def from_obj(cls, obj: Dict[str, Any]) -> "CaseInput":
+        if not isinstance(obj, dict):
+            raise ValueError("Case must be a JSON object.")
+        if "id" not in obj or "question" not in obj:
+            raise ValueError("Case must contain 'id' and 'question'.")
+        tags = obj.get("tags") or []
+        if tags is None:
+            tags = []
+        if not isinstance(tags, list):
+            raise ValueError("Case 'tags' must be a list if provided.")
+        expected = obj.get("expected")
+        expected_regex = obj.get("expected_regex")
+        expected_contains = obj.get("expected_contains")
+        return cls(
+            id=str(obj["id"]),
+            question=str(obj["question"]),
+            expected=None if expected is None else str(expected),
+            expected_regex=None if expected_regex is None else str(expected_regex),
+            expected_contains=None if expected_contains is None else str(expected_contains),
+            tags=[str(t) for t in tags],
+            skip=bool(obj.get("skip", False)),
+        )
+
+
+def load_cases(path: Path) -> List[CaseInput]:
+    if not path.exists():
+        raise FileNotFoundError(f"Cases file not found: {path}")
+    out: List[CaseInput] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {lineno}: {exc}") from exc
+            try:
+                case = CaseInput.from_obj(obj)
+            except Exception as exc:
+                raise ValueError(f"Invalid case at line {lineno}: {exc}") from exc
+            out.append(case)
+    return out
+
+
+def build_agent(llm, provider) -> "AgentRunner":
+    artifacts = RunArtifacts()
+
+    def saver(feature_name: str, parsed: object) -> None:
+        artifacts.answer = str(parsed)
+
+    task_profile = TaskProfile(
+        task_name="Demo QA",
+        goal="Answer analytics questions over the demo dataset",
+        output_format="Plain text answer",
+        focus_hints=[
+            "Prefer aggregates",
+            "Use concise answers",
+        ],
+    )
+
+    agent = create_generic_agent(
+        llm_invoke=llm,
+        providers={provider.name: provider},
+        saver=saver,
+        task_profile=task_profile,
+    )
+    return AgentRunner(agent=agent, artifacts=artifacts)
+
+
+class AgentRunner:
+    def __init__(self, agent: BaseGraphAgent, artifacts: RunArtifacts | None = None, run_id: str | None = None):
+        self.agent = agent
+        self.artifacts = artifacts or RunArtifacts()
+        self.run_id = run_id or datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        self._counter = 0
+
+    def run_question(self, question: str, *, artifacts_root: Path | None = None) -> str:
+        self._counter += 1
+        adhoc_case = CaseInput(id=f"adhoc_{self._counter:04d}", question=question)
+        result = self.run_one(adhoc_case, artifacts_root=artifacts_root)
+        if result.status != "ok":
+            detail = result.error or result.status
+            raise RuntimeError(f"Run failed for question: {detail}")
+        if result.answer is None:
+            raise RuntimeError("Run returned no answer.")
+        return result.answer
+
+    def run_one(self, case: CaseInput, *, artifacts_root: Path | None = None) -> RunResult:
+        self.artifacts.plan = None
+        self.artifacts.context = None
+        self.artifacts.raw_synth = None
+        self.artifacts.answer = None
+
+        timings = Timings()
+        error_msg: str | None = None
+
+        artifact_dir: Optional[Path] = None
+        if artifacts_root is not None:
+            artifact_dir = artifacts_root / case.id
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        start_total = time.perf_counter()
+
+        if case.skip:
+            timings.total_s = 0.0
+            result = RunResult(
+                id=case.id,
+                question=case.question,
+                answer=None,
+                status="skipped",
+                timings=timings,
+                expected_check=None,
+                error=None,
+                plan_path=str(artifact_dir / "plan.json") if artifact_dir else None,
+                context_path=str(artifact_dir / "context.json") if artifact_dir else None,
+                answer_path=str(artifact_dir / "answer.txt") if artifact_dir else None,
+                raw_synth_path=str(artifact_dir / "raw_synth.txt") if artifact_dir else None,
+                tags=case.tags,
+            )
+            if artifact_dir:
+                (artifact_dir / "plan.json").write_text("{}", encoding="utf-8")
+                (artifact_dir / "context.json").write_text("{}", encoding="utf-8")
+                (artifact_dir / "answer.txt").write_text("", encoding="utf-8")
+                (artifact_dir / "raw_synth.txt").write_text("", encoding="utf-8")
+            return result
+
+        plan: Plan | None = None
+        ctx_text: Dict[str, str] | None = None
+        raw_synth: str | None = None
+        answer: str | None = None
+        expected_check: ExpectedCheck | None = None
+        status = "ok"
+
+        try:
+            t0 = time.perf_counter()
+            plan = self.agent._plan(case.question)  # type: ignore[attr-defined]
+            timings.plan_s = time.perf_counter() - t0
+            self.artifacts.plan = plan.model_dump()
+
+            t0 = time.perf_counter()
+            ctx_items = self.agent._fetch(case.question, plan)  # type: ignore[attr-defined]
+            if getattr(self.agent, "llm_refetch", None):
+                ctx_items, plan = self.agent._assess_refetch_loop(case.question, ctx_items, plan)  # type: ignore[attr-defined]
+            ctx_items = self.agent._ensure_required_baseline(case.question, ctx_items)  # type: ignore[attr-defined]
+            timings.fetch_s = time.perf_counter() - t0
+            ctx_text = {k: v.text for k, v in (ctx_items or {}).items()}
+            self.artifacts.context = ctx_text
+
+            t0 = time.perf_counter()
+            draft = self.agent._synthesize(case.question, ctx_items, plan)  # type: ignore[attr-defined]
+            draft, _ = self.agent._verify_and_refine(case.question, ctx_items, plan, draft)  # type: ignore[attr-defined]
+            raw_synth = draft.text
+            self.artifacts.raw_synth = raw_synth
+            answer = self.agent.domain_parser(draft)
+            self.artifacts.answer = str(answer)
+            timings.synth_s = time.perf_counter() - t0
+        except Exception as exc:
+            status = "error"
+            error_msg = f"{exc.__class__.__name__}: {exc}"
+            stack = traceback.format_exc()
+            if artifact_dir:
+                (artifact_dir / "error.txt").write_text(stack, encoding="utf-8")
+            else:
+                error_msg = stack
+        finally:
+            timings.total_s = time.perf_counter() - start_total
+
+        if artifact_dir:
+            if self.artifacts.plan is not None:
+                (artifact_dir / "plan.json").write_text(
+                    json.dumps(self.artifacts.plan, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+            else:
+                (artifact_dir / "plan.json").write_text("{}", encoding="utf-8")
+            if self.artifacts.context is not None:
+                (artifact_dir / "context.json").write_text(
+                    json.dumps(self.artifacts.context, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+            else:
+                (artifact_dir / "context.json").write_text("{}", encoding="utf-8")
+            if self.artifacts.answer is not None:
+                (artifact_dir / "answer.txt").write_text(self.artifacts.answer, encoding="utf-8")
+            if self.artifacts.raw_synth is not None:
+                (artifact_dir / "raw_synth.txt").write_text(self.artifacts.raw_synth, encoding="utf-8")
+
+        if status != "error" and answer is not None:
+            expected_check = _evaluate_expectation(case, str(answer))
+            if expected_check and not expected_check.passed:
+                status = "mismatch"
+
+        result = RunResult(
+            id=case.id,
+            question=case.question,
+            answer=str(answer) if answer is not None else None,
+            status=status,
+            timings=timings,
+            expected_check=expected_check,
+            error=error_msg,
+            plan_path=str(artifact_dir / "plan.json") if artifact_dir else None,
+            context_path=str(artifact_dir / "context.json") if artifact_dir else None,
+            answer_path=str(artifact_dir / "answer.txt") if artifact_dir else None,
+            raw_synth_path=str(artifact_dir / "raw_synth.txt") if artifact_dir else None,
+            tags=case.tags,
+        )
+        return result
+
+
+def _evaluate_expectation(case: CaseInput, answer: str) -> ExpectedCheck | None:
+    if case.expected is None and case.expected_regex is None and case.expected_contains is None:
+        return None
+    if case.expected_regex is not None:
+        import re
+
+        matched = re.search(case.expected_regex, answer) is not None
+        details = None if matched else f"Regex {case.expected_regex!r} not found in answer."
+        return ExpectedCheck(
+            mode="expected_regex",
+            expected=case.expected_regex,
+            observed=answer,
+            passed=matched,
+            details=details,
+        )
+    if case.expected_contains is not None:
+        matched = case.expected_contains in answer
+        details = None if matched else f"Expected substring {case.expected_contains!r} not found."
+        return ExpectedCheck(
+            mode="expected_contains",
+            expected=case.expected_contains,
+            observed=answer,
+            passed=matched,
+            details=details,
+        )
+    expected = case.expected or ""
+    matched = answer.strip() == expected.strip()
+    details = None if matched else "Answer did not match expected exactly."
+    return ExpectedCheck(
+        mode="expected",
+        expected=expected,
+        observed=answer,
+        passed=matched,
+        details=details,
+    )
+
+
+def ensure_artifacts_root(path: Path | None, *, data_dir: Path) -> Path:
+    if path is None:
+        return data_dir / ".runs" / f"batch_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}"
+    return path
+
+
+def setup_runner(data_dir: Path, schema_path: Path, llm, *, enable_semantic: bool = False) -> AgentRunner:
+    provider, _ = build_provider(data_dir, schema_path, enable_semantic=enable_semantic)
+    return build_agent(llm, provider)
+
+
+__all__ = [
+    "AgentRunner",
+    "CaseInput",
+    "ExpectedCheck",
+    "RunArtifacts",
+    "RunResult",
+    "Timings",
+    "build_agent",
+    "ensure_artifacts_root",
+    "load_cases",
+    "setup_runner",
+]


### PR DESCRIPTION
## Summary
- add a reusable demo_qa AgentRunner for per-case artifacts, expectation checks, and JSONL results
- extend the CLI with a batch subcommand, LLM cache toggles, and summary/exit-code handling, including a model-aware cache namespace and predictable artifact roots
- ensure adhoc REPL runs use unique artifact IDs, fix cache hashing, simplify artifact directories, and surface chat runner errors instead of returning blank answers

## Testing
- python -m compileall examples/demo_qa

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945be8ac6a8832f8bab79106daf6e53)