### PR TITLE
Handle partial batch runs and missed case selection

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -788,7 +788,11 @@ def handle_batch(args) -> int:
                     print(f"Failed to read baseline for --only-missed: {exc}", file=sys.stderr)
                     return 2
             else:
-                print("No baseline results found for --only-missed; running all filtered cases.", file=sys.stderr)
+                print(
+                    "No baseline found for --only-missed. Provide --only-missed-from or run a tagged batch first.",
+                    file=sys.stderr,
+                )
+                return 2
             baseline_meta = _load_run_meta(missed_baseline_run)
             if isinstance(baseline_meta, dict):
                 planned_from_meta = baseline_meta.get("planned_case_ids")

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -121,6 +121,11 @@ def _sanitize_tag(tag: str) -> str:
     return cleaned or "tag"
 
 
+def _effective_paths(artifacts_dir: Path, tag: str) -> tuple[Path, Path]:
+    base = artifacts_dir / "runs" / "tags" / _sanitize_tag(tag)
+    return base / "effective_results.jsonl", base / "effective_meta.json"
+
+
 def _latest_markers(artifacts_dir: Path, tag: str | None) -> tuple[Path, Path]:
     runs_dir = artifacts_dir / "runs"
     if tag:
@@ -205,6 +210,79 @@ def _update_latest_markers(run_folder: Path, results_path: Path, artifacts_dir: 
         latest_path.parent.mkdir(parents=True, exist_ok=True)
         latest_path.write_text(str(run_folder), encoding="utf-8")
         latest_results_path.write_text(str(results_path), encoding="utf-8")
+
+
+def _load_effective_results(artifacts_dir: Path, tag: str) -> tuple[dict[str, RunResult], Optional[dict], Path]:
+    results_path, meta_path = _effective_paths(artifacts_dir, tag)
+    meta: Optional[dict] = None
+    results: dict[str, RunResult] = {}
+    if results_path.exists():
+        results = load_results(results_path)
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            meta = None
+    return results, meta, results_path
+
+
+def _write_effective_results(results_path: Path, results: Mapping[str, RunResult]) -> None:
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    ordered = [results[cid] for cid in sorted(results)]
+    write_results(results_path, ordered)
+
+
+def _update_effective_snapshot(
+    *,
+    artifacts_dir: Path,
+    tag: str,
+    cases_hash: str,
+    cases_path: Path,
+    planned_case_ids: list[str],
+    executed_results: list[RunResult],
+    run_folder: Path,
+    planned_case_ids_source: list[str] | None,
+) -> tuple[Path, Path]:
+    effective_results, effective_meta, effective_results_path = _load_effective_results(artifacts_dir, tag)
+    if effective_meta and effective_meta.get("cases_hash") and effective_meta["cases_hash"] != cases_hash:
+        raise ValueError(
+            f"Existing effective results for tag {tag!r} use a different cases_hash; refusing to merge."
+        )
+
+    planned_pool: set[str]
+    if effective_meta and isinstance(effective_meta.get("planned_case_ids"), list):
+        planned_pool = {str(cid) for cid in effective_meta["planned_case_ids"]}
+    elif planned_case_ids_source:
+        planned_pool = set(planned_case_ids_source)
+    else:
+        planned_pool = set(planned_case_ids)
+
+    for res in executed_results:
+        effective_results[res.id] = res
+    _write_effective_results(effective_results_path, effective_results)
+
+    summary_counts = summarize(effective_results.values())
+    executed_total = len(effective_results)
+    missed_total = len(_missed_case_ids(planned_pool, effective_results))
+    meta_path = effective_results_path.with_name("effective_meta.json")
+    built_from = set(effective_meta.get("built_from_runs", [])) if effective_meta else set()
+    built_from.add(str(run_folder))
+    effective_meta_payload = {
+        "tag": tag,
+        "cases_hash": cases_hash,
+        "cases_path": str(cases_path),
+        "planned_case_ids": sorted(planned_pool),
+        "planned_total": len(planned_pool),
+        "executed_total": executed_total,
+        "missed_total": missed_total,
+        "counts": summary_counts,
+        "updated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "built_from_runs": sorted(built_from),
+        "effective_results_path": str(effective_results_path),
+    }
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    dump_json(meta_path, effective_meta_payload)
+    return effective_results_path, meta_path
 
 
 def _find_case_artifact(run_path: Path, case_id: str) -> Optional[Path]:
@@ -402,6 +480,7 @@ def handle_batch(args) -> int:
     run_id = uuid.uuid4().hex[:8]
     interrupted = False
     interrupted_at_case_id: str | None = None
+    cases_hash = _hash_file(args.cases)
 
     try:
         settings = load_settings(config_path=args.config, data_dir=args.data)
@@ -428,7 +507,25 @@ def handle_batch(args) -> int:
 
     baseline_filter_path = args.only_failed_from
     only_failed_baseline_kind: str | None = None
-    if args.only_failed and not baseline_filter_path:
+    effective_results_path: Path | None = None
+    if args.only_failed_from:
+        only_failed_baseline_kind = "path"
+    elif args.tag and args.only_failed:
+        effective_results, effective_meta, eff_path = _load_effective_results(artifacts_dir, args.tag)
+        if not effective_results:
+            print(f"No effective results found for tag {args.tag!r}; run a tagged batch first.", file=sys.stderr)
+            return 2
+        if effective_meta and effective_meta.get("cases_hash") not in (None, cases_hash):
+            print(
+                f"Effective results cases_hash {effective_meta.get('cases_hash')} does not match current cases file.",
+                file=sys.stderr,
+            )
+            return 2
+        baseline_for_filter = effective_results
+        baseline_filter_path = eff_path
+        effective_results_path = eff_path
+        only_failed_baseline_kind = "effective"
+    elif args.only_failed:
         latest_results = _load_latest_results(artifacts_dir, args.tag)
         if latest_results:
             baseline_filter_path = latest_results
@@ -440,14 +537,15 @@ def handle_batch(args) -> int:
                 if candidate.exists():
                     baseline_filter_path = candidate
                     only_failed_baseline_kind = "latest"
-    if args.only_failed_from:
-        only_failed_baseline_kind = "path"
-    if baseline_filter_path:
+    if baseline_filter_path and baseline_for_filter is None:
         try:
             baseline_for_filter = load_results(baseline_filter_path)
         except Exception as exc:
             print(f"Failed to read baseline for --only-failed-from: {exc}", file=sys.stderr)
             return 2
+    if args.only_failed and baseline_for_filter is None:
+        print("No baseline found for --only-failed.", file=sys.stderr)
+        return 2
 
     compare_path = args.compare_to
     if compare_path is None and args.only_failed and baseline_filter_path:
@@ -479,33 +577,70 @@ def handle_batch(args) -> int:
     missed_baseline_run: Path | None = None
     only_missed_baseline_kind: str | None = None
     if args.only_missed:
-        missed_baseline_path = args.only_missed_from or _load_latest_results(artifacts_dir, args.tag)
         if args.only_missed_from:
+            missed_baseline_path = args.only_missed_from
             only_missed_baseline_kind = "path"
-        elif missed_baseline_path:
-            only_missed_baseline_kind = "latest"
-        missed_baseline_run = _run_dir_from_results_path(missed_baseline_path)
-        if missed_baseline_run is None:
-            missed_baseline_run = _load_latest_run(artifacts_dir, args.tag)
-        if missed_baseline_path:
             try:
                 missed_baseline_results = load_results(missed_baseline_path)
             except Exception as exc:
-                print(f"Failed to read baseline for --only-missed: {exc}", file=sys.stderr)
+                print(f"Failed to read baseline for --only-missed-from: {exc}", file=sys.stderr)
                 return 2
-        else:
-            print("No baseline results found for --only-missed; running all filtered cases.", file=sys.stderr)
-        baseline_meta = _load_run_meta(missed_baseline_run)
-        if isinstance(baseline_meta, dict):
-            planned_from_meta = baseline_meta.get("planned_case_ids")
-            if isinstance(planned_from_meta, list):
-                baseline_planned_ids = {str(cid) for cid in planned_from_meta}
-            else:
+        elif args.tag:
+            effective_results, effective_meta, eff_path = _load_effective_results(artifacts_dir, args.tag)
+            if not effective_results:
+                print(f"No effective results found for tag {args.tag!r}; run a tagged batch first.", file=sys.stderr)
+                return 2
+            if effective_meta and effective_meta.get("cases_hash") not in (None, cases_hash):
                 print(
-                    "Baseline run meta missing planned_case_ids; computing missed relative to current filtered cases.",
+                    f"Effective results cases_hash {effective_meta.get('cases_hash')} does not match current cases file.",
+                    file=sys.stderr,
+                )
+                return 2
+            missed_baseline_path = eff_path
+            missed_baseline_results = effective_results
+            only_missed_baseline_kind = "effective"
+            baseline_planned_ids = (
+                {str(cid) for cid in effective_meta.get("planned_case_ids", [])}
+                if isinstance(effective_meta, dict)
+                else None
+            )
+            if not baseline_planned_ids:
+                print(
+                    "Effective results missing planned_case_ids; computing missed relative to current filtered cases.",
                     file=sys.stderr,
                 )
                 baseline_planned_ids = {case.id for case in cases}
+        else:
+            missed_baseline_path = args.only_missed_from or _load_latest_results(artifacts_dir, args.tag)
+            if args.only_missed_from:
+                only_missed_baseline_kind = "path"
+            elif missed_baseline_path:
+                only_missed_baseline_kind = "latest"
+            missed_baseline_run = _run_dir_from_results_path(missed_baseline_path)
+            if missed_baseline_run is None:
+                missed_baseline_run = _load_latest_run(artifacts_dir, args.tag)
+            if missed_baseline_path:
+                try:
+                    missed_baseline_results = load_results(missed_baseline_path)
+                except Exception as exc:
+                    print(f"Failed to read baseline for --only-missed: {exc}", file=sys.stderr)
+                    return 2
+            else:
+                print("No baseline results found for --only-missed; running all filtered cases.", file=sys.stderr)
+            baseline_meta = _load_run_meta(missed_baseline_run)
+            if isinstance(baseline_meta, dict):
+                planned_from_meta = baseline_meta.get("planned_case_ids")
+                if isinstance(planned_from_meta, list):
+                    baseline_planned_ids = {str(cid) for cid in planned_from_meta}
+                else:
+                    print(
+                        "Baseline run meta missing planned_case_ids; computing missed relative to current filtered cases.",
+                        file=sys.stderr,
+                    )
+                    baseline_planned_ids = {case.id for case in cases}
+        if args.only_missed and missed_baseline_results is None:
+            print("No baseline found for --only-missed.", file=sys.stderr)
+            return 2
 
     planned_case_ids = [case.id for case in cases]
     if args.only_missed:
@@ -661,10 +796,25 @@ def handle_batch(args) -> int:
         )
 
     _update_latest_markers(run_folder, results_path, artifacts_dir, args.tag)
