### PR TITLE
Handle only-missed overlay scope checks

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -308,22 +308,47 @@ def _only_missed_selection(
     overlay_results: Mapping[str, RunResult] | None,
     *,
     overlay_scope_hash: str | None = None,
-    overlay_scope_matches_current: bool | None = None,
+    selection_scope_hash: str | None = None,
+    overlay_tag: str | None = None,
+    selection_tag: str | None = None,
+    overlay_disabled_reason: str | None = None,
     overlay_ignored_reason: str | None = None,
 ) -> tuple[set[str], dict[str, object]]:
     selected = set(selected_case_ids)
     baseline_ids = set(baseline_results.keys()) if baseline_results else set()
-    overlay_executed = set(overlay_results.keys()) if overlay_results else set()
+    overlay_scope_matches_current: bool | None = None
+    overlay_tag_matches_current: bool | None = None
+    overlay_results_for_calc: Mapping[str, RunResult] | None = None
+    ignored_reason = overlay_ignored_reason or overlay_disabled_reason
+    if overlay_results is not None and overlay_disabled_reason is None:
+        overlay_scope_matches_current = (
+            overlay_scope_hash == selection_scope_hash if overlay_scope_hash is not None and selection_scope_hash is not None else None
+        )
+        overlay_tag_matches_current = (
+            overlay_tag == selection_tag if overlay_tag is not None and selection_tag is not None else None
+        )
+        overlay_results_for_calc = overlay_results
+        if overlay_scope_matches_current is False:
+            overlay_results_for_calc = None
+            ignored_reason = "scope_mismatch"
+        elif overlay_tag_matches_current is False:
+            overlay_results_for_calc = None
+            ignored_reason = "tag_mismatch"
+    overlay_executed = set(overlay_results_for_calc.keys()) if overlay_results_for_calc else set()
     missed_base = selected - baseline_ids
     missed_final = missed_base - overlay_executed
     breakdown: dict[str, object] = {
         "missed_base": missed_base,
         "overlay_executed": overlay_executed,
         "overlay_scope_hash": overlay_scope_hash,
-        "overlay_scope_matches_current": overlay_scope_matches_current if overlay_scope_matches_current is not None else False,
+        "overlay_scope_matches_current": overlay_scope_matches_current,
     }
-    if overlay_ignored_reason:
-        breakdown["overlay_ignored_reason"] = overlay_ignored_reason
+    if overlay_tag is not None:
+        breakdown["overlay_tag"] = overlay_tag
+    if overlay_tag_matches_current is not None:
+        breakdown["overlay_tag_matches_current"] = overlay_tag_matches_current
+    if ignored_reason:
+        breakdown["overlay_ignored_reason"] = ignored_reason
     return missed_final, breakdown
 
 
@@ -797,30 +822,16 @@ def handle_batch(args) -> int:
             return 2
         overlay_scope_hash = cast(Optional[str], overlay_run_meta.get("scope_hash") if isinstance(overlay_run_meta, Mapping) else None)
         overlay_tag = cast(Optional[str], overlay_run_meta.get("tag") if isinstance(overlay_run_meta, Mapping) else None)
