### PR TITLE
Improve anti-flake history handling

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -30,7 +30,7 @@ from .runner import (
     save_status,
     summarize,
 )
-from .runs.case_history import _append_case_history, _load_case_history
+from .runs.case_history import _append_case_history, _iter_case_entries_newest_first
 from .runs.coverage import _missed_case_ids
 from .runs.effective import (
     _append_effective_diff,
@@ -119,8 +119,8 @@ def _load_ids(path: Optional[Path]) -> set[str] | None:
 
 def _consecutive_passes(
     case_id: str,
-    overlay_result: RunResult,
-    artifacts_dir: Path | None = None,
+    overlay_entry: Mapping[str, object] | None,
+    history_path: Path | None,
     *,
     tag: str | None = None,
     scope_hash: str = "",
@@ -128,34 +128,36 @@ def _consecutive_passes(
     fail_on: str = "bad",
     require_assert: bool = False,
     strict_scope_history: bool = False,
-) -> bool:
-    if passes_required <= 1 or artifacts_dir is None:
-        return overlay_result.status not in bad_statuses(fail_on, require_assert)
+    max_entries: int | None = None,
+) -> tuple[bool, list[dict]]:
     bad = bad_statuses(fail_on, require_assert)
-    if overlay_result.status in bad:
-        return False
-    count = 1
-    history_path = artifacts_dir / "runs" / "cases" / f"{case_id}.jsonl"
-    entries = list(reversed(_load_case_history(history_path)))
-    skip_first = True  # overlay_result already counted; skip the most recent history entry
-    for entry in entries:
-        if skip_first:
-            skip_first = False
-            continue
-        if tag is not None and entry.get("tag") != tag:
-            continue
-        # Old history entries may not contain scope_hash; treat missing as compatible for migration unless strict_scope_history is set.
-        if scope_hash:
-            entry_scope = entry.get("scope_hash")
-            if entry_scope != scope_hash and (strict_scope_history or entry_scope is not None):
-                continue
+    if overlay_entry is None:
+        return False, []
+    if passes_required <= 1 or history_path is None:
+        return (overlay_entry.get("status") not in bad, [dict(overlay_entry)])
+    entries: list[dict] = []
+    passes_needed = max(passes_required, 1)
+    iterator = _iter_case_entries_newest_first(
+        history_path,
+        case_id,
+        tag,
+        scope_hash or None,
+        strict_scope=strict_scope_history,
+        fail_on=fail_on,
+        require_assert=require_assert,
+        overlay_entry=dict(overlay_entry) if overlay_entry else None,
+        max_entries=max_entries or (passes_needed + 5),
+    )
+    consecutive = 0
+    for entry in iterator:
+        entries.append(entry)
         status = str(entry.get("status", ""))
         if status in bad:
-            break
-        count += 1
-        if count >= passes_required:
-            return True
-    return count >= passes_required
+            return False, entries
+        consecutive += 1
+        if consecutive >= passes_needed:
+            return True, entries
+    return False, entries
 
 
 def _only_failed_selection(
@@ -169,20 +171,45 @@ def _only_failed_selection(
     scope_hash: str = "",
     anti_flake_passes: int = 1,
     strict_scope_history: bool = False,
+    overlay_run_meta: Mapping[str, object] | None = None,
+    overlay_run_path: Path | None = None,
+    explain_selection: bool = False,
+    explain_limit: int = 20,
 ) -> tuple[set[str], dict[str, object]]:
     baseline = baseline_results or {}
     overlay = overlay_results or {}
     bad = bad_statuses(fail_on, require_assert)
     baseline_bad = {cid for cid, res in baseline.items() if res.status in bad}
     overlay_bad = {cid for cid, res in overlay.items() if res.status in bad}
-    overlay_good = {
-        cid
-        for cid, res in overlay.items()
-        if res.status not in bad
-        and _consecutive_passes(
+    overlay_run_id = cast(Optional[str], overlay_run_meta.get("run_id") if isinstance(overlay_run_meta, Mapping) else None)
+    overlay_ts: Optional[object] = None
+    if isinstance(overlay_run_meta, Mapping):
+        overlay_ts = overlay_run_meta.get("ended_at") or overlay_run_meta.get("timestamp") or overlay_run_meta.get("started_at")
+    if overlay_ts is None and overlay_run_path and overlay_run_path.exists():
+        try:
+            overlay_ts = overlay_run_path.stat().st_mtime
+        except OSError:
+            overlay_ts = None
+    overlay_entries: dict[str, dict] = {}
+    for cid, res in overlay.items():
+        entry = {
+            "run_id": overlay_run_id or (str(overlay_run_path) if overlay_run_path else "overlay"),
+            "ts": overlay_ts,
+            "timestamp": overlay_ts,
+            "status": res.status,
+            "scope_hash": scope_hash,
+            "tag": tag,
+            "run_dir": str(overlay_run_path) if overlay_run_path else None,
+        }
+        overlay_entries[cid] = {k: v for k, v in entry.items() if v is not None}
+
+    overlay_good: set[str] = set()
+    healed_details: dict[str, list[dict]] = {}
+    for cid, res in overlay.items():
+        ok, history_entries = _consecutive_passes(
             cid,
-            res,
-            artifacts_dir,
+            overlay_entries.get(cid),
+            artifacts_dir / "runs" / "cases" / f"{cid}.jsonl" if artifacts_dir else None,
             tag=tag,
             scope_hash=scope_hash,
             passes_required=anti_flake_passes,
@@ -190,7 +217,10 @@ def _only_failed_selection(
             require_assert=require_assert,
             strict_scope_history=strict_scope_history,
         )
-    }
+        if ok:
+            overlay_good.add(cid)
+            if explain_selection:
+                healed_details[cid] = history_entries
 
     healed = baseline_bad & overlay_good
     selection = (baseline_bad - healed) | overlay_bad
@@ -199,7 +229,34 @@ def _only_failed_selection(
         "healed": healed,
         "new_failures": overlay_bad,
     }
+    if explain_selection and healed_details:
+        limit = max(1, explain_limit)
+        breakdown["healed_details"] = {cid: healed_details[cid] for cid in list(sorted(healed_details))[:limit]}
     return selection, breakdown
+
+
+def _format_healed_explain(
+    healed: Iterable[str],
+    healed_details: Mapping[str, list[dict]] | None,
+    *,
+    anti_flake_passes: int,
+    limit: int,
+) -> list[str]:
+    details = healed_details or {}
+    max_entries = max(1, limit)
+    lines: list[str] = []
+    healed_list = sorted(set(healed))
+    for cid in healed_list[:max_entries]:
+        entries = details.get(cid, [])
+        lines.append(f"Healed because last {anti_flake_passes} results are PASS for case {cid}")
+        for entry in entries[:anti_flake_passes]:
+            rid = entry.get("run_id")
+            ts = entry.get("ts") or entry.get("timestamp")
+            status = entry.get("status")
+            lines.append(f"  - run_id={rid} ts={ts} status={status}")
+    if len(healed_list) > max_entries:
+        lines.append(f"... {len(healed_list) - max_entries} more healed cases not shown (limit={max_entries})")
+    return lines
 
 
 def _only_missed_selection(
@@ -563,6 +620,7 @@ def handle_batch(args) -> int:
     overlay_run_path = None
     overlay_results_path = None
     overlay_disabled = args.no_overlay
+    overlay_run_meta: Optional[Mapping[str, object]] = None
     if not overlay_disabled:
         overlay_run_path = _load_latest_run(artifacts_dir, args.tag, kind="any")
         overlay_results_path = _load_latest_any_results(artifacts_dir, args.tag)
@@ -573,6 +631,8 @@ def handle_batch(args) -> int:
                 print(f"Failed to read overlay results from latest run: {exc}", file=sys.stderr)
                 overlay_results_path = None
                 overlay_results = None
+        if overlay_run_path:
+            overlay_run_meta = _load_run_meta(overlay_run_path)
 
     filtered_cases = _select_cases_for_rerun(
         cases,
@@ -596,6 +656,10 @@ def handle_batch(args) -> int:
             scope_hash=scope_id,
             anti_flake_passes=max(1, int(args.anti_flake_passes)),
             strict_scope_history=args.strict_scope_history,
+            overlay_run_meta=overlay_run_meta,
+            overlay_run_path=overlay_run_path,
+            explain_selection=args.explain_selection,
+            explain_limit=args.explain_limit,
         )
         cases = [case for case in cases if case.id in selection_ids]
         failed_selection_ids = selection_ids
@@ -605,7 +669,7 @@ def handle_batch(args) -> int:
         baseline_meta = _load_run_meta(_run_dir_from_results_path(baseline_filter_path))
         baseline_label = baseline_meta.get("run_id") if isinstance(baseline_meta, dict) else None
         baseline_status = baseline_meta.get("run_status") if isinstance(baseline_meta, dict) else None
-        overlay_meta = _load_run_meta(overlay_run_path)
+        overlay_meta = overlay_run_meta if overlay_run_meta is not None else _load_run_meta(overlay_run_path)
         overlay_label = overlay_meta.get("run_id") if isinstance(overlay_meta, dict) else None
         overlay_status = overlay_meta.get("run_status") if isinstance(overlay_meta, dict) else None
         baseline_complete = baseline_meta.get("results_complete") if isinstance(baseline_meta, dict) else None
@@ -627,6 +691,15 @@ def handle_batch(args) -> int:
         print(f"Healed by overlay: {len(healed)}", file=sys.stderr)
         print(f"New failures in overlay: {len(new_failures)}", file=sys.stderr)
         print(f"Final only-failed selection: {len(selection_ids)}", file=sys.stderr)
+        if args.explain_selection and healed:
+            healed_lines = _format_healed_explain(
+                healed,
+                breakdown.get("healed_details"),
+                anti_flake_passes=args.anti_flake_passes,
+                limit=args.explain_limit,
+            )
+            for line in healed_lines:
+                print(line, file=sys.stderr)
 
     only_missed_baseline_kind: str | None = None
     missed_planned_ids: set[str] | None = None
@@ -939,6 +1012,8 @@ def handle_batch(args) -> int:
             "no_overlay": args.no_overlay,
             "anti_flake_passes": args.anti_flake_passes,
             "strict_scope_history": args.strict_scope_history,
+            "explain_selection": args.explain_selection,
+            "explain_limit": args.explain_limit,
         },
         "interrupted": interrupted,
         "interrupted_at_case_id": interrupted_at_case_id,

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -133,8 +133,10 @@ def _consecutive_passes(
     bad = bad_statuses(fail_on, require_assert)
     if overlay_entry is None:
         return False, []
-    if passes_required <= 1 or history_path is None:
+    if passes_required <= 1:
         return (overlay_entry.get("status") not in bad, [dict(overlay_entry)])
+    if history_path is None:
+        return False, [dict(overlay_entry)]
     entries: list[dict] = []
     passes_needed = max(passes_required, 1)
     iterator = _iter_case_entries_newest_first(
@@ -1085,6 +1087,7 @@ def handle_batch(args) -> int:
             git_sha=git_sha,
             run_dir=run_folder,
             results_path=results_path,
+            run_ts=_isoformat_utc(ended_at),
         )
     history_path.parent.mkdir(parents=True, exist_ok=True)
     with history_path.open("a", encoding="utf-8") as f:

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -107,6 +107,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Require scope_hash match in history when counting consecutive passes (disable migration fallback)",
     )
+    batch_p.add_argument(
+        "--explain-selection",
+        action="store_true",
+        help="Explain why cases were selected/healed when using --only-failed/--only-missed",
+    )
+    batch_p.add_argument(
+        "--explain-limit",
+        type=int,
+        default=20,
+        help="Maximum number of cases to include in explain output",
+    )
     batch_p.add_argument("--plan-only", action="store_true", help="Run planner only (no fetch/synthesize)")
     batch_p.add_argument("--quiet", action="store_true", help="Print only summary and exit code")
     batch_p.add_argument("--show-failures", type=int, default=10, help="How many failing cases to show")

--- a/examples/demo_qa/runs/case_history.py
+++ b/examples/demo_qa/runs/case_history.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Mapping, Optional
 
 from ..runner import RunResult
+from .layout import _load_run_meta
+
+
+logger = logging.getLogger(__name__)
 
 
 def _reason_text(res: RunResult) -> str:
@@ -36,8 +41,10 @@ def _append_case_history(
 ) -> None:
     history_dir = artifacts_dir / "runs" / "cases"
     history_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     payload = {
-        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "timestamp": ts,
+        "ts": ts,
         "run_id": run_id,
         "tag": tag,
         "note": note,
@@ -74,4 +81,85 @@ def _load_case_history(path: Path) -> list[dict]:
     return entries
 
 
-__all__ = ["_append_case_history", "_load_case_history"]
+def _parse_ts(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            try:
+                return float(value)
+            except Exception:
+                return None
+    return None
+
+
+def _entry_ts(entry: Mapping[str, object], *, run_dir: Path | None) -> tuple[float | None, str | None]:
+    ts = _parse_ts(entry.get("ts")) or _parse_ts(entry.get("timestamp"))
+    if ts is not None:
+        return ts, None
+    meta_ts: float | None = None
+    if run_dir:
+        meta = _load_run_meta(run_dir)
+        if isinstance(meta, dict):
+            meta_ts = _parse_ts(meta.get("ended_at") or meta.get("timestamp") or meta.get("started_at"))
+        if meta_ts is None:
+            try:
+                meta_ts = run_dir.stat().st_mtime
+            except OSError:
+                meta_ts = None
+    return meta_ts, "history order fallback used"
+
+
+def _iter_case_entries_newest_first(
+    history_path: Path,
+    case_id: str,
+    tag: str | None,
+    scope_hash: str | None,
+    *,
+    strict_scope: bool,
+    fail_on: str,
+    require_assert: bool,
+    overlay_entry: dict | None,
+    max_entries: int,
+) -> Iterable[dict]:
+    entries = list(_load_case_history(history_path)) if history_path.exists() else []
+    if overlay_entry:
+        entries.append(dict(overlay_entry))
+
+    accepted: dict[str, dict] = {}
+    ts_map: dict[str, float | None] = {}
+    warnings_emitted = False
+    for idx, entry in enumerate(entries):
+        if tag is not None and entry.get("tag") not in {tag, None}:
+            continue
+        entry_scope = entry.get("scope_hash")
+        if scope_hash:
+            if entry_scope != scope_hash and (strict_scope or entry_scope is not None):
+                continue
+        run_id = str(entry.get("run_id")) if entry.get("run_id") is not None else None
+        if not run_id:
+            continue
+        run_dir = None
+        if entry.get("run_dir"):
+            run_dir = Path(str(entry["run_dir"]))
+        ts_value, warn = _entry_ts(entry, run_dir=run_dir)
+        if ts_value is None and warn:
+            warnings_emitted = True
+        current_ts = ts_map.get(run_id)
+        candidate_ts = ts_value if ts_value is not None else idx
+        if run_id not in accepted or (current_ts if current_ts is not None else -1) < candidate_ts:
+            accepted[run_id] = entry
+            ts_map[run_id] = candidate_ts
+    if warnings_emitted:
+        logger.warning("ts missing; history order fallback used for case %s", case_id)
+
+    sorted_entries = sorted(accepted.items(), key=lambda kv: ts_map.get(kv[0], 0), reverse=True)
+    for _, entry in sorted_entries[:max_entries]:
+        yield entry
+
+
+__all__ = ["_append_case_history", "_iter_case_entries_newest_first", "_load_case_history"]

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -10,6 +10,8 @@ from typing import cast
 import pytest
 
 from examples.demo_qa.batch import (
+    _consecutive_passes,
+    _format_healed_explain,
     _fingerprint_dir,
     _only_failed_selection,
     _only_missed_selection,
@@ -151,17 +153,16 @@ def test_anti_flake_requires_two_passes_without_double_count(tmp_path: Path) -> 
     history_dir = artifacts_dir / "runs" / "cases"
     history_dir.mkdir(parents=True)
     history_file = history_dir / f"{case_id}.jsonl"
-    # most recent in history = overlay run we already count
-    history_file.write_text(
-        json.dumps({"status": "ok", "scope_hash": "s"}, ensure_ascii=False) + "\n"
-        + json.dumps({"status": "failed", "scope_hash": "s"}, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    overlay_res = _mk_result(case_id, "ok")
-    healed = _consecutive_passes(
+    now = "2024-01-02T00:00:00Z"
+    history_entries = [
+        {"status": "ok", "scope_hash": "s", "run_id": "r1", "ts": now, "timestamp": now},
+    ]
+    history_file.write_text("\n".join(json.dumps(e, ensure_ascii=False) for e in history_entries), encoding="utf-8")
+    overlay_entry = {"status": "ok", "scope_hash": "s", "run_id": "r1", "ts": now, "timestamp": now}
+    healed, _ = _consecutive_passes(
         case_id,
-        overlay_res,
-        artifacts_dir,
+        overlay_entry,
+        artifacts_dir / "runs" / "cases" / f"{case_id}.jsonl",
         scope_hash="s",
         passes_required=2,
         fail_on="bad",
@@ -169,6 +170,75 @@ def test_anti_flake_requires_two_passes_without_double_count(tmp_path: Path) -> 
         strict_scope_history=True,
     )
     assert healed is False
+
+
+def test_anti_flake_order_independent(tmp_path: Path) -> None:
+    artifacts_dir = tmp_path
+    case_id = "case-1"
+    history_dir = artifacts_dir / "runs" / "cases"
+    history_dir.mkdir(parents=True)
+    history_file = history_dir / f"{case_id}.jsonl"
+    entries = [
+        {"status": "ok", "scope_hash": "s", "run_id": "r2", "ts": "2024-01-03T00:00:00Z"},
+        {"status": "failed", "scope_hash": "s", "run_id": "r1", "ts": "2024-01-01T00:00:00Z"},
+        {"status": "ok", "scope_hash": "s", "run_id": "r3", "ts": "2024-01-02T00:00:00Z"},
+    ]
+    history_file.write_text("\n".join(json.dumps(e, ensure_ascii=False) for e in entries), encoding="utf-8")
+    overlay_entry = {"status": "ok", "scope_hash": "s", "run_id": "r4", "ts": "2024-01-04T00:00:00Z"}
+
+    healed, used_entries = _consecutive_passes(
+        case_id,
+        overlay_entry,
+        history_file,
+        scope_hash="s",
+        passes_required=2,
+        fail_on="bad",
+        require_assert=False,
+        strict_scope_history=True,
+    )
+    assert healed is True
+    assert used_entries[0]["run_id"] == "r4"
+
+
+def test_anti_flake_respects_legacy_scope_when_not_strict(tmp_path: Path) -> None:
+    artifacts_dir = tmp_path
+    case_id = "case-legacy"
+    history_dir = artifacts_dir / "runs" / "cases"
+    history_dir.mkdir(parents=True)
+    history_file = history_dir / f"{case_id}.jsonl"
+    history_file.write_text(
+        "\n".join(
+            json.dumps(e, ensure_ascii=False)
+            for e in [
+                {"status": "ok", "scope_hash": None, "run_id": "r1", "ts": "2024-01-01T00:00:00Z"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    overlay_entry = {"status": "ok", "scope_hash": "s", "run_id": "r2", "ts": "2024-01-02T00:00:00Z"}
+
+    healed_strict, _ = _consecutive_passes(
+        case_id,
+        overlay_entry,
+        history_file,
+        scope_hash="s",
+        passes_required=2,
+        fail_on="bad",
+        require_assert=False,
+        strict_scope_history=True,
+    )
+    healed_migrating, _ = _consecutive_passes(
+        case_id,
+        overlay_entry,
+        history_file,
+        scope_hash="s",
+        passes_required=2,
+        fail_on="bad",
+        require_assert=False,
+        strict_scope_history=False,
+    )
+    assert healed_strict is False
+    assert healed_migrating is True
 
 
 def test_only_missed_uses_planned_pool_from_baseline_meta(tmp_path: Path) -> None:
@@ -223,3 +293,17 @@ def test_update_latest_markers_handles_tag(tmp_path: Path) -> None:
     assert refreshed_tag.results.read_text(encoding="utf-8").strip() == str(results_path)
     assert refreshed_tag.any_run.read_text(encoding="utf-8").strip() == str(partial_dir)
     assert refreshed_tag.legacy_run.read_text(encoding="utf-8").strip() == str(run_dir)
+
+
+def test_format_healed_explain_includes_key_lines() -> None:
+    healed = {"a", "b"}
+    healed_details = {
+        "a": [
+            {"run_id": "r2", "ts": "2024-01-02T00:00:00Z", "status": "ok"},
+            {"run_id": "r1", "ts": "2024-01-01T00:00:00Z", "status": "ok"},
+        ]
+    }
+    lines = _format_healed_explain(healed, healed_details, anti_flake_passes=2, limit=2)
+    assert any("Baseline" not in line for line in lines)  # sanity: no noise
+    assert any("Healed because last 2 results are PASS for case a" in line for line in lines)
+    assert any("run_id=r2" in line and "status=ok" in line for line in lines)

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -304,6 +304,5 @@ def test_format_healed_explain_includes_key_lines() -> None:
         ]
     }
     lines = _format_healed_explain(healed, healed_details, anti_flake_passes=2, limit=2)
-    assert any("Baseline" not in line for line in lines)  # sanity: no noise
     assert any("Healed because last 2 results are PASS for case a" in line for line in lines)
     assert any("run_id=r2" in line and "status=ok" in line for line in lines)


### PR DESCRIPTION
## Summary
- add run_id/ts metadata to case history entries and iterate newest-first with run_id deduplication and strict-scope handling
- refactor anti-flake pass counting to merge overlay results, support explain output, and expose CLI flags for selection explanations
- expand anti-flake unit coverage for order independence, scope migration, overlay deduplication, and explain formatting

## Testing
- `pytest -q` *(fails: missing `pydantic_settings`; dependency install blocked by proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e318458c832f91e66657e5daeb8d)