### PR TITLE
Fix pyright typing issues in schema binding

### DIFF
--- a/src/fetchgraph/schema/bind.py
+++ b/src/fetchgraph/schema/bind.py
@@ -205,8 +205,8 @@ def _bind_field(
         rel = relation_index.get(rel_alias)
         if rel is None:
             raise UnknownRelation(rel_alias)
-        target_entity = entity_index.get(rel.to_entity)
-        if target_entity and field in target_entity.field_names():
+        target_entity_desc = entity_index.get(rel.to_entity)
+        if target_entity_desc and field in target_entity_desc.field_names():
             candidates.append(
                 _Candidate(
                     source="declared",
@@ -220,8 +220,8 @@ def _bind_field(
         for rel in schema.relations:
             if rel.from_entity != root_entity:
                 continue
-            target_entity = entity_index.get(rel.to_entity)
-            if target_entity and field in target_entity.field_names():
+            target_entity_desc = entity_index.get(rel.to_entity)
+            if target_entity_desc and field in target_entity_desc.field_names():
                 candidates.append(
                     _Candidate(
                         source="auto_add",

--- a/tests/test_schema_binding_v1.py
+++ b/tests/test_schema_binding_v1.py
@@ -19,7 +19,7 @@ class DummyProvider:
         self.describe_calls = 0
         self.name = "dummy"
 
-    def describe_schema(self):
+    def describe_schema(self) -> object:
         self.describe_calls += 1
         return self.schema
 


### PR DESCRIPTION
## Summary
- avoid reusing string-typed target variables when selecting candidate entities during binding
- relax DummyProvider describe_schema return annotation to support SchemaResult coercion in tests

## Testing
- pyright


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464111e87c832f9dd5e89548e7c226)