### PR TITLE
Default batch history to artifacts directory

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -566,7 +566,7 @@ def handle_batch(args) -> int:
     results_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path = results_path.with_name("summary.json")
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    history_path = Path(args.history) if args.history else (data_dir / ".runs" / "history.jsonl")
+    history_path = Path(args.history) if args.history else (artifacts_dir / "history.jsonl")
 
     log_dir = Path(args.log_dir) if args.log_dir else data_dir / ".runs" / "logs"
     configure_logging(

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -95,7 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")
     batch_p.add_argument("--show-artifacts", action="store_true", help="Show artifact paths for failures")
-    batch_p.add_argument("--history", type=Path, default=None, help="Path to history.jsonl (default: <data>/.runs/history.jsonl)")
+    batch_p.add_argument("--history", type=Path, default=None, help="Path to history.jsonl (default: <artifacts-dir>/history.jsonl)")
     batch_p.add_argument("--include-tags", type=str, default=None, help="Comma-separated tags to include")
     batch_p.add_argument("--exclude-tags", type=str, default=None, help="Comma-separated tags to exclude")
     batch_p.add_argument("--include-ids", type=Path, default=None, help="Path to file with ids to include (one per line)")


### PR DESCRIPTION
## Summary
- default batch history file to the configured artifacts directory when none is provided explicitly
- clarify the batch --history help text to reflect the new default

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587c6110c0832f847cff968e1bc49e)