### PR TITLE
Require py311 for demo QA and fix event paths

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -32,6 +32,7 @@ export DEMO_QA_LLM__BASE_URL=http://localhost:8000/v1
 ```
 
 ### Зависимости демо
+* Требуется Python 3.11+ (используется стандартный `tomllib`).
 ```
 pip install -e .[demo]
 # или

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -480,6 +480,18 @@ def handle_batch(args) -> int:
         summary_by_tag_path = summary_path.with_name("summary_by_tag.json")
         dump_json(summary_by_tag_path, summary_by_tag)
 
+    if event_logger:
+        event_logger.emit(
+            {
+                "type": "run_finished",
+                "counts": counts,
+                "exit_code": exit_code,
+                "duration_ms": duration_ms,
+                "run_dir": str(run_folder),
+                "results_path": str(results_path),
+            }
+        )
+
     latest_path = run_folder.parent / "latest.txt"
     latest_results_path = run_folder.parent / "latest_results.txt"
     latest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/demo_qa/requirements.txt
+++ b/examples/demo_qa/requirements.txt
@@ -1,3 +1,4 @@
+# Requires Python >=3.11 (relies on stdlib tomllib)
 pydantic-settings>=2.2
 python-dotenv>=1.0
 openai

--- a/src/pydantic_settings/__init__.py
+++ b/src/pydantic_settings/__init__.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import os
+import sys
+from typing import Any, Callable, ClassVar, Dict, Iterable, Mapping, TypeAlias
+
+if sys.version_info < (3, 11):  # pragma: no cover - demo dependency guard
+    raise ImportError("pydantic_settings requires Python 3.11+ (standard tomllib).")
+
 import tomllib
-from typing import Any, Callable, ClassVar, Dict, Iterable, Mapping
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
-def SettingsConfigDict(**kwargs: Any) -> Dict[str, Any]:
-    return dict(**kwargs)
+SettingsConfigDict: TypeAlias = ConfigDict
 
 
 def _deep_update(base: Dict[str, Any], updates: Mapping[str, Any]) -> Dict[str, Any]:
@@ -35,7 +39,7 @@ class TomlConfigSettingsSource:
 
 
 class BaseSettings(BaseModel):
-    model_config: ClassVar[SettingsConfigDict] = {}
+    model_config: ClassVar[SettingsConfigDict] = ConfigDict()
 
     def __init__(self, **values: Any) -> None:
         sources = self.settings_customise_sources(


### PR DESCRIPTION
## Summary
- require Python 3.11+ for demo_qa settings instead of vendoring tomli
- fix chat REPL to log events from the actual run directory and surface the correct path
- document the Python requirement for demo usage and clarify requirements files
- remove dead per-tag timing fields and count errors toward checked totals in summaries
- raise on duplicate result ids when reading results and emit run_finished batch events; tidy chat import order

## Testing
- pyright


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694720b59ef4832fb7d0a41a545b24d5)