### PR TITLE
Ensure REPL errors store artifacts in per-run directories

### DIFF
--- a/examples/demo_qa/chat_repl.py
+++ b/examples/demo_qa/chat_repl.py
@@ -99,12 +99,13 @@ def start_repl(
             continue
 
         run_id = uuid.uuid4().hex[:8]
+        run_dir = runs_root / f"{run_id}_{uuid.uuid4().hex[:8]}"
         event_logger = EventLogger(path=None, run_id=run_id)
 
         artifacts: RunArtifacts | None = None
         try:
             case = Case(id=run_id, question=line, tags=[])
-            result = run_one(case, runner, runs_root, plan_only=False, event_logger=event_logger)
+            result = run_one(case, runner, runs_root, plan_only=False, event_logger=event_logger, run_dir=run_dir)
             plan_obj = _load_json(Path(result.artifacts_dir) / "plan.json")
             ctx_obj = _load_json(Path(result.artifacts_dir) / "context.json") or {}
             artifacts = RunArtifacts(
@@ -124,7 +125,7 @@ def start_repl(
             print(result.answer or "")
             print(f"Events: {Path(result.artifacts_dir) / 'events.jsonl'}")
         except Exception as exc:  # pragma: no cover - REPL resilience
-            error_artifacts = artifacts or RunArtifacts(run_id=run_id, run_dir=runs_root, question=line)
+            error_artifacts = artifacts or RunArtifacts(run_id=run_id, run_dir=run_dir, question=line)
             error_artifacts.error = error_artifacts.error or str(exc)
             last_artifacts = error_artifacts
             save_artifacts(error_artifacts)

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -273,9 +273,14 @@ def run_one(
     *,
     plan_only: bool = False,
     event_logger: EventLogger | None = None,
+    run_dir: Path | None = None,
 ) -> RunResult:
-    run_id = uuid.uuid4().hex[:8]
-    run_dir = artifacts_root / f"{case.id}_{run_id}"
+    if run_dir is None:
+        run_id = uuid.uuid4().hex[:8]
+        run_dir = artifacts_root / f"{case.id}_{run_id}"
+    else:
+        run_id = run_dir.name.split("_")[-1]
+
     case_logger = event_logger.for_case(case.id, run_dir / "events.jsonl") if event_logger else None
     if case_logger:
         case_logger.emit({"type": "case_started", "case_id": case.id, "run_dir": str(run_dir)})


### PR DESCRIPTION
## Summary
- allow `run_one` to accept an explicit run directory so callers can coordinate artifact locations
- create a per-run directory in the REPL before invoking the runner and reuse it for error artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ac41bde0832f8da60e88043b4751)