-        overlay_scope_matches_current: bool | None = None
-        overlay_ignored_reason: str | None = None
-        overlay_results_for_missed: Mapping[str, RunResult] | None = overlay_results if not args.no_overlay else None
-        if overlay_results_for_missed is not None:
-            overlay_scope_matches_current = overlay_scope_hash == scope_id
-            if not overlay_scope_matches_current:
-                overlay_results_for_missed = None
-                overlay_ignored_reason = "scope_mismatch"
-            elif args.tag and overlay_tag is not None and overlay_tag != args.tag:
-                overlay_results_for_missed = None
-                overlay_scope_matches_current = False
-                overlay_ignored_reason = "tag_mismatch"
-            else:
-                overlay_scope_matches_current = True
-        elif overlay_scope_hash is not None:
-            overlay_scope_matches_current = overlay_scope_hash == scope_id
         selected_case_ids = _planned_pool_from_meta(missed_effective_meta, missed_baseline_path, suite_case_ids)
         missed_ids, missed_breakdown = _only_missed_selection(
             selected_case_ids,
             missed_baseline_results,
-            overlay_results_for_missed,
+            overlay_results if not args.no_overlay else None,
             overlay_scope_hash=overlay_scope_hash,
-            overlay_scope_matches_current=overlay_scope_matches_current,
-            overlay_ignored_reason=overlay_ignored_reason,
+            selection_scope_hash=scope_id,
+            overlay_tag=overlay_tag,
+            selection_tag=args.tag,
+            overlay_disabled_reason="no_overlay" if args.no_overlay else None,
         )
         target_ids = missed_ids
         if args.only_failed and failed_selection_ids is not None:

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -345,7 +345,7 @@ def _only_missed_selection(
     }
     if overlay_tag is not None:
         breakdown["overlay_tag"] = overlay_tag
-    if overlay_tag_matches_current is not None:
+    if selection_tag is not None:
         breakdown["overlay_tag_matches_current"] = overlay_tag_matches_current
     if ignored_reason:
         breakdown["overlay_ignored_reason"] = ignored_reason

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -187,6 +187,22 @@ def test_only_missed_applies_overlay_when_scope_matches() -> None:
     assert "overlay_ignored_reason" not in breakdown
 
 
+def test_only_missed_exposes_tag_match_flag_even_when_overlay_tag_missing() -> None:
+    baseline = {"A": _mk_result("A", "ok")}
+    overlay = {"B": _mk_result("B", "ok")}
+
+    _, breakdown = _only_missed_selection(
+        ["A", "B"],
+        baseline,
+        overlay,
+        selection_tag="current-tag",
+    )
+
+    assert breakdown["overlay_executed"] == {"B"}
+    assert "overlay_tag_matches_current" in breakdown
+    assert breakdown["overlay_tag_matches_current"] is None
+
+
 def test_only_failed_strict_scope_ignores_overlay_pass(tmp_path: Path) -> None:
     baseline = {"A": _mk_result("A", "failed")}
     overlay = {"A": _mk_result("A", "ok")}

--- a/tests/test_demo_qa_batch.py
+++ b/tests/test_demo_qa_batch.py
@@ -149,14 +149,14 @@ def test_only_missed_selection_uses_overlay_executed() -> None:
 
 def test_only_missed_ignores_overlay_when_scope_mismatches() -> None:
     baseline = {"A": _mk_result("A", "ok")}
+    overlay = {"B": _mk_result("B", "ok")}
 
     missed, breakdown = _only_missed_selection(
         ["A", "B", "C"],
         baseline,
-        None,
+        overlay,
         overlay_scope_hash="overlay_scope",
-        overlay_scope_matches_current=False,
-        overlay_ignored_reason="scope_mismatch",
+        selection_scope_hash="current_scope",
     )
 
     assert missed == {"B", "C"}
@@ -176,7 +176,7 @@ def test_only_missed_applies_overlay_when_scope_matches() -> None:
         baseline,
         overlay,
         overlay_scope_hash="scope_current",
-        overlay_scope_matches_current=True,
+        selection_scope_hash="scope_current",
     )
 
     assert missed == {"C"}


### PR DESCRIPTION
## Summary
- guard only-missed overlay subtraction by verifying scope hash and tag before applying overlay results
- expose overlay scope match metadata in the only-missed breakdown output
- add regression tests covering overlay scope mismatch and match scenarios

## Testing
- pytest tests/test_demo_qa_batch.py::test_only_missed_selection_uses_overlay_executed tests/test_demo_qa_batch.py::test_only_missed_ignores_overlay_when_scope_mismatches tests/test_demo_qa_batch.py::test_only_missed_applies_overlay_when_scope_matches *(fails: missing pydantic_settings dependency; proxy blocked fetching packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695907faa968832fa854570b3b003d10)