### PR TITLE
Unify demo QA diff logic

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -66,7 +66,7 @@ python -m examples.demo_qa.cli batch \
 
 * Артефакты по умолчанию пишутся в `<data>/.runs/runs/<timestamp>_<cases_stem>/cases/<id>_<runid>/` (`plan.json`, `context.json`, `answer.txt`, `raw_synth.txt`, `error.txt`).
 * `results.jsonl` содержит по строке на кейс, рядом сохраняется `summary.json` с агрегацией статусов и, при наличии `--compare-to`, diff по прогрессу.
-* Флаги `--fail-on (error|mismatch/unchecked/any)`, `--max-fails`, `--fail-fast`, `--require-assert`, `--compare-to`, `--only-failed-from/--only-failed` и `--plan-only` управляют выбором кейсов, остановкой и кодом выхода (0/1/2).
+* Флаги `--fail-on (error|bad|unchecked|any|skipped)`, `--max-fails`, `--fail-fast`, `--require-assert`, `--compare-to`, `--only-failed-from/--only-failed` и `--plan-only` управляют выбором кейсов, остановкой и кодом выхода (0/1/2).
 * Без `--out` результаты складываются в `<artifacts_dir>/runs/<timestamp>_<cases_stem>/results.jsonl`, а `runs/latest.txt` указывает на последнюю папку запуска.
 * Быстрый фокус на упавших: `--only-failed` возьмёт `runs/latest/results.jsonl`, `--show-artifacts` печатает пути, репро-команды выводятся для каждого FAIL.
 * Команды уровня кейса: `demo_qa case run <id> --cases ...` и `demo_qa case open <id> --run runs/latest` для быстрого воспроизведения.

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -17,9 +17,11 @@ from .runner import (
     Case,
     EventLogger,
     RunResult,
+    bad_statuses,
     build_agent,
-    compare_results,
+    diff_runs,
     format_status_line,
+    is_failure,
     load_cases,
     load_results,
     run_one,
@@ -41,17 +43,6 @@ def write_summary(out_path: Path, summary: dict) -> Path:
     return summary_path
 
 
-def _median_duration(results: Mapping[str, RunResult]) -> Optional[float]:
-    durations = [res.duration_ms for res in results.values() if res.duration_ms is not None]
-    if not durations:
-        return None
-    durations.sort()
-    mid = len(durations) // 2
-    if len(durations) % 2 == 1:
-        return durations[mid] / 1000
-    return (durations[mid - 1] + durations[mid]) / 2000
-
-
 def _pass_rate(counts: Mapping[str, object]) -> Optional[float]:
     total = int(counts.get("total", 0) or 0)
     skipped = int(counts.get("skipped", 0) or 0)
@@ -59,26 +50,6 @@ def _pass_rate(counts: Mapping[str, object]) -> Optional[float]:
     if denom <= 0:
         return None
     return (counts.get("ok", 0) or 0) / denom
-
-
-def bad_statuses(fail_on: str, require_assert: bool) -> set[str]:
-    unchecked = {"unchecked", "plan_only"}
-    bad = {"error", "failed", "mismatch"}
-    if fail_on == "error":
-        bad = {"error"}
-    elif fail_on in {"unchecked", "any"}:
-        bad |= unchecked
-    elif fail_on == "skipped":
-        bad |= {"skipped"}
-
-    if require_assert:
-        bad |= unchecked
-
-    return bad
-
-
-def is_failure(status: str, fail_on: str, require_assert: bool) -> bool:
-    return status in bad_statuses(fail_on, require_assert)
 
 
 def _hash_file(path: Path) -> str:
@@ -231,94 +202,10 @@ def handle_chat(args) -> int:
     return 0
 
 
-def _bad_statuses() -> set[str]:
-    return bad_statuses("bad", False)
-
-
-def _reason(res: RunResult) -> str:
-    if res.reason:
-        return res.reason
-    if res.error:
-        return res.error
-    if res.expected_check and res.expected_check.detail:
-        return res.expected_check.detail
-    return ""
-
-
-def _artifact_links(res: RunResult) -> dict[str, str]:
-    links = {}
-    base = Path(res.artifacts_dir)
-    for name in ["plan.json", "answer.txt", "raw_synth.txt", "status.json"]:
-        path = base / name
-        if path.exists():
-            links[name] = str(path)
-    return links
-
-
-def compare_runs(base_path: Path, new_path: Path) -> dict[str, object]:
+def compare_runs(base_path: Path, new_path: Path, *, fail_on: str, require_assert: bool) -> dict[str, object]:
     base = load_results(base_path)
     new = load_results(new_path)
-    bad = _bad_statuses()
-
-    new_fail: list[dict] = []
-    fixed: list[dict] = []
-    still_fail: list[dict] = []
-
-    for case_id, new_res in new.items():
-        old_res = base.get(case_id)
-        if old_res is None:
-            continue
-        old_bad = old_res.status in bad
-        new_bad = new_res.status in bad
-        if not old_bad and new_bad:
-            new_fail.append(
-                {
-                    "id": case_id,
-                    "from": old_res.status,
-                    "to": new_res.status,
-                    "reason": _reason(new_res),
-                    "artifacts": _artifact_links(new_res),
-                }
-            )
-        elif old_bad and not new_bad:
-            fixed.append(
-                {
-                    "id": case_id,
-                    "from": old_res.status,
-                    "to": new_res.status,
-                    "reason": _reason(new_res),
-                    "artifacts": _artifact_links(new_res),
-                }
-            )
-        elif old_bad and new_bad:
-            still_fail.append(
-                {
-                    "id": case_id,
-                    "from": old_res.status,
-                    "to": new_res.status,
-                    "reason": _reason(new_res),
-                    "artifacts": _artifact_links(new_res),
-                }
-            )
-
-    base_counts = summarize(base.values())
-    new_counts = summarize(new.values())
-    base_med = _median_duration(base)
-    new_med = _median_duration(new)
-    base_avg = base_counts.get("avg_total_s")
-    new_avg = new_counts.get("avg_total_s")
-    return {
-        "new_fail": new_fail,
-        "fixed": fixed,
-        "still_fail": still_fail,
-        "all_ids": list(new.keys()),
-        "base_counts": base_counts,
-        "new_counts": new_counts,
-        "base_median": base_med,
-        "new_median": new_med,
-        "base_avg": base_avg,
-        "new_avg": new_avg,
-    }
+    return diff_runs(base.values(), new.values(), fail_on=fail_on, require_assert=require_assert)
 
 
 def render_markdown(compare: dict[str, object], out_path: Optional[Path]) -> str:
@@ -348,7 +235,7 @@ def render_markdown(compare: dict[str, object], out_path: Optional[Path]) -> str
             return
         lines.append("| id | status | reason | artifacts |")
         lines.append("|---|---|---|---|")
-        for row in rows:
+        for row in sorted(rows, key=lambda r: r.get("id", "")):
             artifacts = row.get("artifacts", {})
             links = ", ".join(f"[{k}]({v})" for k, v in artifacts.items())
             lines.append(
@@ -372,13 +259,14 @@ def write_junit(compare: dict[str, object], out_path: Path) -> None:
     suite = ET.Element("testsuite", name="demo_qa_compare")
     bad = compare["new_fail"] + compare["still_fail"]  # type: ignore[operator]
     fixed = compare["fixed"]  # type: ignore[assignment]
-    all_ids = set(compare.get("all_ids", []) or [])  # type: ignore[arg-type]
+    all_ids_list = list(compare.get("all_ids", []) or [])  # type: ignore[arg-type]
+    all_ids = sorted(all_ids_list)
     cases_total = len(all_ids)
     suite.set("tests", str(cases_total))
     suite.set("failures", str(len(bad)))
     suite.set("errors", "0")
 
-    for row in bad:
+    for row in sorted(bad, key=lambda r: r.get("id", "")):
         tc = ET.SubElement(suite, "testcase", name=row["id"])
         msg = row.get("reason", "") or f"{row.get('from')} → {row.get('to')}"
         failure = ET.SubElement(tc, "failure", message=msg)
@@ -386,10 +274,12 @@ def write_junit(compare: dict[str, object], out_path: Path) -> None:
         if artifacts:
             failure.text = "\n".join(f"{k}: {v}" for k, v in artifacts.items())
 
-    for row in fixed:
+    for row in sorted(fixed, key=lambda r: r.get("id", "")):
         ET.SubElement(suite, "testcase", name=row["id"])
 
-    ok_ids = all_ids - {row["id"] for row in bad} - {row["id"] for row in fixed}
+    bad_ids = {row["id"] for row in bad}
+    fixed_ids = {row["id"] for row in fixed}
+    ok_ids = [cid for cid in all_ids if cid not in bad_ids and cid not in fixed_ids]
     for cid in ok_ids:
         ET.SubElement(suite, "testcase", name=cid)
 
@@ -535,12 +425,16 @@ def handle_batch(args) -> int:
     write_results(results_path, results)
     counts = summarize(results)
 
-    results_by_id = {r.id: r for r in results}
     diff_block: dict | None = None
     baseline_path: Path | None = None
     if baseline_for_compare:
         baseline_path = args.compare_to or baseline_filter_path
-        diff = compare_results(baseline_for_compare, results_by_id, require_assert=args.require_assert)
+        diff = diff_runs(
+            baseline_for_compare.values(),
+            results,
+            fail_on=args.fail_on,
+            require_assert=args.require_assert,
+        )
         if baseline_path:
             diff["baseline_path"] = str(baseline_path)
         diff_block = diff
@@ -648,20 +542,20 @@ def handle_batch(args) -> int:
         print(summary_line)
         if diff_block:
             print(
-                f"Δ vs baseline: +{len(diff_block.get('new_ok', []))} green, "
-                f"-{len(diff_block.get('regressed', []))} regressions, "
-                f"{len(diff_block.get('still_bad', []))} still failing, "
-                f"{len(diff_block.get('new_unchecked', []))} new unchecked"
+                f"Δ vs baseline: +{len(diff_block.get('fixed', []))} fixed, "
+                f"-{len(diff_block.get('new_fail', []))} regressions, "
+                f"{len(diff_block.get('still_fail', []))} still failing, "
+                f"{len(diff_block.get('new_cases', []))} new cases"
             )
         return exit_code
 
     print(summary_line)
     if diff_block:
         print(
-            f"Δ vs baseline: +{len(diff_block.get('new_ok', []))} green, "
-            f"-{len(diff_block.get('regressed', []))} regressions, "
-            f"{len(diff_block.get('still_bad', []))} still failing, "
-            f"{len(diff_block.get('new_unchecked', []))} new unchecked"
+            f"Δ vs baseline: +{len(diff_block.get('fixed', []))} fixed, "
+            f"-{len(diff_block.get('new_fail', []))} regressions, "
+            f"{len(diff_block.get('still_fail', []))} still failing, "
+            f"{len(diff_block.get('new_cases', []))} new cases"
         )
 
     failures_list: dict[str, RunResult] = {}
@@ -828,7 +722,7 @@ def handle_compare(args) -> int:
     if not args.base.exists() or not args.new.exists():
         print("Base or new results file not found.", file=sys.stderr)
         return 2
-    comparison = compare_runs(args.base, args.new)
+    comparison = compare_runs(args.base, args.new, fail_on=args.fail_on, require_assert=args.require_assert)
     report = render_markdown(comparison, args.out)
     print(report)
     if args.junit:

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -87,6 +87,11 @@ def build_parser() -> argparse.ArgumentParser:
     batch_p.add_argument("--exclude-ids", type=Path, default=None, help="Path to file with ids to exclude (one per line)")
     batch_p.add_argument("--events", choices=["on", "off"], default="on", help="Enable events.jsonl emission")
     batch_p.add_argument("--events-file", type=Path, default=None, help="Override events file path")
+    batch_p.add_argument(
+        "--fingerprint-verbose",
+        action="store_true",
+        help="Include per-file entries in data fingerprint (defaults to counts only)",
+    )
 
     case_root = sub.add_parser("case", help="Single-case utilities")
     case_sub = case_root.add_subparsers(dest="case_command", required=True)

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -63,7 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
     batch_p.add_argument("--fail-fast", action="store_true", help="Stop on first failing case")
     batch_p.add_argument(
         "--fail-on",
-        choices=["error", "mismatch", "bad", "unchecked", "any", "skipped"],
+        choices=["error", "bad", "unchecked", "any", "skipped"],
         default="bad",
         help="Which statuses should cause a failing exit code",
     )
@@ -120,6 +120,13 @@ def build_parser() -> argparse.ArgumentParser:
     compare_p.add_argument("--new", type=Path, required=True, help="Path to new results.jsonl")
     compare_p.add_argument("--out", type=Path, default=None, help="Path to markdown report to write")
     compare_p.add_argument("--junit", type=Path, default=None, help="Path to junit xml output")
+    compare_p.add_argument(
+        "--fail-on",
+        choices=["error", "bad", "unchecked", "any", "skipped"],
+        default="bad",
+        help="Which statuses should be treated as failures when diffing",
+    )
+    compare_p.add_argument("--require-assert", action="store_true", help="Treat unchecked cases as failures when diffing")
 
     return parser
 

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -632,6 +632,8 @@ def diff_runs(
 
         if base_res is None:
             new_cases.append(case_id)
+            if new_bad:
+                new_fail.append(_entry(case_id, base_res, new_res))
         else:
             if base_res.status != new_res.status:
                 changed_status.append({"id": case_id, "from": base_res.status, "to": new_res.status})

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -531,65 +531,158 @@ def load_results(path: Path) -> Dict[str, RunResult]:
     return results
 
 
-def _bucket(status: str, checked: bool, require_assert: bool) -> str:
-    if status == "ok":
-        return "OK" if checked else "UNCHECKED"
-    if status in {"mismatch", "failed", "error"}:
-        return "BAD"
-    if status in {"unchecked", "plan_only"}:
-        return "BAD" if require_assert else "UNCHECKED"
-    return "NEUTRAL"
+def bad_statuses(fail_on: str, require_assert: bool) -> set[str]:
+    unchecked = {"unchecked", "plan_only"}
+    bad = {"error", "failed", "mismatch"}
+    if fail_on == "error":
+        bad = {"error"}
+    elif fail_on in {"unchecked", "any"}:
+        bad |= unchecked
+    elif fail_on == "skipped":
+        bad |= {"skipped"}
+
+    if require_assert:
+        bad |= unchecked
+
+    return bad
 
 
-def compare_results(
-    baseline: Mapping[str, RunResult],
-    current: Mapping[str, RunResult],
+def is_failure(status: str, fail_on: str, require_assert: bool) -> bool:
+    return status in bad_statuses(fail_on, require_assert)
+
+
+def _artifact_links(res: RunResult) -> dict[str, str]:
+    links: dict[str, str] = {}
+    base = Path(res.artifacts_dir)
+    for name in ["plan.json", "answer.txt", "raw_synth.txt", "status.json"]:
+        path = base / name
+        if path.exists():
+            links[name] = str(path)
+    return links
+
+
+def _reason(res: RunResult) -> str:
+    if res.reason:
+        return res.reason
+    if res.error:
+        return res.error
+    if res.expected_check and res.expected_check.detail:
+        return res.expected_check.detail
+    return ""
+
+
+def _median_duration(results: Mapping[str, RunResult]) -> float | None:
+    durations = [res.duration_ms for res in results.values() if res.duration_ms is not None]
+    if not durations:
+        return None
+    durations.sort()
+    mid = len(durations) // 2
+    if len(durations) % 2 == 1:
+        return durations[mid] / 1000
+    return (durations[mid - 1] + durations[mid]) / 2000
+
+
+def _count_bad_from_summary(counts: Mapping[str, object], fail_on: str, require_assert: bool) -> int:
+    bad = bad_statuses(fail_on, require_assert)
+    total = 0
+    for status in bad:
+        try:
+            total += int(counts.get(status, 0) or 0)
+        except Exception:
+            continue
+    return total
+
+
+def diff_runs(
+    base_results: Iterable[RunResult],
+    new_results: Iterable[RunResult],
     *,
+    fail_on: str,
     require_assert: bool,
 ) -> Dict[str, object]:
-    new_ok: List[str] = []
-    regressed: List[str] = []
-    still_ok: List[str] = []
-    still_bad: List[str] = []
-    new_unchecked: List[str] = []
-    status_changes: Dict[str, Dict[str, str]] = {}
-    new_cases: List[str] = []
+    base_by_id = {res.id: res for res in base_results}
+    new_by_id = {res.id: res for res in new_results}
+    all_ids = sorted(new_by_id.keys())
 
-    for case_id, res in current.items():
-        base_res = baseline.get(case_id)
-        new_bucket = _bucket(res.status, res.checked, require_assert)
+    bad = bad_statuses(fail_on, require_assert)
+
+    def _is_bad(res: RunResult | None) -> bool:
+        return bool(res and res.status in bad)
+
+    def _entry(case_id: str, base_res: RunResult | None, new_res: RunResult) -> dict[str, object]:
+        return {
+            "id": case_id,
+            "from": base_res.status if base_res else None,
+            "to": new_res.status,
+            "reason": _reason(new_res),
+            "artifacts": _artifact_links(new_res),
+        }
+
+    new_fail: list[dict[str, object]] = []
+    fixed: list[dict[str, object]] = []
+    still_fail: list[dict[str, object]] = []
+    changed_status: list[dict[str, str | None]] = []
+    new_cases: list[str] = []
+
+    for case_id in all_ids:
+        new_res = new_by_id[case_id]
+        base_res = base_by_id.get(case_id)
+        base_bad = _is_bad(base_res)
+        new_bad = _is_bad(new_res)
+
         if base_res is None:
             new_cases.append(case_id)
-            if new_bucket == "OK":
-                new_ok.append(case_id)
-            elif new_bucket == "BAD":
-                still_bad.append(case_id)
-            status_changes[case_id] = {"from": "new", "to": res.status}
+        else:
+            if base_res.status != new_res.status:
+                changed_status.append({"id": case_id, "from": base_res.status, "to": new_res.status})
+
+        if base_res is None:
             continue
 
-        base_bucket = _bucket(base_res.status, base_res.checked, require_assert)
-        if base_res.checked and res.status == "unchecked":
-            new_unchecked.append(case_id)
-        if base_bucket == "OK" and new_bucket in {"BAD", "UNCHECKED"}:
-            regressed.append(case_id)
-        elif base_bucket in {"BAD", "UNCHECKED"} and new_bucket == "OK":
-            new_ok.append(case_id)
-        elif base_bucket == "OK" and new_bucket == "OK":
-            still_ok.append(case_id)
-        elif base_bucket in {"BAD", "UNCHECKED"} and new_bucket in {"BAD", "UNCHECKED"}:
-            still_bad.append(case_id)
+        if not base_bad and new_bad:
+            new_fail.append(_entry(case_id, base_res, new_res))
+        elif base_bad and not new_bad:
+            fixed.append(_entry(case_id, base_res, new_res))
+        elif base_bad and new_bad:
+            still_fail.append(_entry(case_id, base_res, new_res))
 
-        if base_res.status != res.status:
-            status_changes[case_id] = {"from": base_res.status, "to": res.status}
+    base_counts = summarize(base_by_id.values())
+    new_counts = summarize(new_by_id.values())
+    base_med = _median_duration(base_by_id)
+    new_med = _median_duration(new_by_id)
+    base_avg = base_counts.get("avg_total_s")
+    new_avg = new_counts.get("avg_total_s")
+
+    def _count_delta(key: str) -> int | float | None:
+        base_val = base_counts.get(key)
+        new_val = new_counts.get(key)
+        if isinstance(base_val, (int, float)) and isinstance(new_val, (int, float)):
+            return new_val - base_val
+        return None
+
+    delta_keys = {"ok", "mismatch", "failed", "error", "skipped", "unchecked", "plan_only", "total"}
+    count_deltas = {k: _count_delta(k) for k in delta_keys}
 
     return {
-        "new_ok": new_ok,
-        "regressed": regressed,
-        "still_ok": still_ok,
-        "still_bad": still_bad,
-        "new_unchecked": new_unchecked,
-        "status_changes": status_changes,
+        "all_ids": all_ids,
+        "new_fail": new_fail,
+        "fixed": fixed,
+        "still_fail": still_fail,
+        "changed_status": changed_status,
         "new_cases": new_cases,
+        "base_counts": base_counts,
+        "new_counts": new_counts,
+        "counts_delta": count_deltas,
+        "base_median": base_med,
+        "new_median": new_med,
+        "base_avg": base_avg,
+        "new_avg": new_avg,
+        "median_delta": (new_med - base_med) if (new_med is not None and base_med is not None) else None,
+        "avg_delta": (new_avg - base_avg) if (isinstance(new_avg, (int, float)) and isinstance(base_avg, (int, float))) else None,
+        "base_bad_total": _count_bad_from_summary(base_counts, fail_on, require_assert),
+        "new_bad_total": _count_bad_from_summary(new_counts, fail_on, require_assert),
+        "fail_on": fail_on,
+        "require_assert": require_assert,
     }
 
 
@@ -605,24 +698,6 @@ def format_status_line(result: RunResult) -> str:
     return f"FAIL {result.id} {result.status} ({reason or 'unknown'}) {timing}"
 
 
-__all__ = [
-    "AgentRunner",
-    "Case",
-    "ExpectedCheck",
-    "RunArtifacts",
-    "RunResult",
-    "EventLogger",
-    "build_agent",
-    "compare_results",
-    "format_status_line",
-    "load_results",
-    "load_cases",
-    "run_one",
-    "save_artifacts",
-    "save_status",
-    "summarize",
-    "_match_expected",
-]
 class EventLogger:
     def __init__(self, path: Path | None, run_id: str):
         self.path = path
@@ -641,3 +716,25 @@ class EventLogger:
         if path is None:
             return self
         return EventLogger(path, self.run_id)
+
+
+__all__ = [
+    "AgentRunner",
+    "Case",
+    "ExpectedCheck",
+    "RunArtifacts",
+    "RunResult",
+    "EventLogger",
+    "build_agent",
+    "bad_statuses",
+    "diff_runs",
+    "format_status_line",
+    "is_failure",
+    "load_results",
+    "load_cases",
+    "run_one",
+    "save_artifacts",
+    "save_status",
+    "summarize",
+    "_match_expected",
+]

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -365,7 +365,7 @@ def summarize(results: Iterable[RunResult]) -> Dict[str, object]:
         "checked_ok": checked_ok,
         "unchecked_no_assert": unchecked_no_assert,
         "plan_only": plan_only,
-        "summary_by_tag": per_tag,
+        "summary_by_tag": {tag: per_tag[tag] for tag in sorted(per_tag)},
         **totals,
     }
     if total_times:
@@ -660,7 +660,7 @@ def diff_runs(
             return new_val - base_val
         return None
 
-    delta_keys = {"ok", "mismatch", "failed", "error", "skipped", "unchecked", "plan_only", "total"}
+    delta_keys = ["total", "ok", "mismatch", "failed", "error", "unchecked", "plan_only", "skipped"]
     count_deltas = {k: _count_delta(k) for k in delta_keys}
 
     return {

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -4,7 +4,7 @@ import itertools
 
 import pytest
 
-from examples.demo_qa.batch import bad_statuses, is_failure
+from examples.demo_qa.batch import bad_statuses, is_failure, render_markdown
 
 
 @pytest.mark.parametrize(
@@ -17,3 +17,21 @@ def test_is_failure_matches_bad_statuses(fail_on: str, require_assert: bool) -> 
     assert bad  # sanity check
     for status in statuses:
         assert is_failure(status, fail_on, require_assert) == (status in bad)
+
+
+def test_render_markdown_uses_fail_policy() -> None:
+    compare = {
+        "base_counts": {"ok": 0, "mismatch": 2, "error": 1, "failed": 0},
+        "new_counts": {"ok": 1, "mismatch": 0, "error": 0, "failed": 0},
+        "base_bad_total": 1,
+        "new_bad_total": 0,
+        "fail_on": "error",
+        "require_assert": False,
+        "new_fail": [],
+        "fixed": [],
+        "still_fail": [],
+        "all_ids": [],
+    }
+    report = render_markdown(compare, None)
+    assert "- Base OK: 0, Bad: 1" in report
+    assert "- New  OK: 1, Bad: 0" in report

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -9,7 +9,7 @@ from examples.demo_qa.batch import bad_statuses, is_failure
 
 @pytest.mark.parametrize(
     "fail_on,require_assert",
-    itertools.product(["bad", "error", "mismatch", "unchecked", "any", "skipped"], [False, True]),
+    itertools.product(["bad", "error", "unchecked", "any", "skipped"], [False, True]),
 )
 def test_is_failure_matches_bad_statuses(fail_on: str, require_assert: bool) -> None:
     statuses = ["ok", "mismatch", "failed", "error", "unchecked", "plan_only", "skipped"]

--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -108,14 +108,25 @@ def test_diff_runs_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
+        RunResult(
+            id="new_bad",
+            question="",
+            status="failed",
+            checked=True,
+            reason=None,
+            details=None,
+            artifacts_dir="/tmp/newbad",
+            duration_ms=10,
+            tags=[],
+        ),
     ]
 
     diff = diff_runs(baseline, current, fail_on="bad", require_assert=True)
 
-    assert {row["id"] for row in diff["new_fail"]} == {"ok_to_bad"}
+    assert {row["id"] for row in diff["new_fail"]} == {"ok_to_bad", "new_bad"}
     assert {row["id"] for row in diff["fixed"]} == {"err_to_ok"}
     assert {row["id"] for row in diff["still_fail"]} == {"still_bad"}
-    assert diff["new_cases"] == ["new_ok"]
+    assert diff["new_cases"] == ["new_bad", "new_ok"]
 
 
 def test_summarize_counts_checked_and_unchecked() -> None:

--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from examples.demo_qa.runner import Case, RunResult, _match_expected, compare_results, summarize
+from examples.demo_qa.runner import Case, RunResult, _match_expected, diff_runs, summarize
 
 
 def test_match_expected_unchecked_when_no_expectations() -> None:
@@ -26,9 +26,9 @@ def test_match_expected_contains_pass_and_fail() -> None:
     assert missing_answer.detail == "no answer"
 
 
-def test_compare_results_tracks_regressions_and_improvements() -> None:
-    baseline = {
-        "ok_to_bad": RunResult(
+def test_diff_runs_tracks_regressions_and_improvements() -> None:
+    baseline = [
+        RunResult(
             id="ok_to_bad",
             question="",
             status="ok",
@@ -39,7 +39,7 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-        "err_to_ok": RunResult(
+        RunResult(
             id="err_to_ok",
             question="",
             status="error",
@@ -50,10 +50,10 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-        "checked_to_unchecked": RunResult(
-            id="checked_to_unchecked",
+        RunResult(
+            id="still_bad",
             question="",
-            status="ok",
+            status="mismatch",
             checked=True,
             reason=None,
             details=None,
@@ -61,10 +61,10 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-    }
+    ]
 
-    current = {
-        "ok_to_bad": RunResult(
+    current = [
+        RunResult(
             id="ok_to_bad",
             question="",
             status="mismatch",
@@ -75,7 +75,7 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-        "err_to_ok": RunResult(
+        RunResult(
             id="err_to_ok",
             question="",
             status="ok",
@@ -86,18 +86,18 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-        "checked_to_unchecked": RunResult(
-            id="checked_to_unchecked",
+        RunResult(
+            id="still_bad",
             question="",
-            status="unchecked",
-            checked=False,
+            status="failed",
+            checked=True,
             reason=None,
             details=None,
             artifacts_dir="/tmp/ok2",
             duration_ms=10,
             tags=[],
         ),
-        "new_ok": RunResult(
+        RunResult(
             id="new_ok",
             question="",
             status="ok",
@@ -108,14 +108,14 @@ def test_compare_results_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
-    }
+    ]
 
-    diff = compare_results(baseline, current, require_assert=True)
+    diff = diff_runs(baseline, current, fail_on="bad", require_assert=True)
 
-    assert "ok_to_bad" in diff["regressed"]
-    assert "err_to_ok" in diff["new_ok"]
-    assert "checked_to_unchecked" in diff["new_unchecked"]
-    assert "new_ok" in diff["new_ok"]
+    assert {row["id"] for row in diff["new_fail"]} == {"ok_to_bad"}
+    assert {row["id"] for row in diff["fixed"]} == {"err_to_ok"}
+    assert {row["id"] for row in diff["still_fail"]} == {"still_bad"}
+    assert diff["new_cases"] == ["new_ok"]
 
 
 def test_summarize_counts_checked_and_unchecked() -> None:


### PR DESCRIPTION
## Summary
- add shared fail-policy helpers and diff_runs to demo_qa.runner for a single source of truth on comparison
- have batch compare paths and CLI compare render markdown/JUnit from the shared diff including new fail-on/require-assert options
- stabilize report ordering, honor supported fail-on modes (error|bad|unchecked|any|skipped) across CLI/docs/tests, and tidy batch diff handling/tests

## Testing
- PYTHONPATH=. pytest tests/test_demo_qa_runner.py tests/test_demo_qa_batch.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946fb4a945c832fa4f04abd4a4a8f32)