+    effective_path = None
+    effective_meta_path = None
+    if args.tag:
+        try:
+            effective_path, effective_meta_path = _update_effective_snapshot(
+                artifacts_dir=artifacts_dir,
+                tag=args.tag,
+                cases_hash=cases_hash,
+                cases_path=args.cases,
+                planned_case_ids=planned_case_ids,
+                executed_results=results,
+                run_folder=run_folder,
+                planned_case_ids_source=planned_case_ids,
+            )
+        except Exception as exc:
+            print(f"Failed to update effective results for tag {args.tag!r}: {exc}", file=sys.stderr)
 
     config_hash = _hash_file(args.config) if args.config else None
     schema_hash = _hash_file(args.schema)
-    cases_hash = _hash_file(args.cases)
     data_fingerprint = _fingerprint_dir(args.data, verbose=args.fingerprint_verbose)
     llm_settings = settings.llm
     run_meta = {
@@ -695,6 +845,7 @@ def handle_batch(args) -> int:
             "only_missed_from": str(missed_baseline_path) if missed_baseline_path else None,
             "only_missed_baseline_kind": only_missed_baseline_kind,
             "baseline_tag": args.tag,
+            "effective_path": str(effective_path) if effective_path else None,
             "plan_only": args.plan_only,
             "fail_fast": args.fail_fast,
             "max_fails": args.max_fails,

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -694,12 +694,12 @@ def handle_batch(args) -> int:
             print("No baseline found for --only-missed.", file=sys.stderr)
             return 2
 
-    planned_case_ids = [case.id for case in cases]
+    selected_case_ids = [case.id for case in cases]
     if args.only_missed:
-        planned_pool = baseline_planned_ids or set(planned_case_ids)
+        planned_pool = baseline_planned_ids or set(selected_case_ids)
         missed_ids = _missed_case_ids(planned_pool, missed_baseline_results)
         cases = [case for case in cases if case.id in missed_ids]
-        planned_case_ids = [case.id for case in cases]
+        selected_case_ids = [case.id for case in cases]
         if not cases:
             print("0 missed cases selected.", file=sys.stderr)
 
@@ -800,9 +800,11 @@ def handle_batch(args) -> int:
     ended_at = datetime.datetime.utcnow()
     duration_ms = int((ended_at - started_at).total_seconds() * 1000)
     executed_results = {res.id: res for res in results}
-    planned_total = len(planned_case_ids)
+    planned_total = len(selected_case_ids)
     executed_total = len(results)
-    missed_total = len(_missed_case_ids(planned_case_ids, executed_results))
+    missed_total = len(_missed_case_ids(selected_case_ids, executed_results))
+    suite_planned_total = len(suite_case_ids)
+    suite_missed_total = len(_missed_case_ids(suite_case_ids, executed_results))
     summary = {
         "run_id": run_id,
         "started_at": started_at.isoformat() + "Z",
@@ -817,6 +819,8 @@ def handle_batch(args) -> int:
         "planned_total": planned_total,
         "executed_total": executed_total,
         "missed_total": missed_total,
+        "suite_planned_total": suite_planned_total,
+        "suite_missed_total": suite_missed_total,
         "interrupted": interrupted,
         "interrupted_at_case_id": interrupted_at_case_id,
         "tag": args.tag,
@@ -885,7 +889,7 @@ def handle_batch(args) -> int:
             "data_dir": str(args.data),
         },
         "suite_case_ids": suite_case_ids,
-        "planned_case_ids": planned_case_ids,
+        "selected_case_ids": selected_case_ids,
         "planned_total": planned_total,
         "selected_filters": {
             "include_tags": sorted(include_tags) if include_tags else None,

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -146,6 +146,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     compare_p.add_argument("--require-assert", action="store_true", help="Treat unchecked cases as failures when diffing")
 
+    history_p = sub.add_parser("history", help="History utilities")
+    history_sub = history_p.add_subparsers(dest="history_command", required=True)
+    case_hist = history_sub.add_parser("case", help="Show history for a case id")
+    case_hist.add_argument("case_id")
+    case_hist.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    case_hist.add_argument("--tag", type=str, default=None, help="Filter by tag")
+    case_hist.add_argument("--limit", type=int, default=20, help="Limit rows")
+
+    report_p = sub.add_parser("report", help="Reports over runs/effective snapshots")
+    report_sub = report_p.add_subparsers(dest="report_command", required=True)
+    tag_report = report_sub.add_parser("tag", help="Report current effective snapshot for a tag")
+    tag_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    tag_report.add_argument("--tag", type=str, required=True, help="Tag to report")
+    run_report = report_sub.add_parser("run", help="Report a specific run folder or run_id")
+    run_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    run_report.add_argument("--run", type=Path, required=True, help="Run dir or run_id under runs/")
+
     return parser
 
 
@@ -173,6 +190,22 @@ def main() -> None:
         code = handle_stats(args)
     elif args.command == "compare":
         code = handle_compare(args)
+    elif args.command == "history":
+        from .batch import handle_history_case
+
+        if args.history_command == "case":
+            code = handle_history_case(args)
+        else:
+            code = 1
+    elif args.command == "report":
+        from .batch import handle_report_run, handle_report_tag
+
+        if args.report_command == "tag":
+            code = handle_report_tag(args)
+        elif args.report_command == "run":
+            code = handle_report_run(args)
+        else:
+            code = 1
     else:
         code = 0
     raise SystemExit(code)

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -57,7 +57,7 @@ def build_parser() -> argparse.ArgumentParser:
     batch_p.add_argument(
         "--only-missed",
         action="store_true",
-        help="Run only cases missing in the latest (or tag-latest) effective results",
+        help="Run only cases missing in effective results for --tag (or latest results when no tag is set)",
     )
     batch_p.add_argument(
         "--only-missed-from",

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -59,6 +59,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run only cases missing in the latest (or tag-latest) effective results",
     )
+    batch_p.add_argument(
+        "--only-missed-from",
+        type=Path,
+        default=None,
+        help="Run only cases missing in the provided results.jsonl (or latest if omitted)",
+    )
     batch_p.add_argument("--out", type=Path, required=False, default=None, help="Path to results jsonl")
     batch_p.add_argument("--artifacts-dir", type=Path, default=None, help="Where to store per-case artifacts")
     batch_p.add_argument("--enable-semantic", action="store_true")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -52,6 +52,13 @@ def build_parser() -> argparse.ArgumentParser:
     batch_p.add_argument("--schema", type=Path, required=True)
     batch_p.add_argument("--config", type=Path, default=None, help="Path to demo_qa.toml")
     batch_p.add_argument("--cases", type=Path, required=True, help="Path to cases jsonl")
+    batch_p.add_argument("--tag", type=str, default=None, help="Label this run and use tag-specific latest pointers")
+    batch_p.add_argument("--note", type=str, default=None, help="Free-form note to attach to the run metadata")
+    batch_p.add_argument(
+        "--only-missed",
+        action="store_true",
+        help="Run only cases missing in the latest (or tag-latest) effective results",
+    )
     batch_p.add_argument("--out", type=Path, required=False, default=None, help="Path to results jsonl")
     batch_p.add_argument("--artifacts-dir", type=Path, default=None, help="Where to store per-case artifacts")
     batch_p.add_argument("--enable-semantic", action="store_true")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -24,6 +24,8 @@ from .batch import (  # noqa: E402
     handle_compare,
     handle_stats,
 )  # noqa: E402
+from .commands.history import handle_history_case  # noqa: E402
+from .commands.report import handle_report_run, handle_report_tag  # noqa: E402
 from .data_gen import generate_and_save  # noqa: E402
 
 
@@ -191,15 +193,11 @@ def main() -> None:
     elif args.command == "compare":
         code = handle_compare(args)
     elif args.command == "history":
-        from .batch import handle_history_case
-
         if args.history_command == "case":
             code = handle_history_case(args)
         else:
             code = 1
     elif args.command == "report":
-        from .batch import handle_report_run, handle_report_tag
-
         if args.report_command == "tag":
             code = handle_report_tag(args)
         elif args.report_command == "run":

--- a/examples/demo_qa/commands/__init__.py
+++ b/examples/demo_qa/commands/__init__.py
@@ -1,0 +1,6 @@
+"""Lightweight command entrypoints for demo QA CLI."""
+
+from .history import handle_history_case
+from .report import handle_report_run, handle_report_tag
+
+__all__ = ["handle_history_case", "handle_report_run", "handle_report_tag"]

--- a/examples/demo_qa/commands/history.py
+++ b/examples/demo_qa/commands/history.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..runs.case_history import _load_case_history
+
+
+def handle_history_case(args) -> int:
+    artifacts_dir = args.data / ".runs"
+    path = artifacts_dir / "runs" / "cases" / f"{args.case_id}.jsonl"
+    entries = _load_case_history(path)
+    if args.tag:
+        entries = [e for e in entries if e.get("tag") == args.tag]
+    if not entries:
+        print(f"No history found for case {args.case_id}.")
+        return 0
+    entries = list(reversed(entries))[: args.limit]
+    header = (
+        f"{'timestamp':<25} {'run_id':<12} {'tag':<15} {'status':<10} "
+        f"{'reason':<30} {'note':<15} {'run_dir':<30}"
+    )
+    print(header)
+    for e in entries:
+        ts = str(e.get("timestamp", ""))[:25]
+        print(
+            f"{ts:<25} {str(e.get('run_id','')):<12} {str(e.get('tag','')):<15} "
+            f"{str(e.get('status','')):<10} {str(e.get('reason','')):<30} {str(e.get('note','')):<15} "
+            f"{str(e.get('run_dir','')):<30}"
+        )
+    return 0
+
+
+__all__ = ["handle_history_case"]

--- a/examples/demo_qa/commands/report.py
+++ b/examples/demo_qa/commands/report.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ..runner import bad_statuses, load_results, summarize
+from ..runs.effective import _load_effective_diff
+from ..runs.layout import _effective_paths
+
+
+def _resolve_run_dir_arg(run_arg: Path, artifacts_dir: Path) -> Optional[Path]:
+    if run_arg.exists():
+        return run_arg
+    candidate = artifacts_dir / "runs" / run_arg
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def handle_report_run(args) -> int:
+    artifacts_dir = args.data / ".runs"
+    run_dir = _resolve_run_dir_arg(args.run, artifacts_dir)
+    if not run_dir:
+        print("Run directory not found.", file=sys.stderr)
+        return 2
+    summary_path = run_dir / "summary.json"
+    if not summary_path.exists():
+        print(f"summary.json not found in {run_dir}", file=sys.stderr)
+        return 2
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Failed to read summary: {exc}", file=sys.stderr)
+        return 2
+    print(f"Run: {run_dir}")
+    for key in ["run_id", "tag", "note", "exit_code", "interrupted", "interrupted_at_case_id", "results_path"]:
+        if key in summary:
+            print(f"{key}: {summary.get(key)}")
+    counts = summary.get("counts") or {}
+    if counts:
+        print("Counts:", counts)
+    return 0
+
+
+def _reason_text(res) -> str:
+    if getattr(res, "reason", None):
+        return res.reason
+    if getattr(res, "error", None):
+        return res.error
+    expected = getattr(res, "expected_check", None)
+    if expected and getattr(expected, "detail", None):
+        return expected.detail
+    return ""
+
+
+def handle_report_tag(args) -> int:
+    artifacts_dir = args.data / ".runs"
+    eff_results_path, eff_meta_path = _effective_paths(artifacts_dir, args.tag)
+    if not eff_results_path.exists() or not eff_meta_path.exists():
+        print(f"No effective snapshot found for tag {args.tag!r}.", file=sys.stderr)
+        return 2
+    try:
+        meta = json.loads(eff_meta_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Failed to read effective_meta.json: {exc}", file=sys.stderr)
+        return 2
+    try:
+        results = load_results(eff_results_path)
+    except Exception as exc:
+        print(f"Failed to read effective results: {exc}", file=sys.stderr)
+        return 2
+    counts = meta.get("counts") or summarize(results.values())
+    fail_on = meta.get("fail_on", "bad")
+    require_assert = bool(meta.get("require_assert", False))
+    print(f"Tag: {args.tag}")
+    print(f"Planned: {meta.get('planned_total')} | Executed: {meta.get('executed_total')} | Missed: {meta.get('missed_total')}")
+    print("Counts:", counts)
+    bad = bad_statuses(str(fail_on), require_assert)
+    failing = [res for res in results.values() if res.status in bad]
+    failing = sorted(failing, key=lambda r: r.id)[:10]
+    if failing:
+        print("Failing cases (top 10):")
+        for res in failing:
+            print(f"- {res.id}: {res.status} ({_reason_text(res)}) [{res.artifacts_dir}]")
+    diff_entry = _load_effective_diff(eff_results_path.parent)
+    if diff_entry:
+        print("Last effective change:")
+        for key in ["timestamp", "run_id", "note"]:
+            if key in diff_entry:
+                print(f"  {key}: {diff_entry.get(key)}")
+        for label in ["regressed", "fixed", "changed_bad", "new_cases"]:
+            items = diff_entry.get(label) or []
+            print(f"  {label}: {len(items)}")
+    return 0
+
+
+__all__ = ["handle_report_run", "handle_report_tag", "_resolve_run_dir_arg"]

--- a/examples/demo_qa/runs/__init__.py
+++ b/examples/demo_qa/runs/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for managing demo QA run artifacts."""
+
+__all__ = []

--- a/examples/demo_qa/runs/case_history.py
+++ b/examples/demo_qa/runs/case_history.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+from ..runner import RunResult
+
+
+def _reason_text(res: RunResult) -> str:
+    if res.reason:
+        return res.reason
+    if res.error:
+        return res.error
+    expected = getattr(res, "expected_check", None)
+    if expected and getattr(expected, "detail", None):
+        return expected.detail
+    return ""
+
+
+def _append_case_history(
+    artifacts_dir: Path,
+    result: RunResult,
+    *,
+    run_id: str,
+    tag: str | None,
+    note: str | None,
+    fail_on: str,
+    require_assert: bool,
+    scope_hash: str,
+    cases_hash: str,
+    git_sha: str | None,
+    run_dir: Path,
+    results_path: Path,
+) -> None:
+    history_dir = artifacts_dir / "runs" / "cases"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        "run_id": run_id,
+        "tag": tag,
+        "note": note,
+        "status": result.status,
+        "reason": _reason_text(result),
+        "duration_ms": result.duration_ms,
+        "artifacts_dir": result.artifacts_dir,
+        "run_dir": str(run_dir),
+        "results_path": str(results_path),
+        "fail_on": fail_on,
+        "require_assert": require_assert,
+        "scope_hash": scope_hash,
+        "cases_hash": cases_hash,
+        "git_sha": git_sha,
+    }
+    target = history_dir / f"{result.id}.jsonl"
+    with target.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _load_case_history(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    entries: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except Exception:
+                continue
+    return entries
+
+
+__all__ = ["_append_case_history", "_load_case_history"]

--- a/examples/demo_qa/runs/coverage.py
+++ b/examples/demo_qa/runs/coverage.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional
+
+from ..runner import RunResult
+
+
+def _missed_case_ids(planned_case_ids: Iterable[str], executed_results: Mapping[str, RunResult] | None) -> set[str]:
+    planned_set = set(planned_case_ids)
+    if not executed_results:
+        return planned_set
+    try:
+        executed_ids = set(executed_results.keys())
+    except Exception:
+        executed_ids = set()
+    return planned_set - executed_ids
+
+
+__all__ = ["_missed_case_ids"]

--- a/examples/demo_qa/runs/effective.py
+++ b/examples/demo_qa/runs/effective.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Mapping, Optional
+
+from ..runner import RunResult, bad_statuses, load_results, summarize
+from ..utils import dump_json
+from .coverage import _missed_case_ids
+from .layout import _effective_paths
+from .io import write_results
+
+
+def _load_effective_results(artifacts_dir: Path, tag: str) -> tuple[dict[str, RunResult], Optional[dict], Path]:
+    results_path, meta_path = _effective_paths(artifacts_dir, tag)
+    meta: Optional[dict] = None
+    results: dict[str, RunResult] = {}
+    if results_path.exists():
+        results = load_results(results_path)
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            meta = None
+    return results, meta, results_path
+
+
+def _write_effective_results(results_path: Path, results: Mapping[str, RunResult]) -> None:
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    ordered = [results[cid] for cid in sorted(results)]
+    write_results(results_path, ordered)
+
+
+def _reason_text(res: RunResult) -> str:
+    if res.reason:
+        return res.reason
+    if res.error:
+        return res.error
+    expected = getattr(res, "expected_check", None)
+    if expected and getattr(expected, "detail", None):
+        return expected.detail
+    return ""
+
+
+def _build_effective_diff(
+    before: Mapping[str, RunResult],
+    after: Mapping[str, RunResult],
+    *,
+    fail_on: str,
+    require_assert: bool,
+    run_id: str,
+    tag: str,
+    note: str | None,
+    run_dir: Path,
+    results_path: Path,
+    scope_hash: str,
+) -> dict[str, object]:
+    bad = bad_statuses(fail_on, require_assert)
+    before_bad = {cid for cid, res in before.items() if res.status in bad}
+    after_bad = {cid for cid, res in after.items() if res.status in bad}
+    ids = set(before) | set(after)
+    regressed: list[dict[str, object]] = []
+    fixed: list[dict[str, object]] = []
+    changed_bad: list[dict[str, object]] = []
+    new_cases: list[dict[str, object]] = []
+    other_changed: list[dict[str, object]] = []
+    for cid in ids:
+        prev = before.get(cid)
+        cur = after.get(cid)
+        prev_status = prev.status if prev else None
+        cur_status = cur.status if cur else None
+        if prev is None and cur is not None:
+            new_cases.append({"id": cid, "to": cur_status})
+            continue
+        if cur is None or prev is None:
+            continue
+        if prev_status == cur_status:
+            continue
+        entry = {"id": cid, "from": prev_status, "to": cur_status, "reason": _reason_text(cur)}
+        was_bad = cid in before_bad
+        now_bad = cid in after_bad
+        if not was_bad and now_bad:
+            regressed.append(entry)
+        elif was_bad and not now_bad:
+            fixed.append(entry)
+        elif was_bad and now_bad:
+            changed_bad.append(entry)
+        else:
+            other_changed.append(entry)
+    return {
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        "tag": tag,
+        "note": note,
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "results_path": str(results_path),
+        "fail_on": fail_on,
+        "require_assert": require_assert,
+        "scope_hash": scope_hash,
+        "regressed": sorted(regressed, key=lambda r: r["id"]),
+        "fixed": sorted(fixed, key=lambda r: r["id"]),
+        "changed_bad": sorted(changed_bad, key=lambda r: r["id"]),
+        "changed_other": sorted(other_changed, key=lambda r: r["id"]),
+        "new_cases": sorted(new_cases, key=lambda r: r["id"]),
+    }
+
+
+def _append_effective_diff(tag_dir: Path, diff_entry: Mapping[str, object]) -> None:
+    tag_dir.mkdir(parents=True, exist_ok=True)
+    changes_path = tag_dir / "effective_changes.jsonl"
+    with changes_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(diff_entry, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _load_effective_diff(tag_dir: Path) -> Optional[dict]:
+    path = tag_dir / "effective_changes.jsonl"
+    if not path.exists():
+        return None
+    last: Optional[dict] = None
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                last = json.loads(line)
+            except Exception:
+                continue
+    return last
+
+
+def _update_effective_snapshot(
+    *,
+    artifacts_dir: Path,
+    tag: str,
+    cases_hash: str,
+    cases_path: Path,
+    suite_case_ids: list[str],
+    executed_results: list[RunResult],
+    run_folder: Path,
+    scope: Mapping[str, object],
+    scope_hash: str,
+    fail_on: str,
+    require_assert: bool,
+) -> tuple[Path, Path, dict[str, RunResult], dict[str, RunResult]]:
+    effective_results, effective_meta, effective_results_path = _load_effective_results(artifacts_dir, tag)
+    if effective_meta and effective_meta.get("cases_hash") and effective_meta["cases_hash"] != cases_hash:
+        raise ValueError(
+            f"Existing effective results for tag {tag!r} use a different cases_hash; refusing to merge."
+        )
+    if effective_meta and effective_meta.get("scope_hash") and effective_meta["scope_hash"] != scope_hash:
+        raise ValueError(
+            f"Existing effective results for tag {tag!r} have a different scope; refusing to merge."
+        )
+
+    planned_pool: set[str]
+    if effective_meta and isinstance(effective_meta.get("planned_case_ids"), list):
+        planned_pool = {str(cid) for cid in effective_meta["planned_case_ids"]}
+    else:
+        planned_pool = set(suite_case_ids)
+
+    before_effective = dict(effective_results)
+    for res in executed_results:
+        effective_results[res.id] = res
+    _write_effective_results(effective_results_path, effective_results)
+
+    summary_counts = summarize(effective_results.values())
+    executed_total = len(effective_results)
+    missed_total = len(_missed_case_ids(planned_pool, effective_results))
+    meta_path = effective_results_path.with_name("effective_meta.json")
+    built_from = set(effective_meta.get("built_from_runs", [])) if effective_meta else set()
+    built_from.add(str(run_folder))
+    effective_meta_payload = {
+        "tag": tag,
+        "cases_hash": cases_hash,
+        "cases_path": str(cases_path),
+        "planned_case_ids": sorted(planned_pool),
+        "planned_total": len(planned_pool),
+        "executed_total": executed_total,
+        "missed_total": missed_total,
+        "counts": summary_counts,
+        "updated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "built_from_runs": sorted(built_from),
+        "effective_results_path": str(effective_results_path),
+        "scope": scope,
+        "scope_hash": scope_hash,
+        "fail_on": fail_on,
+        "require_assert": require_assert,
+    }
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    dump_json(meta_path, effective_meta_payload)
+    return effective_results_path, meta_path, before_effective, effective_results
+
+
+__all__ = [
+    "_append_effective_diff",
+    "_build_effective_diff",
+    "_load_effective_results",
+    "_load_effective_diff",
+    "_update_effective_snapshot",
+    "_write_effective_results",
+]

--- a/examples/demo_qa/runs/io.py
+++ b/examples/demo_qa/runs/io.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from ..runner import RunResult
+
+
+def write_results(out_path: Path, results: Iterable[RunResult]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        for res in results:
+            f.write(json.dumps(res.to_json(), ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+__all__ = ["write_results"]

--- a/examples/demo_qa/runs/layout.py
+++ b/examples/demo_qa/runs/layout.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+
+def _sanitize_tag(tag: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in tag)
+    return cleaned or "tag"
+
+
+def _effective_paths(artifacts_dir: Path, tag: str) -> tuple[Path, Path]:
+    base = artifacts_dir / "runs" / "tags" / _sanitize_tag(tag)
+    return base / "effective_results.jsonl", base / "effective_meta.json"
+
+
+def _latest_markers(artifacts_dir: Path, tag: str | None) -> tuple[Path, Path]:
+    runs_dir = artifacts_dir / "runs"
+    if tag:
+        slug = _sanitize_tag(tag)
+        return runs_dir / f"tag-latest-{slug}.txt", runs_dir / f"tag-latest-results-{slug}.txt"
+    return runs_dir / "latest.txt", runs_dir / "latest_results.txt"
+
+
+def _load_latest_run(artifacts_dir: Path, tag: str | None = None) -> Optional[Path]:
+    latest_file, _ = _latest_markers(artifacts_dir, tag)
+    if latest_file.exists():
+        content = latest_file.read_text(encoding="utf-8").strip()
+        if content:
+            return Path(content)
+    return None
+
+
+def _load_latest_results(artifacts_dir: Path, tag: str | None = None) -> Optional[Path]:
+    _, latest_file = _latest_markers(artifacts_dir, tag)
+    if latest_file.exists():
+        content = latest_file.read_text(encoding="utf-8").strip()
+        if content:
+            return Path(content)
+    latest_run = _load_latest_run(artifacts_dir, tag)
+    if latest_run:
+        summary_path = latest_run / "summary.json"
+        if summary_path.exists():
+            try:
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+                results_path = summary.get("results_path")
+                if results_path:
+                    return Path(results_path)
+            except Exception:
+                pass
+    return None
+
+
+def _load_run_meta(run_path: Path | None) -> Optional[dict]:
+    if run_path is None:
+        return None
+    meta_path = run_path / "run_meta.json"
+    if not meta_path.exists():
+        return None
+    try:
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _run_dir_from_results_path(results_path: Path | None) -> Optional[Path]:
+    if results_path is None:
+        return None
+    run_dir = results_path.parent
+    summary_path = run_dir / "summary.json"
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            run_dir_from_summary = summary.get("run_dir")
+            if run_dir_from_summary:
+                return Path(run_dir_from_summary)
+        except Exception:
+            pass
+    return run_dir
+
+
+def _update_latest_markers(run_folder: Path, results_path: Path, artifacts_dir: Path, tag: str | None) -> None:
+    marker_pairs = {_latest_markers(artifacts_dir, None)}
+    if tag:
+        marker_pairs.add(_latest_markers(artifacts_dir, tag))
+    for latest_path, latest_results_path in marker_pairs:
+        latest_path.parent.mkdir(parents=True, exist_ok=True)
+        latest_path.write_text(str(run_folder), encoding="utf-8")
+        latest_results_path.write_text(str(results_path), encoding="utf-8")
+
+
+__all__ = [
+    "_effective_paths",
+    "_latest_markers",
+    "_load_latest_results",
+    "_load_latest_run",
+    "_load_run_meta",
+    "_run_dir_from_results_path",
+    "_sanitize_tag",
+    "_update_latest_markers",
+]

--- a/examples/demo_qa/runs/scope.py
+++ b/examples/demo_qa/runs/scope.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Mapping, Optional, Set
+
+
+def _scope_payload(
+    *,
+    cases_hash: str,
+    include_tags: Set[str] | None,
+    exclude_tags: Set[str] | None,
+    include_ids: Set[str] | None,
+    exclude_ids: Set[str] | None,
+) -> dict[str, object]:
+    return {
+        "cases_hash": cases_hash,
+        "include_tags": sorted(include_tags) if include_tags else None,
+        "exclude_tags": sorted(exclude_tags) if exclude_tags else None,
+        "include_ids": sorted(include_ids) if include_ids else None,
+        "exclude_ids": sorted(exclude_ids) if exclude_ids else None,
+    }
+
+
+def _scope_hash(scope: Mapping[str, object]) -> str:
+    payload = json.dumps(scope, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+__all__ = ["_scope_hash", "_scope_payload"]

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -3,35 +3,10 @@ from __future__ import annotations
 import itertools
 import json
 import os
-import sys
 import time
-import types
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel
-
-if "pydantic_settings" not in sys.modules:
-    stub = types.ModuleType("pydantic_settings")
-
-    class BaseSettings(BaseModel):
-        model_config = {}
-
-    def SettingsConfigDict(**kwargs):
-        return kwargs
-
-    stub.BaseSettings = BaseSettings
-    stub.SettingsConfigDict = SettingsConfigDict
-
-    sources_mod = types.ModuleType("pydantic_settings.sources")
-
-    def TomlConfigSettingsSource(settings_cls, toml_file):
-        return {}
-
-    sources_mod.TomlConfigSettingsSource = TomlConfigSettingsSource
-    stub.sources = sources_mod
-    sys.modules["pydantic_settings"] = stub
-    sys.modules["pydantic_settings.sources"] = sources_mod
 
 from examples.demo_qa.batch import (
     _fingerprint_dir,

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -3,12 +3,46 @@ from __future__ import annotations
 import itertools
 import json
 import os
+import sys
 import time
+import types
 from pathlib import Path
 
 import pytest
+from pydantic import BaseModel
 
-from examples.demo_qa.batch import _fingerprint_dir, bad_statuses, is_failure, render_markdown, write_results
+if "pydantic_settings" not in sys.modules:
+    stub = types.ModuleType("pydantic_settings")
+
+    class BaseSettings(BaseModel):
+        model_config = {}
+
+    def SettingsConfigDict(**kwargs):
+        return kwargs
+
+    stub.BaseSettings = BaseSettings
+    stub.SettingsConfigDict = SettingsConfigDict
+
+    sources_mod = types.ModuleType("pydantic_settings.sources")
+
+    def TomlConfigSettingsSource(settings_cls, toml_file):
+        return {}
+
+    sources_mod.TomlConfigSettingsSource = TomlConfigSettingsSource
+    stub.sources = sources_mod
+    sys.modules["pydantic_settings"] = stub
+    sys.modules["pydantic_settings.sources"] = sources_mod
+
+from examples.demo_qa.batch import (
+    _fingerprint_dir,
+    _latest_markers,
+    _missed_case_ids,
+    _update_latest_markers,
+    bad_statuses,
+    is_failure,
+    render_markdown,
+    write_results,
+)
 from examples.demo_qa.runner import RunResult, diff_runs
 
 
@@ -92,3 +126,27 @@ def test_write_results_is_deterministic(tmp_path: Path) -> None:
     line = out.read_text(encoding="utf-8").strip()
     expected = json.dumps(res.to_json(), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     assert line == expected
+
+
+def test_missed_case_ids_diff_planned_and_executed() -> None:
+    planned = ["a", "b", "c", "a"]
+    executed = {_mk_result("b", "ok").id: _mk_result("b", "ok")}
+    assert _missed_case_ids(planned, executed) == {"a", "c"}
+
+
+def test_update_latest_markers_handles_tag(tmp_path: Path) -> None:
+    artifacts_dir = tmp_path / "data" / ".runs"
+    run_dir = artifacts_dir / "runs" / "20240101_cases"
+    results_path = run_dir / "results.jsonl"
+    run_dir.mkdir(parents=True)
+    results_path.write_text("{}", encoding="utf-8")
+
+    _update_latest_markers(run_dir, results_path, artifacts_dir, "feature/beta")
+
+    latest_default, latest_results_default = _latest_markers(artifacts_dir, None)
+    assert latest_default.read_text(encoding="utf-8").strip() == str(run_dir)
+    assert latest_results_default.read_text(encoding="utf-8").strip() == str(results_path)
+
+    latest_tag, latest_results_tag = _latest_markers(artifacts_dir, "feature/beta")
+    assert latest_tag.read_text(encoding="utf-8").strip() == str(run_dir)
+    assert latest_results_tag.read_text(encoding="utf-8").strip() == str(results_path)

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -8,16 +8,9 @@ from pathlib import Path
 
 import pytest
 
-from examples.demo_qa.batch import (
-    _fingerprint_dir,
-    _latest_markers,
-    _missed_case_ids,
-    _update_latest_markers,
-    bad_statuses,
-    is_failure,
-    render_markdown,
-    write_results,
-)
+from examples.demo_qa.batch import _fingerprint_dir, bad_statuses, is_failure, render_markdown, write_results
+from examples.demo_qa.runs.coverage import _missed_case_ids
+from examples.demo_qa.runs.layout import _latest_markers, _update_latest_markers
 from examples.demo_qa.runner import RunResult, diff_runs
 
 

--- a/tests/test_demo_qa_commands.py
+++ b/tests/test_demo_qa_commands.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_commands_report_import_is_lightweight() -> None:
+    script = """
+import sys
+
+import examples.demo_qa.commands.report  # noqa: F401
+
+heavy = [name for name in sys.modules if name.startswith("examples.demo_qa.llm") or name.startswith("examples.demo_qa.provider")]
+if heavy:
+    raise SystemExit(f"Heads up: heavy deps imported: {heavy}")
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary
- add batch CLI options for tagging, notes, and rerunning only missed cases with tag-specific latest markers
- persist batch metadata on partial runs, capturing planned/executed/missed totals, tag/note, and interruption details in summaries, history, and run_meta
- add helpers and tests for missed-case calculation and latest marker updates, including test stubs for optional demo dependencies

## Testing
- pytest tests/test_demo_qa_batch.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69485063c5cc832f90212f13806ac97b)