### PR TITLE
Relax OpenAI API key handling for demo QA

### DIFF
--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -17,6 +17,7 @@ python -m examples.demo_qa.cli gen --out demo_data --rows 1000 --seed 42
 ### Файл demo_qa.toml
 См. шаблон `examples/demo_qa/demo_qa.toml.example`.
 Автопоиск: `--config`, затем `<DATA_DIR>/demo_qa.toml`, затем `examples/demo_qa/demo_qa.toml`.
+`llm.api_key` можно опустить: при инициализации LLM используется `OPENAI_API_KEY`, а при его отсутствии — строка `"unused"`.
 
 ### .env.demo_qa
 Пример:
@@ -30,6 +31,7 @@ DEMO_QA_LLM__BASE_URL=http://localhost:8000/v1
 export DEMO_QA_LLM__API_KEY=sk-...
 export DEMO_QA_LLM__BASE_URL=http://localhost:8000/v1
 ```
+Если не задавать `DEMO_QA_LLM__API_KEY` и не выставлять `OPENAI_API_KEY`, LLM-клиент подставит `"unused"` и не упадёт.
 
 ### Зависимости демо
 * Требуется Python 3.11+ (используется стандартный `tomllib`).
@@ -44,7 +46,7 @@ pip install -r examples/demo_qa/requirements.txt
 
 ### OpenAI / совместимый прокси
 1. Скопируйте `examples/demo_qa/demo_qa.toml.example` в удобное место и укажите
-   `llm.api_key` (можно `env:OPENAI_API_KEY` или любое значение, если прокси не проверяет ключ),
+   при необходимости `llm.api_key` (можно `env:OPENAI_API_KEY`; если не указать, возьмётся `OPENAI_API_KEY` или `"unused"`),
    `base_url` (формат `http://host:port/v1`), модели и температуры.
 2. Запустите чат с указанием конфига:
 ```bash

--- a/examples/demo_qa/demo_qa.toml
+++ b/examples/demo_qa/demo_qa.toml
@@ -1,5 +1,4 @@
 [llm]
-api_key = "unused"
 base_url = "http://localhost:8000/v1"
 plan_model = "gpt-4o-mini"
 synth_model = "gpt-4o-mini"

--- a/examples/demo_qa/llm/openai_adapter.py
+++ b/examples/demo_qa/llm/openai_adapter.py
@@ -46,15 +46,15 @@ class OpenAILLM(LLMInvoke):
             self.logger.info("OpenAILLM using endpoint %s", endpoint)
 
     def _resolve_api_key(self, api_key: str | None) -> str:
-        if api_key is None:
-            raise RuntimeError("OpenAI provider selected but llm.api_key is missing.")
-        if api_key.startswith("env:"):
-            env_var = api_key.split(":", 1)[1]
-            value = os.getenv(env_var)
-            if not value:
-                raise RuntimeError(f"Environment variable {env_var} referenced in config but not set.")
-            return value
-        return api_key
+        if api_key:
+            if api_key.startswith("env:"):
+                env_var = api_key.split(":", 1)[1]
+                value = os.getenv(env_var)
+                return value or "unused"
+            return api_key
+
+        env_key = os.getenv("OPENAI_API_KEY")
+        return env_key or "unused"
 
     def _validate_base_url(self, base_url: str | None) -> str | None:
         if base_url in (None, ""):

--- a/examples/demo_qa/settings.py
+++ b/examples/demo_qa/settings.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any, ClassVar, Dict
 from urllib.parse import urlparse
@@ -16,6 +15,7 @@ except ImportError as exc:  # pragma: no cover - make missing dependency explici
         "pydantic-settings is required for demo_qa configuration. "
         "Install demo extras via `pip install -e .[demo]` or `pip install -r examples/demo_qa/requirements.txt`."
     ) from exc
+
 
 class LLMSettings(BaseModel):
     base_url: str | None = Field(default=None)
@@ -86,14 +86,6 @@ class DemoQASettings(BaseSettings):
             sources.append(TomlConfigSettingsSource(settings_cls, toml_file=cls._toml_path))
         sources.append(file_secret_settings)
         return tuple(sources)
-
-    @model_validator(mode="after")
-    def require_api_key(self) -> "DemoQASettings":
-        if not self.llm.api_key:
-            env_key = os.getenv("OPENAI_API_KEY")
-            if env_key:
-                self.llm.api_key = env_key
-        return self
 
 
 def resolve_config_path(config: Path | None, data_dir: Path | None) -> Path | None:

--- a/tests/test_demo_qa_settings.py
+++ b/tests/test_demo_qa_settings.py
@@ -13,6 +13,20 @@ def write_toml(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _install_fake_openai(monkeypatch, created: dict):
+    def _store_and_return(kwargs):
+        created["chat_kwargs"] = kwargs
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    class FakeOpenAI:
+        def __init__(self, api_key=None, base_url=None, **kwargs):
+            created["api_key"] = api_key
+            created["base_url"] = base_url
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: _store_and_return(kwargs)))
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAI))
+
+
 def test_env_overrides_toml(tmp_path, monkeypatch):
     config_path = tmp_path / "demo_qa.toml"
     write_toml(
@@ -62,10 +76,15 @@ base_url = "http://localhost:1234/v1"
 """,
     )
     monkeypatch.setenv("OPENAI_API_KEY", "sk-global")
+    created = {}
+    _install_fake_openai(monkeypatch, created)
 
     settings, resolved = load_settings(config_path=config_path)
     assert resolved == config_path
-    assert settings.llm.api_key == "sk-global"
+    llm = build_llm(settings)
+
+    llm("hello", sender="generic_plan")
+    assert created["api_key"] == "sk-global"
 
 
 def test_base_url_passed_to_openai_client(tmp_path, monkeypatch):
@@ -83,21 +102,7 @@ plan_model = "demo-plan"
 
     created = {}
 
-    class FakeOpenAI:
-        def __init__(self, api_key=None, base_url=None, **kwargs):
-            created["api_key"] = api_key
-            created["base_url"] = base_url
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(
-                    create=lambda **kwargs: _store_and_return(kwargs)
-                )
-            )
-
-    def _store_and_return(kwargs):
-        created["chat_kwargs"] = kwargs
-        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
-
-    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAI))
+    _install_fake_openai(monkeypatch, created)
 
     settings, resolved = load_settings(config_path=config_path)
     assert resolved == config_path
@@ -194,3 +199,51 @@ def test_no_options_uses_base_client(monkeypatch):
         "messages": [{"role": "user", "content": "question"}],
         "temperature": 0.2,
     }
+
+
+def test_missing_api_key_uses_unused(monkeypatch):
+    created: dict = {}
+    _install_fake_openai(monkeypatch, created)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    llm = OpenAILLM(
+        api_key=None,
+        base_url=None,
+        plan_model="demo-plan",
+        synth_model="demo-synth",
+    )
+    llm("hello", sender="generic_plan")
+
+    assert created["api_key"] == "unused"
+
+
+def test_env_reference_uses_openai_api_key(monkeypatch):
+    created: dict = {}
+    _install_fake_openai(monkeypatch, created)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+
+    llm = OpenAILLM(
+        api_key="env:OPENAI_API_KEY",
+        base_url=None,
+        plan_model="demo-plan",
+        synth_model="demo-synth",
+    )
+    llm("hello", sender="generic_plan")
+
+    assert created["api_key"] == "sk-env"
+
+
+def test_env_reference_defaults_to_unused_when_missing(monkeypatch):
+    created: dict = {}
+    _install_fake_openai(monkeypatch, created)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    llm = OpenAILLM(
+        api_key="env:OPENAI_API_KEY",
+        base_url=None,
+        plan_model="demo-plan",
+        synth_model="demo-synth",
+    )
+    llm("hello", sender="generic_plan")
+
+    assert created["api_key"] == "unused"


### PR DESCRIPTION
## Summary
- allow the demo QA OpenAI adapter to normalize API keys by honoring env references, falling back to OPENAI_API_KEY, and defaulting to a placeholder
- drop the require_api_key setting, keep the demo config API key optional, and reflect the relaxed behavior in the packaged config and docs
- expand coverage around API key resolution paths in the demo QA tests

## Testing
- python -m pytest tests/test_demo_qa_settings.py tests/test_demo_qa_settings_sources.py *(fails: missing pydantic_settings dependency is not available through the proxy in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959418f762c832fa9b3076c9ccfabc7)