### PR TITLE
Switch demo_qa schema output to JSON

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -8,7 +8,7 @@
 python -m examples.demo_qa.cli gen --out demo_data --rows 1000 --seed 42
 ```
 
-Команда создаст четыре CSV, `schema.yaml`, `meta.json` и `stats.json`.
+Команда создаст четыре CSV, `schema.json`, `meta.json` и `stats.json`.
 
 ## Конфигурация LLM (pydantic-settings)
 
@@ -47,7 +47,7 @@ pip install -r examples/demo_qa/requirements.txt
    `base_url` (формат `http://host:port/v1`), модели и температуры.
 2. Запустите чат с указанием конфига:
 ```bash
-python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.yaml --config path/to/demo_qa.toml
+python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.json --config path/to/demo_qa.toml
 ```
 
 Флаг `--enable-semantic` строит семантический индекс, если передана модель эмбеддингов.
@@ -59,7 +59,7 @@ python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.y
 ```bash
 python -m examples.demo_qa.cli batch \
   --data demo_data \
-  --schema demo_data/schema.yaml \
+  --schema demo_data/schema.json \
   --cases cases.jsonl \
   --out results.jsonl
 ```
@@ -76,7 +76,7 @@ python -m examples.demo_qa.cli batch \
 любым ключом доступа, если прокси не проверяет его. Запуск:
 
 ```bash
-python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.yaml --config path/to/demo_qa.toml
+python -m examples.demo_qa.cli chat --data demo_data --schema demo_data/schema.json --config path/to/demo_qa.toml
 ```
 
 Большинство OpenAI-совместимых сервисов ожидают конечную точку `/v1` в `base_url`.

--- a/examples/demo_qa/data_gen.py
+++ b/examples/demo_qa/data_gen.py
@@ -256,15 +256,9 @@ def save_dataset(dataset: GeneratedDataset, out_dir: Path) -> None:
 
 
 def save_schema(schema: SchemaConfig, path: Path) -> None:
-    def _to_dict(obj):
-        if isinstance(obj, list):
-            return [_to_dict(o) for o in obj]
-        if hasattr(obj, "__dict__"):
-            return {k: _to_dict(v) for k, v in obj.__dict__.items()}
-        return obj
-
+    schema_dict = asdict(schema)
     with path.open("w", encoding="utf-8") as f:
-        json.dump(_to_dict(schema), f, ensure_ascii=False, indent=2)
+        json.dump(schema_dict, f, ensure_ascii=False, indent=2)
 
 
 @dataclass
@@ -299,7 +293,7 @@ def generate_and_save(out_dir: Path, *, rows: int = 1000, seed: int | None = Non
     validate_dataset(dataset, rows)
     save_dataset(dataset, out_dir)
     schema = default_schema(enable_semantic=enable_semantic)
-    save_schema(schema, out_dir / "schema.yaml")
+    save_schema(schema, out_dir / "schema.json")
     meta = MetaInfo(seed=seed, rows=rows, created_at=datetime.utcnow().isoformat())
     write_meta(out_dir / "meta.json", meta)
 

--- a/tests/test_demo_qa_schema_io.py
+++ b/tests/test_demo_qa_schema_io.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from examples.demo_qa.data_gen import generate_and_save
+from examples.demo_qa.schema_io import load_schema
+
+
+def test_generate_and_load_schema_json(tmp_path: Path) -> None:
+    out_dir = tmp_path / "demo_data"
+    generate_and_save(out_dir, rows=5, seed=123)
+
+    schema_path = out_dir / "schema.json"
+    assert schema_path.exists()
+
+    schema = load_schema(schema_path)
+
+    assert schema.name == "demo_qa"
+    assert {e.name for e in schema.entities} >= {"customers", "products", "orders", "order_items"}
+    assert {r.name for r in schema.relations} >= {"orders_to_customers", "items_to_orders", "items_to_products"}


### PR DESCRIPTION
## Summary
- save the generated demo_qa schema as schema.json using JSON serialization
- update demo QA documentation and CLI examples to point to schema.json
- add a roundtrip test to ensure schema.json is created and loadable

## Testing
- pytest tests/test_demo_qa_schema_io.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694715f311f4832fb415c2af2e8ed155)