### PR TITLE
Add overlay-aware baseline handling for selection workflows

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -14,8 +14,8 @@ from .logging_config import configure_logging
 from .provider_factory import build_provider
 from .runner import (
     Case,
-    DiffReport,
     DiffCaseChange,
+    DiffReport,
     EventLogger,
     RunResult,
     RunTimings,
@@ -40,8 +40,8 @@ from .runs.effective import (
 )
 from .runs.io import write_results
 from .runs.layout import (
-    _load_latest_results,
     _load_latest_any_results,
+    _load_latest_results,
     _load_latest_run,
     _load_run_meta,
     _run_dir_from_results_path,

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -560,7 +560,6 @@ def handle_batch(args) -> int:
         exclude_ids=exclude_ids,
     )
     suite_case_ids = [case.id for case in filtered_cases]
-    filtered_case_lookup = {case.id: case for case in filtered_cases}
     cases = filtered_cases
     failed_selection_ids: set[str] | None = None
 

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -140,7 +140,7 @@ def _consecutive_passes(
     for entry in entries:
         if tag is not None and entry.get("tag") != tag:
             continue
-        # Old history entries may not contain scope_hash; treat missing as compatible for migration unless strict.
+        # Old history entries may not contain scope_hash; treat missing as compatible for migration unless strict_scope_history is set.
         if scope_hash:
             entry_scope = entry.get("scope_hash")
             if entry_scope != scope_hash and (strict_scope_history or entry_scope is not None):

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -544,13 +544,13 @@ def handle_batch(args) -> int:
     if not overlay_disabled:
         overlay_run_path = _load_latest_run(artifacts_dir, args.tag, kind="any")
         overlay_results_path = _load_latest_any_results(artifacts_dir, args.tag)
-    if overlay_results_path and not args.no_overlay:
-        try:
-            overlay_results = load_results(overlay_results_path)
-        except Exception as exc:
-            print(f"Failed to read overlay results from latest run: {exc}", file=sys.stderr)
-            overlay_results_path = None
-            overlay_results = None
+        if overlay_results_path:
+            try:
+                overlay_results = load_results(overlay_results_path)
+            except Exception as exc:
+                print(f"Failed to read overlay results from latest run: {exc}", file=sys.stderr)
+                overlay_results_path = None
+                overlay_results = None
 
     filtered_cases = _select_cases_for_rerun(
         cases,

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -107,6 +107,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Require scope_hash match in history when counting consecutive passes (disable migration fallback)",
     )
+    batch_p.add_argument(
+        "--explain-selection",
+        action="store_true",
+        help="Explain why cases were selected/healed when using --only-failed/--only-missed",
+    )
+    batch_p.add_argument(
+        "--explain-limit",
+        type=int,
+        default=20,
+        help="Maximum number of cases to include in explain output",
+    )
     batch_p.add_argument("--plan-only", action="store_true", help="Run planner only (no fetch/synthesize)")
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -96,6 +96,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Ignore latest partial run when selecting only-failed/only-missed (use baseline only)",
     )
+    batch_p.add_argument(
+        "--anti-flake-passes",
+        type=int,
+        default=2,
+        help="Require N consecutive PASS results to consider a test healed (applies to --only-failed overlay logic)",
+    )
     batch_p.add_argument("--plan-only", action="store_true", help="Run planner only (no fetch/synthesize)")
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -91,6 +91,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run only cases that failed/mismatched/errored in a previous results.jsonl",
     )
     batch_p.add_argument("--only-failed", action="store_true", help="Use latest run for --only-failed-from automatically")
+    batch_p.add_argument(
+        "--no-overlay",
+        action="store_true",
+        help="Ignore latest partial run when selecting only-failed/only-missed (use baseline only)",
+    )
     batch_p.add_argument("--plan-only", action="store_true", help="Run planner only (no fetch/synthesize)")
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -102,6 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=2,
         help="Require N consecutive PASS results to consider a test healed (applies to --only-failed overlay logic)",
     )
+    batch_p.add_argument(
+        "--strict-scope-history",
+        action="store_true",
+        help="Require scope_hash match in history when counting consecutive passes (disable migration fallback)",
+    )
     batch_p.add_argument("--plan-only", action="store_true", help="Run planner only (no fetch/synthesize)")
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")

