### PR TITLE
Refine demo QA JSON handling and lint hygiene

### DIFF
--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -16,7 +16,7 @@ def ensure_repo_imports() -> None:
 
 ensure_repo_imports()
 
-from .batch import (
+from .batch import (  # noqa: E402
     handle_batch,
     handle_case_open,
     handle_case_run,

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional
+from typing import Dict, Iterable, List, Mapping
 
 from fetchgraph.core import create_generic_agent
 from fetchgraph.core.models import TaskProfile

--- a/examples/demo_qa/settings.py
+++ b/examples/demo_qa/settings.py
@@ -122,7 +122,7 @@ def load_settings(
     DemoQASettings._toml_path = resolved
     try:
         settings = DemoQASettings(**(overrides or {}))
-    except ValidationError as exc:
+    except ValidationError:
         DemoQASettings._toml_path = None
         raise
     DemoQASettings._toml_path = None

--- a/examples/demo_qa/utils.py
+++ b/examples/demo_qa/utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def dump_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+
+
+__all__ = ["dump_json"]


### PR DESCRIPTION
## Summary
- introduce a shared JSON dump helper for demo_qa and reuse it for summary, summary-by-tag, and run_meta artifacts
- enforce deterministic ordering for markdown artifact links and JUnit failure details
- clean up import hygiene and unused variables flagged by ruff in demo_qa helpers

## Testing
- ruff check examples/demo_qa
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471ed6ee64832f8bd08429be415933)