### PR TITLE
Add optional API key handling for demo QA LLM

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -18,6 +18,10 @@ python -m examples.demo_qa.cli gen --out demo_data --rows 1000 --seed 42
 См. шаблон `examples/demo_qa/demo_qa.toml.example`.
 Автопоиск: `--config`, затем `<DATA_DIR>/demo_qa.toml`, затем `examples/demo_qa/demo_qa.toml`.
 
+Флаг `llm.require_api_key` управляет тем, нужно ли ошибаться при отсутствии ключа и добавлять заголовок
+`Authorization`. По умолчанию он `true` (безопасное поведение для реального OpenAI), для локального прокси
+можно поставить `false`, тогда ключ не требуется и не отправляется.
+
 ### .env.demo_qa
 Пример:
 ```

--- a/examples/demo_qa/llm/factory.py
+++ b/examples/demo_qa/llm/factory.py
@@ -16,6 +16,7 @@ def build_llm(settings: DemoQASettings) -> LLMInvoke:
         synth_temperature=settings.llm.synth_temperature,
         timeout_s=settings.llm.timeout_s,
         retries=settings.llm.retries,
+        require_api_key=settings.llm.require_api_key,
     )
 
 


### PR DESCRIPTION
## Summary
- add a `require_api_key` flag to the demo QA LLM adapter and pass-through configuration so Authorization is optional when desired
- update docs to clarify how the flag controls API key requirements for real OpenAI vs local proxies
- extend adapter tests to cover both required and optional API key paths

## Testing
- `pytest tests/test_demo_qa_settings.py` *(fails: missing `pydantic-settings` dependency because external package downloads are blocked by the proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593ae4a96c832fa15beb5a6cc2d0ac)