### PR TITLE
Handle missing cases when comparing demo QA runs

### DIFF
--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -61,6 +61,28 @@ def test_diff_runs_tracks_regressions_and_improvements() -> None:
             duration_ms=10,
             tags=[],
         ),
+        RunResult(
+            id="missing_ok",
+            question="",
+            status="ok",
+            checked=True,
+            reason=None,
+            details=None,
+            artifacts_dir="/tmp/miss-ok",
+            duration_ms=10,
+            tags=[],
+        ),
+        RunResult(
+            id="missing_bad",
+            question="",
+            status="failed",
+            checked=True,
+            reason=None,
+            details=None,
+            artifacts_dir="/tmp/miss-bad",
+            duration_ms=10,
+            tags=[],
+        ),
     ]
 
     current = [
@@ -123,9 +145,10 @@ def test_diff_runs_tracks_regressions_and_improvements() -> None:
 
     diff = diff_runs(baseline, current, fail_on="bad", require_assert=True)
 
-    assert {row["id"] for row in diff["new_fail"]} == {"ok_to_bad", "new_bad"}
+    assert {row["id"] for row in diff["new_fail"]} == {"ok_to_bad", "new_bad", "missing_ok"}
     assert {row["id"] for row in diff["fixed"]} == {"err_to_ok"}
-    assert {row["id"] for row in diff["still_fail"]} == {"still_bad"}
+    assert {row["id"] for row in diff["still_fail"]} == {"still_bad", "missing_bad"}
+    assert {"missing_ok", "missing_bad"} <= {row["id"] for row in diff["changed_status"]}
     assert diff["new_cases"] == ["new_bad", "new_ok"]
 
 


### PR DESCRIPTION
## Summary
- include both baseline and new case IDs when diffing demo QA runs
- treat missing new results as regressions so skipped cases are surfaced in reports
- expand diff tests to cover baseline-only cases

## Testing
- pytest tests/test_demo_qa_runner.py
- pytest tests/test_demo_qa_runner.py tests/test_demo_qa_batch.py *(fails: missing demo QA dependencies such as pydantic-settings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a6ae7340832f96ca747bb6db73ab)