### PR TITLE
Respect artifacts dir in history case lookup

### DIFF
--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -153,6 +153,7 @@ def build_parser() -> argparse.ArgumentParser:
     case_hist = history_sub.add_parser("case", help="Show history for a case id")
     case_hist.add_argument("case_id")
     case_hist.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    case_hist.add_argument("--artifacts-dir", type=Path, default=None, help="Base artifacts dir (default: <data>/.runs)")
     case_hist.add_argument("--tag", type=str, default=None, help="Filter by tag")
     case_hist.add_argument("--limit", type=int, default=20, help="Limit rows")
 

--- a/examples/demo_qa/commands/history.py
+++ b/examples/demo_qa/commands/history.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..runs.case_history import _load_case_history
 
 
 def handle_history_case(args) -> int:
-    artifacts_dir = args.data / ".runs"
+    artifacts_dir = Path(args.artifacts_dir) if args.artifacts_dir else args.data / ".runs"
     path = artifacts_dir / "runs" / "cases" / f"{args.case_id}.jsonl"
     entries = _load_case_history(path)
     if args.tag:


### PR DESCRIPTION
## Summary
- add --artifacts-dir option to the history case command
- have case history lookups honor the configured artifacts directory instead of assuming <data>/.runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f03402f38832fa0bb699c2d20c045)