### PR TITLE
Enhance demo QA CLI UX and diagnostics

### DIFF
--- a/examples/demo_qa/chat_repl.py
+++ b/examples/demo_qa/chat_repl.py
@@ -8,16 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Optional, Sequence
 
+import readline
+
 from fetchgraph.core import create_generic_agent
 from fetchgraph.core.models import TaskProfile
 from fetchgraph.utils import set_run_id
 
 from .provider_factory import build_provider
-
-try:  # pragma: no cover - platform specific
-    import readline
-except ImportError:  # pragma: no cover - Windows fallback
-    readline = None
 
 
 @dataclass
@@ -94,7 +91,7 @@ def _save_artifacts(artifacts: RunArtifacts) -> None:
 
 def _maybe_add_history(entry: str) -> None:
     """Record the entry so it can be recalled with ↑ like a shell."""
-    if not entry or readline is None:  # pragma: no cover - simple guard
+    if not entry:  # pragma: no cover - simple guard
         return
     hist_len = readline.get_current_history_length()
     if hist_len == 0 or readline.get_history_item(hist_len) != entry:

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -58,6 +58,20 @@ def main() -> None:
             run_id=None,
         )
 
+        llm_settings = settings.llm
+        llm_endpoint = llm_settings.base_url or "https://api.openai.com/v1"
+        diagnostics = [
+            f"LLM endpoint: {llm_endpoint}",
+            f"Plan model: {llm_settings.plan_model} (temp={llm_settings.plan_temperature})",
+            f"Synth model: {llm_settings.synth_model} (temp={llm_settings.synth_temperature})",
+            f"Timeout: {llm_settings.timeout_s if llm_settings.timeout_s is not None else 'default'}, "
+            f"Retries: {llm_settings.retries if llm_settings.retries is not None else 'default'}",
+        ]
+        if args.enable_semantic:
+            diagnostics.append(f"Embeddings: CSV semantic backend in {args.data} (*.embeddings.json)")
+        else:
+            diagnostics.append("Embeddings: disabled (use --enable-semantic to build/search embeddings).")
+
         llm = build_llm(settings)
 
         start_repl(
@@ -66,6 +80,7 @@ def main() -> None:
             llm,
             enable_semantic=args.enable_semantic,
             log_file=log_file,
+            diagnostics=diagnostics,
         )
         return
 


### PR DESCRIPTION
## Summary
- add readline-backed input history so the last entry can be recalled and edited with the up arrow
- show startup diagnostics for LLM endpoint/models and semantic embedding setup in the chat command
- clarify REPL instructions for exiting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694652ca6674832fa8b0404ab35e6ce2)