### PR TITLE
Fix overlay scope handling for strict scope healing

### DIFF
--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -169,7 +169,8 @@ def test_only_failed_strict_scope_ignores_overlay_pass(tmp_path: Path) -> None:
 
     assert selection == {"A"}
     assert breakdown["healed"] == set()
-    assert any("overlay_scope_matches_current=False" in line for line in breakdown.get("explain", []))
+    explain_lines = cast(list[str], breakdown.get("explain", []) or [])
+    assert any("overlay_scope_matches_current=False" in line for line in explain_lines)
 
 
 def test_only_failed_strict_scope_allows_overlay_pass_when_scope_matches(tmp_path: Path) -> None:
@@ -216,7 +217,7 @@ def test_only_failed_explain_notes_scope_mismatch(tmp_path: Path) -> None:
         explain_selection=True,
     )
 
-    explain_lines = breakdown.get("explain", [])
+    explain_lines = cast(list[str], breakdown.get("explain", []) or [])
     assert any("ignored due to strict scope mismatch" in line for line in explain_lines)
 
 

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -147,6 +147,79 @@ def test_only_missed_selection_uses_overlay_executed() -> None:
     assert breakdown["overlay_executed"] == {"c"}
 
 
+def test_only_failed_strict_scope_ignores_overlay_pass(tmp_path: Path) -> None:
+    baseline = {"A": _mk_result("A", "failed")}
+    overlay = {"A": _mk_result("A", "ok")}
+    overlay_meta = {"run_id": "overlay", "scope_hash": "scope_overlay", "ended_at": "2024-01-01T00:00:00Z"}
+
+    selection, breakdown = _only_failed_selection(
+        baseline,
+        overlay,
+        fail_on="bad",
+        require_assert=False,
+        artifacts_dir=tmp_path,
+        tag="t1",
+        scope_hash="scope_current",
+        anti_flake_passes=1,
+        strict_scope_history=True,
+        overlay_run_meta=overlay_meta,
+        overlay_run_path=tmp_path,
+        explain_selection=True,
+    )
+
+    assert selection == {"A"}
+    assert breakdown["healed"] == set()
+    assert any("overlay_scope_matches_current=False" in line for line in breakdown.get("explain", []))
+
+
+def test_only_failed_strict_scope_allows_overlay_pass_when_scope_matches(tmp_path: Path) -> None:
+    baseline = {"A": _mk_result("A", "failed")}
+    overlay = {"A": _mk_result("A", "ok")}
+    overlay_meta = {"run_id": "overlay", "scope_hash": "scope_current", "ended_at": "2024-01-01T00:00:00Z"}
+
+    selection, breakdown = _only_failed_selection(
+        baseline,
+        overlay,
+        fail_on="bad",
+        require_assert=False,
+        artifacts_dir=tmp_path,
+        tag="t1",
+        scope_hash="scope_current",
+        anti_flake_passes=1,
+        strict_scope_history=True,
+        overlay_run_meta=overlay_meta,
+        overlay_run_path=tmp_path,
+        explain_selection=True,
+    )
+
+    assert selection == set()
+    assert breakdown["healed"] == {"A"}
+
+
+def test_only_failed_explain_notes_scope_mismatch(tmp_path: Path) -> None:
+    baseline = {"A": _mk_result("A", "failed")}
+    overlay = {"A": _mk_result("A", "ok")}
+    overlay_meta = {"run_id": "overlay", "scope_hash": "scope_other", "ended_at": "2024-01-01T00:00:00Z"}
+
+    _, breakdown = _only_failed_selection(
+        baseline,
+        overlay,
+        fail_on="bad",
+        require_assert=False,
+        artifacts_dir=tmp_path,
+        tag="t1",
+        scope_hash="scope_current",
+        anti_flake_passes=1,
+        strict_scope_history=True,
+        overlay_run_meta=overlay_meta,
+        overlay_run_path=tmp_path,
+        explain_selection=True,
+    )
+
+    explain_lines = breakdown.get("explain", [])
+    assert any("ignored due to strict scope mismatch" in line for line in explain_lines)
+
+
 def test_anti_flake_requires_two_passes_without_double_count(tmp_path: Path) -> None:
     artifacts_dir = tmp_path
     case_id = "x1"

--- a/tests/test_demo_qa_runner.py
+++ b/tests/test_demo_qa_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from examples.demo_qa.runner import Case, RunResult, _match_expected, diff_runs, summarize
 
 
@@ -9,7 +11,7 @@ def test_match_expected_unchecked_when_no_expectations() -> None:
 
 
 def test_match_expected_coerces_non_string_expected_values() -> None:
-    case = Case(id="c1", question="What is foo?", expected=42)
+    case = Case(id="c1", question="What is foo?", expected=cast(str, 42))
 
     mismatch = _match_expected(case, "43")
     assert mismatch is not None


### PR DESCRIPTION
## Summary
- stamp overlay entries with the overlay run’s scope, tag, run id, and timestamp rather than the current selection’s metadata
- enforce strict-scope history by ignoring overlay PASS healing when scope mismatches while still reporting new failures
- expand explain output and add regression tests covering strict-scope overlay healing behavior

## Testing
- ruff check examples/demo_qa/batch.py tests/test_demo_qa_batch.py
- python -m pytest tests/test_demo_qa_batch.py::test_only_failed_strict_scope_ignores_overlay_pass tests/test_demo_qa_batch.py::test_only_failed_strict_scope_allows_overlay_pass_when_scope_matches tests/test_demo_qa_batch.py::test_only_failed_explain_notes_scope_mismatch


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958fd1dbdcc832fb99248863d3043fb)