--- a/examples/demo_qa/runs/case_history.py
+++ b/examples/demo_qa/runs/case_history.py
@@ -9,7 +9,6 @@ from typing import Iterable, Mapping, Optional
 from ..runner import RunResult
 from .layout import _load_run_meta
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/examples/demo_qa/runs/case_history.py
+++ b/examples/demo_qa/runs/case_history.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Mapping, Optional
 
 from ..runner import RunResult
+from .layout import _load_run_meta
+
+
+logger = logging.getLogger(__name__)
 
 
 def _reason_text(res: RunResult) -> str:
@@ -33,11 +38,14 @@ def _append_case_history(
     git_sha: str | None,
     run_dir: Path,
     results_path: Path,
+    run_ts: str | None,
 ) -> None:
     history_dir = artifacts_dir / "runs" / "cases"
     history_dir.mkdir(parents=True, exist_ok=True)
+    ts = run_ts or datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     payload = {
-        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "timestamp": ts,
+        "ts": ts,
         "run_id": run_id,
         "tag": tag,
         "note": note,
@@ -74,4 +82,103 @@ def _load_case_history(path: Path) -> list[dict]:
     return entries
 
 
-__all__ = ["_append_case_history", "_load_case_history"]
+def _parse_ts(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            try:
+                return float(value)
+            except Exception:
+                return None
+    return None
+
+
+def _entry_ts(entry: Mapping[str, object], *, run_dir: Path | None) -> tuple[float | None, str | None]:
+    ts = _parse_ts(entry.get("ts")) or _parse_ts(entry.get("timestamp"))
+    if ts is not None:
+        return ts, None
+    meta_ts: float | None = None
+    if run_dir:
+        meta = _load_run_meta(run_dir)
+        if isinstance(meta, dict):
+            meta_ts = _parse_ts(meta.get("ended_at") or meta.get("timestamp") or meta.get("started_at"))
+        if meta_ts is None:
+            try:
+                meta_ts = run_dir.stat().st_mtime
+            except OSError:
+                meta_ts = None
+    return meta_ts, "history order fallback used"
+
+
+def _iter_case_entries_newest_first(
+    history_path: Path,
+    case_id: str,
+    tag: str | None,
+    scope_hash: str | None,
+    *,
+    strict_scope: bool,
+    fail_on: str,
+    require_assert: bool,
+    overlay_entry: dict | None,
+    max_entries: int,
+) -> Iterable[dict]:
+    entries = list(_load_case_history(history_path)) if history_path.exists() else []
+    overlay_index = None
+    if overlay_entry:
+        overlay_index = len(entries)
+        entries.append(dict(overlay_entry))
+
+    accepted: dict[str, dict] = {}
+    ts_map: dict[str, float | None] = {}
+    is_overlay_map: dict[str, bool] = {}
+    warnings_emitted = False
+    for idx, entry in enumerate(entries):
+        if tag is not None and entry.get("tag") != tag:
+            continue
+        entry_scope = entry.get("scope_hash")
+        if scope_hash:
+            if entry_scope != scope_hash and (strict_scope or entry_scope is not None):
+                continue
+        run_id = str(entry.get("run_id")) if entry.get("run_id") is not None else None
+        if not run_id:
+            continue
+        run_dir = None
+        if entry.get("run_dir"):
+            run_dir = Path(str(entry["run_dir"]))
+        ts_value, warn = _entry_ts(entry, run_dir=run_dir)
+        if ts_value is None and warn:
+            warnings_emitted = True
+        is_overlay = overlay_entry is not None and idx == overlay_index
+        current_ts = ts_map.get(run_id)
+        current_is_overlay = is_overlay_map.get(run_id, False)
+        candidate_ts = ts_value
+        should_replace = False
+        if run_id not in accepted:
+            should_replace = True
+        else:
+            if candidate_ts is not None:
+                if current_ts is None or candidate_ts > current_ts or (
+                    candidate_ts == current_ts and is_overlay and not current_is_overlay
+                ):
+                    should_replace = True
+            else:
+                if current_ts is None and is_overlay and not current_is_overlay:
+                    should_replace = True
+        if should_replace:
+            accepted[run_id] = entry
+            ts_map[run_id] = candidate_ts
+            is_overlay_map[run_id] = is_overlay
+    if warnings_emitted:
+        logger.warning("ts missing; history order fallback used for case %s", case_id)
+
+    sorted_entries = sorted(accepted.items(), key=lambda kv: ts_map.get(kv[0], 0), reverse=True)
+    for _, entry in sorted_entries[:max_entries]:
+        yield entry
+
+
+__all__ = ["_append_case_history", "_iter_case_entries_newest_first", "_load_case_history"]

--- a/examples/demo_qa/runs/layout.py
+++ b/examples/demo_qa/runs/layout.py
@@ -136,7 +136,8 @@ def _update_latest_markers(
     if tag:
         marker_sets.add(_latest_markers(artifacts_dir, tag))
     for markers in marker_sets:
-        markers.complete.parent.mkdir(parents=True, exist_ok=True)
+        for path in [markers.complete, markers.results, markers.any_run, markers.legacy_run]:
+            path.parent.mkdir(parents=True, exist_ok=True)
         markers.any_run.write_text(str(run_folder), encoding="utf-8")
         if results_complete:
             markers.legacy_run.write_text(str(run_folder), encoding="utf-8")

--- a/examples/demo_qa/runs/layout.py
+++ b/examples/demo_qa/runs/layout.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
+
+
+class LatestMarkers(NamedTuple):
+    complete: Path
+    results: Path
+    any_run: Path
+    legacy_run: Path
 
 
 def _sanitize_tag(tag: str) -> str:
@@ -15,41 +22,82 @@ def _effective_paths(artifacts_dir: Path, tag: str) -> tuple[Path, Path]:
     return base / "effective_results.jsonl", base / "effective_meta.json"
 
 
-def _latest_markers(artifacts_dir: Path, tag: str | None) -> tuple[Path, Path]:
+def _latest_markers(artifacts_dir: Path, tag: str | None) -> LatestMarkers:
     runs_dir = artifacts_dir / "runs"
     if tag:
         slug = _sanitize_tag(tag)
-        return runs_dir / f"tag-latest-{slug}.txt", runs_dir / f"tag-latest-results-{slug}.txt"
-    return runs_dir / "latest.txt", runs_dir / "latest_results.txt"
+        return LatestMarkers(
+            runs_dir / f"tag-latest-complete-{slug}.txt",
+            runs_dir / f"tag-latest-results-{slug}.txt",
+            runs_dir / f"tag-latest-any-{slug}.txt",
+            runs_dir / f"tag-latest-{slug}.txt",
+        )
+    return LatestMarkers(
+        runs_dir / "latest_complete.txt",
+        runs_dir / "latest_results.txt",
+        runs_dir / "latest_any.txt",
+        runs_dir / "latest.txt",
+    )
 
 
-def _load_latest_run(artifacts_dir: Path, tag: str | None = None) -> Optional[Path]:
-    latest_file, _ = _latest_markers(artifacts_dir, tag)
-    if latest_file.exists():
-        content = latest_file.read_text(encoding="utf-8").strip()
+def _read_marker(path: Path) -> Optional[Path]:
+    if path.exists():
+        content = path.read_text(encoding="utf-8").strip()
         if content:
             return Path(content)
+    return None
+
+
+def _load_latest_run(artifacts_dir: Path, tag: str | None = None, *, kind: str = "complete") -> Optional[Path]:
+    markers = _latest_markers(artifacts_dir, tag)
+    candidates: list[Path] = []
+    if kind == "any":
+        candidates.append(markers.any_run)
+    candidates.append(markers.complete)
+    candidates.append(markers.legacy_run)
+    for marker in candidates:
+        resolved = _read_marker(marker)
+        if resolved:
+            return resolved
+    return None
+
+
+def _resolve_results_path_for_run(run_path: Path | None) -> Optional[Path]:
+    if run_path is None:
+        return None
+    summary_path = run_path / "summary.json"
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            results_path = summary.get("results_path")
+            if results_path:
+                return Path(results_path)
+        except Exception:
+            pass
+    candidate = run_path / "results.jsonl"
+    if candidate.exists():
+        return candidate
     return None
 
 
 def _load_latest_results(artifacts_dir: Path, tag: str | None = None) -> Optional[Path]:
-    _, latest_file = _latest_markers(artifacts_dir, tag)
-    if latest_file.exists():
-        content = latest_file.read_text(encoding="utf-8").strip()
-        if content:
-            return Path(content)
-    latest_run = _load_latest_run(artifacts_dir, tag)
-    if latest_run:
-        summary_path = latest_run / "summary.json"
-        if summary_path.exists():
-            try:
-                summary = json.loads(summary_path.read_text(encoding="utf-8"))
-                results_path = summary.get("results_path")
-                if results_path:
-                    return Path(results_path)
-            except Exception:
-                pass
-    return None
+    markers = _latest_markers(artifacts_dir, tag)
+    resolved = _read_marker(markers.results)
+    if resolved:
+        return resolved
+    latest_run = _load_latest_run(artifacts_dir, tag, kind="complete")
+    return _resolve_results_path_for_run(latest_run)
+
+
+def _load_latest_any_results(artifacts_dir: Path, tag: str | None = None) -> Optional[Path]:
+    latest_run = _load_latest_run(artifacts_dir, tag, kind="any")
+    if latest_run is None:
+        return None
+    results = _resolve_results_path_for_run(latest_run)
+    if results:
+        return results
+    markers = _latest_markers(artifacts_dir, tag)
+    return _read_marker(markers.results)
 
 
 def _load_run_meta(run_path: Path | None) -> Optional[dict]:
@@ -80,22 +128,30 @@ def _run_dir_from_results_path(results_path: Path | None) -> Optional[Path]:
     return run_dir
 
 
-def _update_latest_markers(run_folder: Path, results_path: Path, artifacts_dir: Path, tag: str | None) -> None:
-    marker_pairs = {_latest_markers(artifacts_dir, None)}
+def _update_latest_markers(
+    run_folder: Path, results_path: Path, artifacts_dir: Path, tag: str | None, *, results_complete: bool
+) -> None:
+    marker_sets = {_latest_markers(artifacts_dir, None)}
     if tag:
-        marker_pairs.add(_latest_markers(artifacts_dir, tag))
-    for latest_path, latest_results_path in marker_pairs:
-        latest_path.parent.mkdir(parents=True, exist_ok=True)
-        latest_path.write_text(str(run_folder), encoding="utf-8")
-        latest_results_path.write_text(str(results_path), encoding="utf-8")
+        marker_sets.add(_latest_markers(artifacts_dir, tag))
+    for markers in marker_sets:
+        markers.complete.parent.mkdir(parents=True, exist_ok=True)
+        markers.any_run.write_text(str(run_folder), encoding="utf-8")
+        markers.legacy_run.write_text(str(run_folder), encoding="utf-8")
+        if results_complete:
+            markers.complete.write_text(str(run_folder), encoding="utf-8")
+            markers.results.write_text(str(results_path), encoding="utf-8")
 
 
 __all__ = [
+    "LatestMarkers",
     "_effective_paths",
+    "_load_latest_any_results",
     "_latest_markers",
     "_load_latest_results",
     "_load_latest_run",
     "_load_run_meta",
+    "_resolve_results_path_for_run",
     "_run_dir_from_results_path",
     "_sanitize_tag",
     "_update_latest_markers",

--- a/examples/demo_qa/runs/layout.py
+++ b/examples/demo_qa/runs/layout.py
@@ -98,8 +98,7 @@ def _load_latest_any_results(artifacts_dir: Path, tag: str | None = None) -> Opt
     results = _resolve_results_path_for_run(latest_run)
     if results:
         return results
-    markers = _latest_markers(artifacts_dir, tag)
-    return _read_marker(markers.results)
+    return None
 
 
 def _load_run_meta(run_path: Path | None) -> Optional[dict]:

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -157,11 +157,13 @@ def test_update_latest_markers_handles_tag(tmp_path: Path) -> None:
     assert latest_default.complete.read_text(encoding="utf-8").strip() == str(run_dir)
     assert latest_default.results.read_text(encoding="utf-8").strip() == str(results_path)
     assert latest_default.any_run.read_text(encoding="utf-8").strip() == str(run_dir)
+    assert latest_default.legacy_run.read_text(encoding="utf-8").strip() == str(run_dir)
 
     latest_tag = _latest_markers(artifacts_dir, "feature/beta")
     assert latest_tag.complete.read_text(encoding="utf-8").strip() == str(run_dir)
     assert latest_tag.results.read_text(encoding="utf-8").strip() == str(results_path)
     assert latest_tag.any_run.read_text(encoding="utf-8").strip() == str(run_dir)
+    assert latest_tag.legacy_run.read_text(encoding="utf-8").strip() == str(run_dir)
 
     partial_dir = artifacts_dir / "runs" / "20240102_cases"
     partial_results = partial_dir / "results.jsonl"
@@ -174,8 +176,10 @@ def test_update_latest_markers_handles_tag(tmp_path: Path) -> None:
     assert refreshed_default.complete.read_text(encoding="utf-8").strip() == str(run_dir)
     assert refreshed_default.results.read_text(encoding="utf-8").strip() == str(results_path)
     assert refreshed_default.any_run.read_text(encoding="utf-8").strip() == str(partial_dir)
+    assert refreshed_default.legacy_run.read_text(encoding="utf-8").strip() == str(run_dir)
 
     refreshed_tag = _latest_markers(artifacts_dir, "feature/beta")
     assert refreshed_tag.complete.read_text(encoding="utf-8").strip() == str(run_dir)
     assert refreshed_tag.results.read_text(encoding="utf-8").strip() == str(results_path)
     assert refreshed_tag.any_run.read_text(encoding="utf-8").strip() == str(partial_dir)
+    assert refreshed_tag.legacy_run.read_text(encoding="utf-8").strip() == str(run_dir)

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -147,6 +147,62 @@ def test_only_missed_selection_uses_overlay_executed() -> None:
     assert breakdown["overlay_executed"] == {"c"}
 
 
+def test_only_missed_ignores_overlay_when_scope_mismatches() -> None:
+    baseline = {"A": _mk_result("A", "ok")}
+    overlay = {"B": _mk_result("B", "ok")}
+
+    missed, breakdown = _only_missed_selection(
+        ["A", "B", "C"],
+        baseline,
+        overlay,
+        overlay_scope_hash="overlay_scope",
+        selection_scope_hash="current_scope",
+    )
+
+    assert missed == {"B", "C"}
+    assert breakdown["missed_base"] == {"B", "C"}
+    assert breakdown["overlay_executed"] == set()
+    assert breakdown["overlay_scope_hash"] == "overlay_scope"
+    assert breakdown["overlay_scope_matches_current"] is False
+    assert breakdown["overlay_ignored_reason"] == "scope_mismatch"
+
+
+def test_only_missed_applies_overlay_when_scope_matches() -> None:
+    baseline = {"A": _mk_result("A", "ok")}
+    overlay = {"B": _mk_result("B", "ok")}
+
+    missed, breakdown = _only_missed_selection(
+        ["A", "B", "C"],
+        baseline,
+        overlay,
+        overlay_scope_hash="scope_current",
+        selection_scope_hash="scope_current",
+    )
+
+    assert missed == {"C"}
+    assert breakdown["missed_base"] == {"B", "C"}
+    assert breakdown["overlay_executed"] == {"B"}
+    assert breakdown["overlay_scope_hash"] == "scope_current"
+    assert breakdown["overlay_scope_matches_current"] is True
+    assert "overlay_ignored_reason" not in breakdown
+
+
+def test_only_missed_exposes_tag_match_flag_even_when_overlay_tag_missing() -> None:
+    baseline = {"A": _mk_result("A", "ok")}
+    overlay = {"B": _mk_result("B", "ok")}
+
+    _, breakdown = _only_missed_selection(
+        ["A", "B"],
+        baseline,
+        overlay,
+        selection_tag="current-tag",
+    )
+
+    assert breakdown["overlay_executed"] == {"B"}
+    assert "overlay_tag_matches_current" in breakdown
+    assert breakdown["overlay_tag_matches_current"] is None
+
+
 def test_only_failed_strict_scope_ignores_overlay_pass(tmp_path: Path) -> None:
     baseline = {"A": _mk_result("A", "failed")}
     overlay = {"A": _mk_result("A", "ok")}

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -11,8 +11,8 @@ import pytest
 
 from examples.demo_qa.batch import (
     _consecutive_passes,
-    _format_healed_explain,
     _fingerprint_dir,
+    _format_healed_explain,
     _only_failed_selection,
     _only_missed_selection,
     _planned_pool_from_meta,
@@ -21,9 +21,9 @@ from examples.demo_qa.batch import (
     render_markdown,
     write_results,
 )
+from examples.demo_qa.runner import DiffReport, RunResult, diff_runs
 from examples.demo_qa.runs.coverage import _missed_case_ids
 from examples.demo_qa.runs.layout import _latest_markers, _update_latest_markers
-from examples.demo_qa.runner import DiffReport, RunResult, diff_runs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -13,6 +13,7 @@ from examples.demo_qa.batch import (
     _fingerprint_dir,
     _only_failed_selection,
     _only_missed_selection,
+    _planned_pool_from_meta,
     bad_statuses,
     is_failure,
     render_markdown,
@@ -174,17 +175,13 @@ def test_only_missed_uses_planned_pool_from_baseline_meta(tmp_path: Path) -> Non
     artifacts_dir = tmp_path
     run_dir = artifacts_dir / "runs" / "r1"
     run_dir.mkdir(parents=True)
-    baseline_results = {"a": _mk_result("a", "ok")}
     results_path = run_dir / "results.jsonl"
     results_path.write_text("", encoding="utf-8")
     meta = {"planned_case_ids": ["a", "b"], "selected_case_ids": ["a", "b"], "scope_hash": "s"}
     (run_dir / "run_meta.json").write_text(json.dumps(meta), encoding="utf-8")
 
-    overlay = {"c": _mk_result("c", "ok")}
-    planned_pool = {"a", "b"}
-    missed, _ = _only_missed_selection(planned_pool, baseline_results, overlay)
-
-    assert missed == {"b"}
+    planned_pool = _planned_pool_from_meta(None, results_path, ["x", "y"])
+    assert planned_pool == {"a", "b"}
 
 
 def test_update_latest_markers_handles_tag(tmp_path: Path) -> None:

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -118,7 +118,14 @@ def test_only_failed_selection_uses_overlay_and_baseline() -> None:
     baseline = {"a": _mk_result("a", "failed"), "b": _mk_result("b", "failed")}
     overlay = {"a": _mk_result("a", "ok"), "c": _mk_result("c", "failed")}
 
-    selection, breakdown = _only_failed_selection(baseline, overlay, fail_on="bad", require_assert=False)
+    selection, breakdown = _only_failed_selection(
+        baseline,
+        overlay,
+        fail_on="bad",
+        require_assert=False,
+        artifacts_dir=None,
+        anti_flake_passes=1,
+    )
 
     assert selection == {"b", "c"}
     assert breakdown["healed"] == {"a"}

--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from examples.demo_qa.runner import Case, RunResult, _match_expected, diff_runs, summarize
 
 
@@ -9,7 +11,7 @@ def test_match_expected_unchecked_when_no_expectations() -> None:
 
 
 def test_match_expected_coerces_non_string_expected_values() -> None:
-    case = Case(id="c1", question="What is foo?", expected=42)
+    case = Case(id="c1", question="What is foo?", expected=cast(str, 42))
 
     mismatch = _match_expected(case, "43")
     assert mismatch is not None

--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import cast
 
-from examples.demo_qa.runner import Case, RunResult, _match_expected, diff_runs, summarize
+from examples.demo_qa.runner import (
+    Case,
+    RunResult,
+    _match_expected,
+    diff_runs,
+    summarize,
+)
 
 
 def test_match_expected_unchecked_when_no_expectations() -> None:


### PR DESCRIPTION
## Summary
- separate latest markers for complete and any runs so partial runs no longer promote the baseline
- apply overlay-aware logic to --only-failed/--only-missed selections and capture run metadata for partial or interrupted runs
- add a --no-overlay flag plus new tests covering selection overlays and marker updates

## Testing
- python -m pytest tests/test_demo_qa_batch.py *(fails: missing `pydantic-settings`; install blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69588536efcc832fb962105cadd21727)