### PR TITLE
Add tag-based compare command support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ NOTE  ?=
 CASE  ?=
 LIMIT ?= 50
 CHANGES ?= 10
+NEW_TAG ?=
+PATTERN ?=
 
 ONLY_FAILED_FROM ?=
 ONLY_MISSED_FROM ?=
@@ -90,7 +92,7 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
         batch batch-tag batch-failed batch-failed-from \
         batch-missed batch-missed-from batch-failed-tag batch-missed-tag \
         batch-fail-fast batch-max-fails \
-        stats history-case report-tag case-run case-open compare compare-tag
+        stats history-case report-tag report-tag-changes tags case-run case-open compare compare-tag
 
 # ==============================================================================
 # help (на русском)
@@ -128,11 +130,13 @@ help:
 	@echo "  make batch-fail-fast      - быстрый smoke (остановиться на первом фейле)"
 	@echo "  make batch-max-fails MAX_FAILS=5 - остановиться после N фейлов"
 	@echo "  make stats                - stats по последним 10 прогонов"
+	@echo "  make tags                 - список тегов (effective snapshots)"
 	@echo ""
 	@echo "Диагностика / анализ:"
 	@echo "  make history-case CASE=case_42 [TAG=...] [LIMIT=50] - история по кейсу"
 	@echo "  make report-tag TAG=...    - сводка по тегу (effective snapshot)"
 	@echo "  make report-tag-changes TAG=... [CHANGES=10] - сводка + последние изменения effective snapshot"
+	@echo "  make tags [PATTERN=*] DATA=... - показать список тегов"
 	@echo "  make case-run  CASE=case_42 - прогнать один кейс"
 	@echo "  make case-open CASE=case_42 - открыть артефакты кейса"
 	@echo ""
@@ -284,6 +288,9 @@ batch-missed-tag: ensure-runs-dir
 # stats (последние 10)
 stats: check
 	@$(CLI) stats --data "$(DATA)" --last 10
+
+tags: check
+	@$(CLI) tags list --data "$(DATA)" $(if $(strip $(PATTERN)),--pattern "$(PATTERN)",) $(if $(strip $(LIMIT)),--limit $(LIMIT),)
 
 # 8) История по кейсу (TAG опционален)
 history-case: check

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ TAG   ?=
 NOTE  ?=
 CASE  ?=
 LIMIT ?= 50
+CHANGES ?= 10
 
 ONLY_FAILED_FROM ?=
 ONLY_MISSED_FROM ?=
@@ -131,6 +132,7 @@ help:
 	@echo "Диагностика / анализ:"
 	@echo "  make history-case CASE=case_42 [TAG=...] [LIMIT=50] - история по кейсу"
 	@echo "  make report-tag TAG=...    - сводка по тегу (effective snapshot)"
+	@echo "  make report-tag-changes TAG=... [CHANGES=10] - сводка + последние изменения effective snapshot"
 	@echo "  make case-run  CASE=case_42 - прогнать один кейс"
 	@echo "  make case-open CASE=case_42 - открыть артефакты кейса"
 	@echo ""
@@ -292,6 +294,10 @@ history-case: check
 report-tag: check
 	@test -n "$(strip $(TAG))" || (echo "TAG обязателен: make report-tag TAG=..." && exit 1)
 	@$(CLI) report tag --data "$(DATA)" --tag "$(TAG)"
+
+report-tag-changes: check
+	@test -n "$(strip $(TAG))" || (echo "TAG обязателен: make report-tag-changes TAG=... [CHANGES=10]" && exit 1)
+	@$(CLI) report tag --data "$(DATA)" --tag "$(TAG)" --changes "$(CHANGES)"
 
 # 10) Дебаг 1 кейса
 case-run: check

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ NEW      ?=
 DIFF_OUT ?= $(DATA)/.runs/diff.md
 JUNIT    ?= $(DATA)/.runs/diff.junit.xml
 BASE_TAG ?= baseline
-NEW_TAG  ?= baseline_v2
 COMPARE_TAG_OUT ?= $(DATA)/.runs/diff.tags.md
 COMPARE_TAG_JUNIT ?= $(DATA)/.runs/diff.tags.junit.xml
 
@@ -137,7 +136,7 @@ help:
 	@echo ""
 	@echo "Сравнение результатов:"
 	@echo "  make compare BASE=... NEW=... [DIFF_OUT=...] [JUNIT=...]"
-	@echo "  make compare-tag BASE_TAG=... NEW_TAG=... [OUT=...] [JUNIT=...]"
+	@echo "  make compare-tag BASE_TAG=baseline NEW_TAG=... [COMPARE_TAG_OUT=...] [COMPARE_TAG_JUNIT=...]"
 	@echo ""
 	@echo "LLM конфиг:"
 	@echo "  make llm-init             - создать $(LLM_TOML) из $(LLM_TOML_EXAMPLE)"
@@ -318,6 +317,7 @@ compare-tag: OUT := $(COMPARE_TAG_OUT)
 compare-tag: JUNIT := $(COMPARE_TAG_JUNIT)
 compare-tag: check
 	@test -n "$(strip $(DATA))" || (echo "Нужно задать DATA=... (где лежит .runs)" && exit 1)
+	@test -n "$(strip $(NEW_TAG))" || (echo "Нужно задать NEW_TAG=... (например NEW_TAG=baseline_v2)" && exit 1)
 	@mkdir -p "$(DATA)/.runs"
 	@$(CLI) compare \
 	  --data "$(DATA)" \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
         llm-init llm-show llm-edit \
         chat \
         batch batch-tag batch-failed batch-failed-from \
-        batch-missed batch-missed-from batch-fail-fast batch-max-fails \
+        batch-missed batch-missed-from batch-failed-tag batch-missed-tag \
+        batch-fail-fast batch-max-fails \
         stats history-case report-tag case-run case-open compare compare-tag
 
 # ==============================================================================
@@ -121,6 +122,8 @@ help:
 	@echo "  make batch-failed         - перепрогон только упавших (baseline = latest)"
 	@echo "  make batch-failed-from ONLY_FAILED_FROM=path/results.jsonl  - only-failed от явного baseline"
 	@echo "  make batch-missed [TAG=...] - добить missed (если TAG задан — относительно effective по тегу)"
+	@echo "  make batch-failed-tag TAG=...   - добить failed/error/mismatch относительно effective snapshot тега"
+	@echo "  make batch-missed-tag TAG=...   - добить missed относительно effective snapshot тега"
 	@echo "  make batch-missed-from ONLY_MISSED_FROM=path/results.jsonl  - добить missed от явного baseline"
 	@echo "  make batch-fail-fast      - быстрый smoke (остановиться на первом фейле)"
 	@echo "  make batch-max-fails MAX_FAILS=5 - остановиться после N фейлов"
@@ -268,6 +271,14 @@ batch-fail-fast: ensure-runs-dir
 
 batch-max-fails: ensure-runs-dir
 	@$(CLI) batch --data "$(DATA)" --schema "$(SCHEMA)" --cases "$(CASES)" --out "$(OUT)" --max-fails "$(MAX_FAILS)"
+
+batch-failed-tag: ensure-runs-dir
+	@test -n "$(strip $(TAG))" || (echo "TAG обязателен: make batch-failed-tag TAG=..." && exit 1)
+	@$(CLI) batch --data "$(DATA)" --schema "$(SCHEMA)" --cases "$(CASES)" --out "$(OUT)" --tag "$(TAG)" --only-failed-effective
+
+batch-missed-tag: ensure-runs-dir
+	@test -n "$(strip $(TAG))" || (echo "TAG обязателен: make batch-missed-tag TAG=..." && exit 1)
+	@$(CLI) batch --data "$(DATA)" --schema "$(SCHEMA)" --cases "$(CASES)" --out "$(OUT)" --tag "$(TAG)" --only-missed-effective
 
 # stats (последние 10)
 stats: check

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ LIMIT ?= 50
 CHANGES ?= 10
 NEW_TAG ?=
 PATTERN ?=
+TAGS_FORMAT ?= table
+TAGS_COLOR ?= auto
 
 ONLY_FAILED_FROM ?=
 ONLY_MISSED_FROM ?=
@@ -290,7 +292,7 @@ stats: check
 	@$(CLI) stats --data "$(DATA)" --last 10
 
 tags: check
-	@$(CLI) tags list --data "$(DATA)" $(if $(strip $(PATTERN)),--pattern "$(PATTERN)",) $(if $(strip $(LIMIT)),--limit $(LIMIT),)
+	@$(CLI) tags list --data "$(DATA)" --format "$(TAGS_FORMAT)" --color "$(TAGS_COLOR)" $(if $(strip $(PATTERN)),--pattern "$(PATTERN)",) $(if $(strip $(LIMIT)),--limit $(LIMIT),)
 
 # 8) История по кейсу (TAG опционален)
 history-case: check

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ DIFF_OUT ?= $(DATA)/.runs/diff.md
 JUNIT    ?= $(DATA)/.runs/diff.junit.xml
 BASE_TAG ?= baseline
 NEW_TAG  ?= baseline_v2
-COMPARE_TAG_OUT ?= diff.md
-COMPARE_TAG_JUNIT ?= diff.junit.xml
+COMPARE_TAG_OUT ?= $(DATA)/.runs/diff.tags.md
+COMPARE_TAG_JUNIT ?= $(DATA)/.runs/diff.tags.junit.xml
 
 MAX_FAILS ?= 5
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ BASE     ?=
 NEW      ?=
 DIFF_OUT ?= $(DATA)/.runs/diff.md
 JUNIT    ?= $(DATA)/.runs/diff.junit.xml
+BASE_TAG ?= baseline
+NEW_TAG  ?= baseline_v2
+COMPARE_TAG_OUT ?= diff.md
+COMPARE_TAG_JUNIT ?= diff.junit.xml
 
 MAX_FAILS ?= 5
 
@@ -85,7 +89,7 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
         chat \
         batch batch-tag batch-failed batch-failed-from \
         batch-missed batch-missed-from batch-fail-fast batch-max-fails \
-        stats history-case report-tag case-run case-open compare
+        stats history-case report-tag case-run case-open compare compare-tag
 
 # ==============================================================================
 # help (на русском)
@@ -130,6 +134,7 @@ help:
 	@echo ""
 	@echo "Сравнение результатов:"
 	@echo "  make compare BASE=... NEW=... [DIFF_OUT=...] [JUNIT=...]"
+	@echo "  make compare-tag BASE_TAG=... NEW_TAG=... [OUT=...] [JUNIT=...]"
 	@echo ""
 	@echo "LLM конфиг:"
 	@echo "  make llm-init             - создать $(LLM_TOML) из $(LLM_TOML_EXAMPLE)"
@@ -296,4 +301,16 @@ compare: check
 	  --base "$(BASE)" \
 	  --new  "$(NEW)" \
 	  --out  "$(DIFF_OUT)" \
+	  --junit "$(JUNIT)"
+
+compare-tag: OUT := $(COMPARE_TAG_OUT)
+compare-tag: JUNIT := $(COMPARE_TAG_JUNIT)
+compare-tag: check
+	@test -n "$(strip $(DATA))" || (echo "Нужно задать DATA=... (где лежит .runs)" && exit 1)
+	@mkdir -p "$(DATA)/.runs"
+	@$(CLI) compare \
+	  --data "$(DATA)" \
+	  --base-tag "$(BASE_TAG)" \
+	  --new-tag "$(NEW_TAG)" \
+	  --out  "$(OUT)" \
 	  --junit "$(JUNIT)"

--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -85,7 +85,9 @@ python -m examples.demo_qa.cli batch \
 
 * `--fail-on (error|bad|unchecked|any|skipped)`, `--max-fails`, `--fail-fast`, `--require-assert` — остановка/код выхода (0/1/2) и строгость проверок.
 * `--only-failed` / `--only-failed-from PATH` — перепрогон только плохих кейсов (baseline = latest либо явно заданный results).
+* `--only-failed-effective` — перепрогон только плохих кейсов относительно effective snapshot для `--tag` (без ручного поиска baseline).
 * `--only-missed` / `--only-missed-from PATH` — “добить” только те кейсы, которые отсутствуют в baseline results (удобно после Ctrl-C).
+* `--only-missed-effective` — “добить” кейсы, которых нет в effective snapshot для `--tag`.
 * `--tag TAG` / `--note "..."` — пометить прогон как часть эксперимента. Для `--tag` поддерживается “effective snapshot”: результаты по тегу накапливаются инкрементально, так что `--only-failed/--only-missed` по тегу корректно работают даже после частичных прогонов.
 * `--plan-only` — строить планы без выполнения.
 
@@ -100,7 +102,7 @@ python -m examples.demo_qa.cli batch \
 * `python -m examples.demo_qa.cli report tag --data <DATA_DIR> --tag <TAG>` — сводка по “effective” результатам тега.
 * `python -m examples.demo_qa.cli report run --data <DATA_DIR> --run runs/latest` — сводка по конкретному run.
 * `python -m examples.demo_qa.cli history case <id> --data <DATA_DIR> [--tag <TAG>]` — история по кейсу.
-* `python -m examples.demo_qa.cli compare --base <PATH> --new <PATH> [--out ... --junit ...]` — сравнить два результата по путям.
+* `python -m examples.demo_qa.cli compare --base <PATH> --new <PATH> [--out ... --junit ... --format md|table|json --color auto|always|never]` — сравнить два результата по путям (табличный и JSON форматы удобны для CI/терминала).
 * `python -m examples.demo_qa.cli compare --data <DATA_DIR> --base-tag <TAG1> --new-tag <TAG2> [...]` — сравнить “effective snapshot” двух тегов без явных путей (работает и для неполных прогонов).
 
 ### Удобные алиасы (bash/zsh)
@@ -122,6 +124,8 @@ dq() { python -m examples.demo_qa.cli "$@"; }
 dq-batch()  { dq batch  --data "$DQ_DATA" --schema "$DQ_SCHEMA" --cases "$DQ_CASES" --out "$DQ_OUT" "$@"; }
 dq-failed() { dq-batch --only-failed "$@"; }
 dq-missed() { dq-batch --only-missed "$@"; }
+dq-failed-effective()  { dq-batch --tag "$DQ_TAG" --only-failed-effective "$@"; }
+dq-missed-effective()  { dq-batch --tag "$DQ_TAG" --only-missed-effective "$@"; }
 
 # Tagged (effective) workflow
 dq-batch-tag()  { dq-batch --tag "$DQ_TAG" "$@"; }

--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -100,6 +100,8 @@ python -m examples.demo_qa.cli batch \
 * `python -m examples.demo_qa.cli report tag --data <DATA_DIR> --tag <TAG>` — сводка по “effective” результатам тега.
 * `python -m examples.demo_qa.cli report run --data <DATA_DIR> --run runs/latest` — сводка по конкретному run.
 * `python -m examples.demo_qa.cli history case <id> --data <DATA_DIR> [--tag <TAG>]` — история по кейсу.
+* `python -m examples.demo_qa.cli compare --base <PATH> --new <PATH> [--out ... --junit ...]` — сравнить два результата по путям.
+* `python -m examples.demo_qa.cli compare --data <DATA_DIR> --base-tag <TAG1> --new-tag <TAG2> [...]` — сравнить “effective snapshot” двух тегов без явных путей (работает и для неполных прогонов).
 
 ### Удобные алиасы (bash/zsh)
 
@@ -131,6 +133,8 @@ dq-stats()   { dq stats  --data "$DQ_DATA" "$@"; }
 dq-report()  { dq report tag --data "$DQ_DATA" --tag "$DQ_TAG" "$@"; }
 dq-run()     { dq report run --data "$DQ_DATA" --run "${1:-runs/latest}"; }
 dq-hist()    { dq history case "$1" --data "$DQ_DATA" --tag "$DQ_TAG" "${@:2}"; }
+dq-compare() { dq compare --base "$1" --new "$2" "${@:3}"; }
+dq-compare-tag() { dq compare --data "$DQ_DATA" --base-tag "${1:-baseline}" --new-tag "${2:-baseline_v2}" "${@:3}"; }
 
 # Дебаг кейса
 dq-case()    { dq case run "$1" --cases "$DQ_CASES" --data "$DQ_DATA" --schema "$DQ_SCHEMA" "${@:2}"; }

--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -138,7 +138,7 @@ dq-report()  { dq report tag --data "$DQ_DATA" --tag "$DQ_TAG" "$@"; }
 dq-run()     { dq report run --data "$DQ_DATA" --run "${1:-runs/latest}"; }
 dq-hist()    { dq history case "$1" --data "$DQ_DATA" --tag "$DQ_TAG" "${@:2}"; }
 dq-compare() { dq compare --base "$1" --new "$2" "${@:3}"; }
-dq-compare-tag() { dq compare --data "$DQ_DATA" --base-tag "${1:-baseline}" --new-tag "${2:-baseline_v2}" "${@:3}"; }
+dq-compare-tag() { dq compare --data "$DQ_DATA" --base-tag "${1:-baseline}" --new-tag "$2" "${@:3}"; }
 
 # Дебаг кейса
 dq-case()    { dq case run "$1" --cases "$DQ_CASES" --data "$DQ_DATA" --schema "$DQ_SCHEMA" "${@:2}"; }

--- a/README_demo_qa.md
+++ b/README_demo_qa.md
@@ -99,7 +99,7 @@ python -m examples.demo_qa.cli batch \
 Отчёты и история:
 
 * `python -m examples.demo_qa.cli stats --data <DATA_DIR> --last 10` — последние прогоны.
-* `python -m examples.demo_qa.cli report tag --data <DATA_DIR> --tag <TAG>` — сводка по “effective” результатам тега.
+* `python -m examples.demo_qa.cli report tag --data <DATA_DIR> --tag <TAG> [--changes 5 --verbose]` — сводка по “effective” результатам тега (короткая по умолчанию, можно показать историю изменений).
 * `python -m examples.demo_qa.cli report run --data <DATA_DIR> --run runs/latest` — сводка по конкретному run.
 * `python -m examples.demo_qa.cli history case <id> --data <DATA_DIR> [--tag <TAG>]` — история по кейсу.
 * `python -m examples.demo_qa.cli compare --base <PATH> --new <PATH> [--out ... --junit ... --format md|table|json --color auto|always|never]` — сравнить два результата по путям (табличный и JSON форматы удобны для CI/терминала).

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import uuid
@@ -40,6 +41,7 @@ from .runs.effective import (
 )
 from .runs.io import write_results
 from .runs.layout import (
+    _effective_paths,
     _load_latest_any_results,
     _load_latest_results,
     _load_latest_run,
@@ -1383,9 +1385,90 @@ def handle_stats(args) -> int:
     return 0
 
 
+def _candidate_artifacts_dirs(data_arg: Path | None) -> list[Path]:
+    bases: list[Path] = []
+    if data_arg is not None:
+        bases.append(data_arg)
+    env_data = os.environ.get("DATA")
+    if env_data:
+        bases.append(Path(env_data))
+    env_dq_data = os.environ.get("DQ_DATA")
+    if env_dq_data:
+        bases.append(Path(env_dq_data))
+    if not bases:
+        bases.append(Path.cwd())
+    artifacts_dirs: list[Path] = []
+    seen: set[Path] = set()
+    for base in bases:
+        candidate = base / ".runs"
+        if candidate not in seen:
+            seen.add(candidate)
+            artifacts_dirs.append(candidate)
+    return artifacts_dirs
+
+
+def _resolve_effective_results_for_tag(
+    tag: str, *, candidates: Iterable[Path], preferred: Path | None = None
+) -> tuple[Optional[Path], Optional[Path], list[Path]]:
+    attempted: list[Path] = []
+    ordered: list[Path] = []
+    if preferred is not None:
+        ordered.append(preferred)
+    for candidate in candidates:
+        if preferred is not None and candidate == preferred:
+            continue
+        ordered.append(candidate)
+    for artifacts_dir in ordered:
+        results_path, meta_path = _effective_paths(artifacts_dir, tag)
+        if results_path.exists() and meta_path.exists():
+            return results_path, artifacts_dir, attempted
+        attempted.append(results_path.parent)
+    return None, None, attempted
+
+
+def _render_missing_effective_error(tag: str, attempted: list[Path]) -> str:
+    message = f"No effective snapshot found for tag {tag!r}. Run a tagged batch to create it."
+    if attempted:
+        locations = ", ".join(str(path) for path in attempted)
+        message = f"{message} Looked in: {locations}."
+    return message
+
+
 def handle_compare(args) -> int:
-    base_path = Path(args.base)
-    new_path = Path(args.new)
+    if args.base and args.base_tag:
+        print("Use either --base or --base-tag (not both).", file=sys.stderr)
+        return 2
+    if args.new and args.new_tag:
+        print("Use either --new or --new-tag (not both).", file=sys.stderr)
+        return 2
+
+    base_path: Path | None = Path(args.base) if args.base else None
+    new_path: Path | None = Path(args.new) if args.new else None
+
+    artifacts_candidates: list[Path] = []
+    preferred_artifacts: Path | None = None
+    if args.base_tag or args.new_tag:
+        artifacts_candidates = _candidate_artifacts_dirs(args.data)
+
+    if args.base_tag:
+        base_path, preferred_artifacts, attempted = _resolve_effective_results_for_tag(
+            args.base_tag, candidates=artifacts_candidates
+        )
+        if base_path is None:
+            print(_render_missing_effective_error(args.base_tag, attempted), file=sys.stderr)
+            return 2
+    if args.new_tag:
+        new_path, _, attempted = _resolve_effective_results_for_tag(
+            args.new_tag, candidates=artifacts_candidates, preferred=preferred_artifacts
+        )
+        if new_path is None:
+            print(_render_missing_effective_error(args.new_tag, attempted), file=sys.stderr)
+            return 2
+
+    if base_path is None or new_path is None:
+        print("Provide --base/--new paths or --base-tag/--new-tag tags to compare.", file=sys.stderr)
+        return 2
+
     if not base_path.exists() or not new_path.exists():
         print("Base or new results file not found.", file=sys.stderr)
         return 2

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -590,6 +590,12 @@ def render_table(compare: DiffReport, *, use_color: bool) -> str:
     base_total = compare.get("base_total_cases", base_counts.get("total", 0))
     new_total = compare.get("new_total_cases", new_counts.get("total", 0))
     delta_bad = compare.get("new_bad_total", 0) - compare.get("base_bad_total", 0)
+    base_med = compare.get("base_median")
+    new_med = compare.get("new_median")
+    med_delta = compare.get("median_delta")
+    base_avg = compare.get("base_avg")
+    new_avg = compare.get("new_avg")
+    avg_delta = compare.get("avg_delta")
     lines: list[str] = []
     lines.append("Summary:")
     lines.append(
@@ -602,9 +608,20 @@ def render_table(compare: DiffReport, *, use_color: bool) -> str:
         "  Δ    : "
         f"ok={_format_delta(counts_delta.get('ok'), positive_good=True, use_color=use_color)} "
         f"bad={_format_delta(delta_bad, positive_good=False, use_color=use_color)} "
+        f"error={_format_delta(counts_delta.get('error'), positive_good=False, use_color=use_color)} "
+        f"mismatch={_format_delta(counts_delta.get('mismatch'), positive_good=False, use_color=use_color)} "
+        f"failed={_format_delta(counts_delta.get('failed'), positive_good=False, use_color=use_color)} "
         f"unchecked={_format_delta(counts_delta.get('unchecked'), positive_good=False, use_color=use_color)} "
         f"total={_format_delta(counts_delta.get('total'), positive_good=True, use_color=use_color)}"
     )
+    if base_med is not None or new_med is not None:
+        lines.append(
+            f"  Median total time: base={base_med if base_med is not None else 'n/a'}s new={new_med if new_med is not None else 'n/a'}s Δ={_format_delta(med_delta, positive_good=False, use_color=use_color)}"
+        )
+    if base_avg is not None or new_avg is not None:
+        lines.append(
+            f"  Avg total time:    base={base_avg if base_avg is not None else 'n/a'}s new={new_avg if new_avg is not None else 'n/a'}s Δ={_format_delta(avg_delta, positive_good=False, use_color=use_color)}"
+        )
     lines.append("")
     base_only_count = compare.get("base_only_count", 0)
     new_only_count = compare.get("new_only_count", 0)
@@ -1611,7 +1628,7 @@ def handle_compare(args) -> int:
     elif format_mode == "table":
         report = render_table(comparison, use_color=stdout_color)
         if out_path:
-            file_report = render_table(comparison, use_color=_should_use_color(color_mode, stream=sys.stdout, force_plain=True))
+            file_report = render_table(comparison, use_color=False)
     elif format_mode == "json":
         report = render_json(comparison)
         file_report = report

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -599,6 +599,28 @@ def _select_cases_for_rerun(
 
 
 def handle_batch(args) -> int:
+    only_failed_effective = bool(getattr(args, "only_failed_effective", False))
+    only_missed_effective = bool(getattr(args, "only_missed_effective", False))
+    if only_failed_effective and args.only_failed:
+        print("Use either --only-failed or --only-failed-effective (not both).", file=sys.stderr)
+        return 2
+    if only_missed_effective and args.only_missed:
+        print("Use either --only-missed or --only-missed-effective (not both).", file=sys.stderr)
+        return 2
+    if only_failed_effective and args.only_failed_from:
+        print("--only-failed-effective is not compatible with --only-failed-from.", file=sys.stderr)
+        return 2
+    if only_missed_effective and args.only_missed_from:
+        print("--only-missed-effective is not compatible with --only-missed-from.", file=sys.stderr)
+        return 2
+    if (only_failed_effective or only_missed_effective) and not args.tag:
+        print("--tag is required when using --only-failed-effective/--only-missed-effective.", file=sys.stderr)
+        return 2
+    if only_failed_effective:
+        args.only_failed = True
+    if only_missed_effective:
+        args.only_missed = True
+
     started_at = datetime.datetime.now(datetime.timezone.utc)
     run_id = uuid.uuid4().hex[:8]
     interrupted = False

--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -51,6 +51,7 @@ from .runs.layout import (
 from .runs.scope import _scope_hash, _scope_payload
 from .settings import load_settings
 from .utils import dump_json
+from .term import color as term_color, fmt_num, fmt_pct, render_table as render_text_table, should_use_color, truncate
 
 
 def write_summary(out_path: Path, summary: dict) -> Path:
@@ -542,33 +543,15 @@ def render_markdown(compare: DiffReport, out_path: Optional[Path]) -> str:
     return content
 
 
-ANSI = {
-    "reset": "\x1b[0m",
-    "red": "\x1b[31m",
-    "green": "\x1b[32m",
-    "yellow": "\x1b[33m",
-    "gray": "\x1b[90m",
-}
-
-
-def _color(text: str, color: str, *, use_color: bool) -> str:
-    if not use_color:
-        return text
-    prefix = ANSI.get(color)
-    if not prefix:
-        return text
-    return f"{prefix}{text}{ANSI['reset']}"
-
-
 def _format_delta(value: int | float | None, *, positive_good: bool, use_color: bool) -> str:
     if value is None:
         return "n/a"
     sign = "+" if value >= 0 else ""
     text = f"{sign}{value}"
     if value == 0:
-        return _color(text, "gray", use_color=use_color)
+        return term_color(text, "gray", use_color=use_color)
     is_improvement = (value > 0 and positive_good) or (value < 0 and not positive_good)
-    return _color(text, "green" if is_improvement else "red", use_color=use_color)
+    return term_color(text, "green" if is_improvement else "red", use_color=use_color)
 
 
 def _top_list(label: str, entries: list[DiffCaseChange], *, use_color: bool) -> list[str]:
@@ -628,7 +611,7 @@ def render_table(compare: DiffReport, *, use_color: bool) -> str:
     lines.append("Coverage:")
     lines.append(f"  base_total_cases={base_total} new_total_cases={new_total}")
     lines.append(
-        f"  only_in_base={_color(str(base_only_count), 'yellow', use_color=use_color)} only_in_new={_color(str(new_only_count), 'yellow', use_color=use_color)}"
+        f"  only_in_base={term_color(str(base_only_count), 'yellow', use_color=use_color)} only_in_new={term_color(str(new_only_count), 'yellow', use_color=use_color)}"
     )
     lines.append("")
     lines.extend(_top_list("Top regressions:", compare["new_fail"], use_color=use_color))
@@ -1482,16 +1465,6 @@ def _format_history_timestamp(entry: dict) -> str:
     return ""
 
 
-def _truncate(text: str, width: int) -> str:
-    if width <= 0:
-        return ""
-    if len(text) <= width:
-        return text
-    if width == 1:
-        return text[:1]
-    return text[: width - 1] + "…"
-
-
 def _status_color(status: str) -> str | None:
     status_upper = status.upper()
     if status_upper in {"SUCCESS", "OK"}:
@@ -1512,10 +1485,6 @@ def _metric_color(value: float | int | None, *, invert: bool = False) -> str | N
     if value >= (0.6 if not invert else 1):
         return "yellow"
     return "red"
-
-
-def _format_percentage(value: float | None) -> str:
-    return f"{value*100:.1f}%" if value is not None else "n/a"
 
 
 def _build_stat_row(entry: Mapping[str, object]) -> dict[str, object]:
@@ -1551,77 +1520,36 @@ def _print_stats(entries: list[dict], *, use_color: bool) -> None:
         print("No history entries found.")
         return
 
-    columns = [
-        {"key": "timestamp", "header": "timestamp", "align": "<", "max": 25, "color": None},
-        {"key": "run_id", "header": "run_id", "align": "<", "max": 14, "color": None},
-        {"key": "status", "header": "status", "align": "<", "max": 12, "color": _status_color},
-        {"key": "tag", "header": "tag", "align": "<", "max": 14, "color": None},
-        {"key": "note", "header": "note", "align": "<", "max": 70, "color": None},
-        {"key": "bad", "header": "bad", "align": ">", "max": None, "color": lambda v: "red" if v.strip().isdigit() and int(v) > 0 else None},
-        {"key": "pass_rate", "header": "pass%", "align": ">", "max": None, "color": None},
-        {"key": "coverage", "header": "cov%", "align": ">", "max": None, "color": None},
-    ]
-
-    rows: list[dict] = []
+    headers = ["timestamp", "run_id", "status", "tag", "note", "bad", "pass%", "cov%"]
+    rows: list[list[str]] = []
     for entry in entries:
         stat = _build_stat_row(entry)
+        bad_value = stat["bad"]
+        bad_display = fmt_num(bad_value)
+        bad_color = "red" if isinstance(bad_value, (int, float)) and bad_value > 0 else "green" if bad_value == 0 else None
+        pass_rate_display = fmt_pct(stat["pass_rate"])
+        coverage_display = fmt_pct(stat["coverage"])
+        status_color = _status_color(str(stat["status"]))
         rows.append(
-            {
-                "timestamp": stat["timestamp"],
-                "run_id": stat["run_id"],
-                "status": stat["status"],
-                "tag": stat["tag"],
-                "note": stat["note"],
-                "bad": "n/a" if stat["bad"] is None else str(stat["bad"]),
-                "bad_raw": stat["bad"],
-                "pass_rate": _format_percentage(stat["pass_rate"]),
-                "pass_rate_raw": stat["pass_rate"],
-                "coverage": _format_percentage(stat["coverage"]),
-                "coverage_raw": stat["coverage"],
-            }
+            [
+                truncate(stat["timestamp"], 25),
+                truncate(stat["run_id"], 14),
+                term_color(str(stat["status"]), status_color, use_color=use_color),
+                truncate(stat["tag"], 14),
+                truncate(stat["note"], 70),
+                term_color(bad_display, bad_color, use_color=use_color),
+                term_color(pass_rate_display, _metric_color(stat["pass_rate"]), use_color=use_color),
+                term_color(coverage_display, _metric_color(stat["coverage"]), use_color=use_color),
+            ]
         )
-
-    widths: dict[str, int] = {}
-    for col in columns:
-        max_width = col.get("max")
-        col_key = col["key"]
-        widths[col_key] = len(col["header"])
-        for row in rows:
-            value = row[col_key]
-            if max_width:
-                value = _truncate(value, max_width)
-            widths[col_key] = max(widths[col_key], len(value))
-
-    header_parts = []
-    for col in columns:
-        col_key = col["key"]
-        header_parts.append(f"{col['header']:{col['align']}{widths[col_key]}}")
-    print("  ".join(header_parts))
-
-    for row in rows:
-        parts: list[str] = []
-        for col in columns:
-            col_key = col["key"]
-            raw_value = row.get(f"{col_key}_raw", None)
-            value = row[col_key]
-            if col.get("max"):
-                value = _truncate(value, col["max"])
-            formatted = f"{value:{col['align']}{widths[col_key]}}"
-            color_func = col.get("color")
-            color_name = None
-            if callable(color_func):
-                if col_key in {"pass_rate", "coverage"}:
-                    color_name = _metric_color(raw_value)
-                elif col_key == "bad":
-                    color_name = color_func(formatted)
-                else:
-                    color_name = color_func(formatted.strip())  # type: ignore[arg-type]
-            elif col_key in {"pass_rate", "coverage"}:
-                color_name = _metric_color(raw_value)
-            if col_key == "bad" and color_name is None and isinstance(raw_value, (int, float)) and raw_value == 0:
-                color_name = "green"
-            parts.append(_color(formatted, color_name, use_color=use_color))
-        print("  ".join(parts))
+    print(
+        render_text_table(
+            headers,
+            rows,
+            align_right={5, 6, 7},
+            col_max={0: 25, 1: 14, 3: 14, 4: 70},
+        )
+    )
 
 
 def _render_stats_json(entries: list[dict], *, include_config_hash: bool) -> str:
@@ -1657,7 +1585,7 @@ def handle_stats(args) -> int:
     entries = _load_history(history_path)
     format_mode = getattr(args, "format", "table")
     color_mode = getattr(args, "color", "auto")
-    use_color = _should_use_color(color_mode, stream=sys.stdout)
+    use_color = should_use_color(color_mode, stream=sys.stdout)
     include_config_hash = bool(args.group_by == "config_hash")
     if format_mode == "json":
         rows: list[dict] = []
@@ -1715,16 +1643,6 @@ def _render_missing_effective_error(tag: str, attempted: list[Path]) -> str:
     return message
 
 
-def _should_use_color(mode: str, *, stream, force_plain: bool = False) -> bool:
-    if force_plain:
-        return False
-    if mode == "always":
-        return True
-    if mode == "never":
-        return False
-    return bool(getattr(stream, "isatty", lambda: False)())
-
-
 def handle_compare(args) -> int:
     if args.base and args.base_tag:
         print("Use either --base or --base-tag (not both).", file=sys.stderr)
@@ -1773,7 +1691,7 @@ def handle_compare(args) -> int:
     out_path = Path(args.out) if args.out is not None else None
     format_mode = getattr(args, "format", "md")
     color_mode = getattr(args, "color", "auto")
-    stdout_color = _should_use_color(color_mode, stream=sys.stdout, force_plain=bool(out_path))
+    stdout_color = False if out_path else should_use_color(color_mode, stream=sys.stdout)
 
     report = ""
     file_report = None

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -171,6 +171,7 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--history", type=Path, default=None, help="Path to history.jsonl (default: <data>/.runs/history.jsonl)")
     stats_p.add_argument("--last", type=int, default=10, help="How many recent runs to show")
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
+    stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
 
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -182,6 +182,8 @@ def build_parser() -> argparse.ArgumentParser:
     new_group.add_argument("--new-tag", type=str, help="Use effective snapshot for this tag as new results")
     compare_p.add_argument("--out", type=Path, default=None, help="Path to markdown report to write")
     compare_p.add_argument("--junit", type=Path, default=None, help="Path to junit xml output")
+    compare_p.add_argument("--format", choices=["md", "table", "json"], default="md", help="Output format")
+    compare_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for table output")
     compare_p.add_argument(
         "--fail-on",
         choices=["error", "bad", "unchecked", "any", "skipped"],

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -208,6 +208,8 @@ def build_parser() -> argparse.ArgumentParser:
     tag_report.add_argument("--tag", type=str, required=True, help="Tag to report")
     tag_report.add_argument("--verbose", action="store_true", help="Print full counts and summary_by_tag")
     tag_report.add_argument("--changes", type=int, default=1, help="How many effective changes to show (default: 1)")
+    tag_report.add_argument("--format", choices=["plain", "table"], default="table", help="Output format")
+    tag_report.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode")
     run_report = report_sub.add_parser("run", help="Report a specific run folder or run_id")
     run_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
     run_report.add_argument("--run", type=Path, required=True, help="Run dir or run_id under runs/")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -164,10 +164,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")
-    compare_p.add_argument("--base", type=Path, required=False, help="Path to baseline results.jsonl")
-    compare_p.add_argument("--new", type=Path, required=False, help="Path to new results.jsonl")
-    compare_p.add_argument("--base-tag", type=str, default=None, help="Use effective snapshot for this tag as baseline")
-    compare_p.add_argument("--new-tag", type=str, default=None, help="Use effective snapshot for this tag as new results")
+    base_group = compare_p.add_mutually_exclusive_group(required=False)
+    base_group.add_argument("--base", type=Path, help="Path to baseline results.jsonl")
+    base_group.add_argument("--base-tag", type=str, help="Use effective snapshot for this tag as baseline")
+    new_group = compare_p.add_mutually_exclusive_group(required=False)
+    new_group.add_argument("--new", type=Path, help="Path to new results.jsonl")
+    new_group.add_argument("--new-tag", type=str, help="Use effective snapshot for this tag as new results")
     compare_p.add_argument("--out", type=Path, default=None, help="Path to markdown report to write")
     compare_p.add_argument("--junit", type=Path, default=None, help="Path to junit xml output")
     compare_p.add_argument(

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -67,6 +67,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Run only cases missing in the provided results.jsonl (or latest if omitted)",
     )
+    batch_p.add_argument(
+        "--only-missed-effective",
+        action="store_true",
+        help="Run only cases missing from the effective snapshot for --tag",
+    )
     batch_p.add_argument("--out", type=Path, required=False, default=None, help="Path to results jsonl")
     batch_p.add_argument("--artifacts-dir", type=Path, default=None, help="Where to store per-case artifacts")
     batch_p.add_argument("--enable-semantic", action="store_true")
@@ -91,6 +96,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run only cases that failed/mismatched/errored in a previous results.jsonl",
     )
     batch_p.add_argument("--only-failed", action="store_true", help="Use latest run for --only-failed-from automatically")
+    batch_p.add_argument(
+        "--only-failed-effective",
+        action="store_true",
+        help="Run only failed/error/mismatch cases from the effective snapshot for --tag",
+    )
     batch_p.add_argument(
         "--no-overlay",
         action="store_true",

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -206,6 +206,8 @@ def build_parser() -> argparse.ArgumentParser:
     tag_report = report_sub.add_parser("tag", help="Report current effective snapshot for a tag")
     tag_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
     tag_report.add_argument("--tag", type=str, required=True, help="Tag to report")
+    tag_report.add_argument("--verbose", action="store_true", help="Print full counts and summary_by_tag")
+    tag_report.add_argument("--changes", type=int, default=1, help="How many effective changes to show (default: 1)")
     run_report = report_sub.add_parser("run", help="Report a specific run folder or run_id")
     run_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
     run_report.add_argument("--run", type=Path, required=True, help="Run dir or run_id under runs/")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -173,7 +173,12 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--last", type=int, default=10, help="How many recent runs to show")
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
     stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
-    stats_p.add_argument("--format", choices=["table", "json"], default="table", help="Output format for stats")
+    stats_p.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format for stats (JSON is a list; config_hash included when grouped)",
+    )
 
     tags_p = sub.add_parser("tags", help="Tag utilities")
     tags_sub = tags_p.add_subparsers(dest="tags_command", required=True)

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -163,8 +163,11 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
 
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
-    compare_p.add_argument("--base", type=Path, required=True, help="Path to baseline results.jsonl")
-    compare_p.add_argument("--new", type=Path, required=True, help="Path to new results.jsonl")
+    compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")
+    compare_p.add_argument("--base", type=Path, required=False, help="Path to baseline results.jsonl")
+    compare_p.add_argument("--new", type=Path, required=False, help="Path to new results.jsonl")
+    compare_p.add_argument("--base-tag", type=str, default=None, help="Use effective snapshot for this tag as baseline")
+    compare_p.add_argument("--new-tag", type=str, default=None, help="Use effective snapshot for this tag as new results")
     compare_p.add_argument("--out", type=Path, default=None, help="Path to markdown report to write")
     compare_p.add_argument("--junit", type=Path, default=None, help="Path to junit xml output")
     compare_p.add_argument(

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -179,9 +179,11 @@ def build_parser() -> argparse.ArgumentParser:
     tags_sub = tags_p.add_subparsers(dest="tags_command", required=True)
     tags_list = tags_sub.add_parser("list", help="List known tags")
     tags_list.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
-    tags_list.add_argument("--pattern", type=str, default=None, help="Glob or regex to filter tag names")
+    tags_list.add_argument("--pattern", type=str, default=None, help="Glob or re:<regex> to filter tag names")
     tags_list.add_argument("--limit", type=int, default=None, help="Maximum number of tags to display")
     tags_list.add_argument("--sort", choices=["name", "updated"], default="updated", help="Sort order")
+    tags_list.add_argument("--format", choices=["table", "json"], default="table", help="Output format")
+    tags_list.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for table output")
 
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -26,6 +26,7 @@ from .batch import (  # noqa: E402
 )  # noqa: E402
 from .commands.history import handle_history_case  # noqa: E402
 from .commands.report import handle_report_run, handle_report_tag  # noqa: E402
+from .commands.tags import handle_tags_list  # noqa: E402
 from .data_gen import generate_and_save  # noqa: E402
 
 
@@ -173,6 +174,14 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
     stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
 
+    tags_p = sub.add_parser("tags", help="Tag utilities")
+    tags_sub = tags_p.add_subparsers(dest="tags_command", required=True)
+    tags_list = tags_sub.add_parser("list", help="List known tags")
+    tags_list.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    tags_list.add_argument("--pattern", type=str, default=None, help="Glob or regex to filter tag names")
+    tags_list.add_argument("--limit", type=int, default=None, help="Maximum number of tags to display")
+    tags_list.add_argument("--sort", choices=["name", "updated"], default="updated", help="Sort order")
+
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")
     base_group = compare_p.add_mutually_exclusive_group(required=False)
@@ -245,6 +254,11 @@ def main() -> None:
     elif args.command == "history":
         if args.history_command == "case":
             code = handle_history_case(args)
+        else:
+            code = 1
+    elif args.command == "tags":
+        if args.tags_command == "list":
+            code = handle_tags_list(args)
         else:
             code = 1
     elif args.command == "report":

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -173,6 +173,7 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--last", type=int, default=10, help="How many recent runs to show")
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
     stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
+    stats_p.add_argument("--format", choices=["table", "json"], default="table", help="Output format for stats")
 
     tags_p = sub.add_parser("tags", help="Tag utilities")
     tags_sub = tags_p.add_subparsers(dest="tags_command", required=True)

--- a/examples/demo_qa/commands/report.py
+++ b/examples/demo_qa/commands/report.py
@@ -6,8 +6,34 @@ from pathlib import Path
 from typing import Optional
 
 from ..runner import bad_statuses, load_results, summarize
-from ..runs.effective import _load_effective_diff, _load_effective_diff_history
+from ..runs.effective import _load_effective_diff_history
 from ..runs.layout import _effective_paths
+
+
+ANSI = {
+    "reset": "\x1b[0m",
+    "red": "\x1b[31m",
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "gray": "\x1b[90m",
+}
+
+
+def _color(text: str, color: str | None, *, use_color: bool) -> str:
+    if not use_color or not color:
+        return text
+    prefix = ANSI.get(color)
+    if not prefix:
+        return text
+    return f"{prefix}{text}{ANSI['reset']}"
+
+
+def _should_use_color(mode: str, *, stream) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
 
 
 def _resolve_run_dir_arg(run_arg: Path, artifacts_dir: Path) -> Optional[Path]:
@@ -55,7 +81,62 @@ def _reason_text(res) -> str:
     return ""
 
 
+def _format_pass_rate(value: float | None) -> str:
+    return f"{value*100:.1f}%" if value is not None else "n/a"
+
+
+def _format_table_rows(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    align_right: set[str],
+    use_color: bool,
+    color_map: dict[str, str] | None = None,
+    indent: str = "",
+    label: str | None = None,
+    label_width: int = 0,
+) -> list[str]:
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def _format_row(row: list[str], *, colorize: bool) -> str:
+        cells: list[str] = []
+        for idx, cell in enumerate(row):
+            header = headers[idx]
+            formatted = cell.rjust(widths[idx]) if header in align_right else cell.ljust(widths[idx])
+            color = (color_map or {}).get(header) if colorize else None
+            if color:
+                formatted = _color(formatted, color, use_color=use_color)
+            cells.append(formatted)
+        return "  ".join(cells)
+
+    lines: list[str] = []
+    label_prefix = ""
+    if label is not None:
+        label_prefix = f"{label:<{label_width}}" if label_width else label
+        lines.append(f"{indent}{label_prefix}  {_format_row(headers, colorize=False)}")
+        label_prefix = f"{'':<{label_width}}" if label_width else ""
+    for row in rows:
+        lines.append(f"{indent}{label_prefix}  {_format_row(row, colorize=True)}")
+    return lines
+
+
+def _color_for_metric(name: str) -> str | None:
+    if name == "ok":
+        return "green"
+    if name in {"bad", "error", "failed"}:
+        return "red"
+    if name in {"mismatch", "unchecked"}:
+        return "yellow"
+    return None
+
+
 def handle_report_tag(args) -> int:
+    format_mode = getattr(args, "format", "table")
+    color_mode = getattr(args, "color", "auto")
+    use_color = _should_use_color(color_mode, stream=sys.stdout)
     artifacts_dir = args.data / ".runs"
     eff_results_path, eff_meta_path = _effective_paths(artifacts_dir, args.tag)
     if not eff_results_path.exists() or not eff_meta_path.exists():
@@ -74,12 +155,11 @@ def handle_report_tag(args) -> int:
     counts = meta.get("counts") or summarize(results.values())
     fail_on = meta.get("fail_on", "bad")
     require_assert = bool(meta.get("require_assert", False))
-    print(f"Tag: {args.tag}")
     planned = meta.get("planned_total")
     executed = meta.get("executed_total")
     missed = meta.get("missed_total")
-    executed_pct = f"{(executed / planned * 100):.1f}%" if planned else "n/a"
-    print(f"Coverage: planned={planned} executed={executed} missed={missed} ({executed_pct} executed)")
+    executed_pct_value = (executed / planned * 100) if planned else None
+    executed_pct = f"{executed_pct_value:.1f}%" if executed_pct_value is not None else "n/a"
     ok = counts.get("ok", 0)
     mismatch = counts.get("mismatch", 0)
     failed = counts.get("failed", 0)
@@ -88,13 +168,72 @@ def handle_report_tag(args) -> int:
     skipped = counts.get("skipped", 0)
     non_skipped = (counts.get("total", 0) or 0) - (skipped or 0)
     pass_rate = (ok / non_skipped) if non_skipped else None
-    pass_rate_display = f"{pass_rate*100:.1f}%" if pass_rate is not None else "n/a"
+    pass_rate_display = _format_pass_rate(pass_rate)
     bad = bad_statuses(str(fail_on), require_assert)
     bad_total = sum(counts.get(status, 0) or 0 for status in bad)
-    print(f"Quality: ok={ok} mismatch={mismatch} failed={failed} error={error} unchecked={unchecked} bad={bad_total} pass_rate={pass_rate_display}")
-    if args.verbose:
-        print("Counts:", counts)
     summary_by_tag = meta.get("counts", {}).get("summary_by_tag") or counts.get("summary_by_tag") or {}
+    bad = bad_statuses(str(fail_on), require_assert)
+    failing = [res for res in results.values() if res.status in bad]
+    failing = sorted(failing, key=lambda r: r.id)[:10]
+    tag_dir = eff_results_path.parent
+    diff_history_path = tag_dir / "effective_changes.jsonl"
+
+    history_limit = max(0, int(args.changes)) if hasattr(args, "changes") else 1
+    history_entries = _load_effective_diff_history(tag_dir, limit=history_limit) if history_limit > 0 else []
+
+    if format_mode == "plain":
+        print(f"Tag: {args.tag}")
+        print(f"Coverage: planned={planned} executed={executed} missed={missed} ({executed_pct} executed)")
+        ok_disp = _color(str(ok), _color_for_metric("ok") or "", use_color=use_color)
+        mismatch_disp = _color(str(mismatch), _color_for_metric("mismatch") or "", use_color=use_color)
+        failed_disp = _color(str(failed), _color_for_metric("failed") or "", use_color=use_color)
+        error_disp = _color(str(error), _color_for_metric("error") or "", use_color=use_color)
+        unchecked_disp = _color(str(unchecked), _color_for_metric("unchecked") or "", use_color=use_color)
+        bad_disp = _color(str(bad_total), _color_for_metric("bad") or "", use_color=use_color)
+        print(
+            "Quality: "
+            f"ok={ok_disp} mismatch={mismatch_disp} failed={failed_disp} error={error_disp} "
+            f"unchecked={unchecked_disp} bad={bad_disp} pass_rate={pass_rate_display}"
+        )
+    elif format_mode == "table":
+        label_width = max(len("Coverage"), len("Quality"))
+        print(f"Tag: {args.tag}")
+        coverage_headers = ["planned", "executed", "missed", "executed%"]
+        coverage_rows = [[str(planned), str(executed), str(missed), executed_pct]]
+        for line in _format_table_rows(
+            coverage_headers,
+            coverage_rows,
+            align_right=set(coverage_headers),
+            use_color=use_color,
+            label="Coverage",
+            label_width=label_width,
+        ):
+            print(line)
+        quality_headers = ["ok", "mismatch", "failed", "error", "unchecked", "bad", "pass_rate"]
+        quality_row = [
+            str(ok),
+            str(mismatch),
+            str(failed),
+            str(error),
+            str(unchecked),
+            str(bad_total),
+            pass_rate_display,
+        ]
+        quality_colors = {name: _color_for_metric(name) for name in quality_headers}
+        for line in _format_table_rows(
+            quality_headers,
+            [quality_row],
+            align_right=set(quality_headers),
+            use_color=use_color,
+            color_map=quality_colors,
+            label="Quality",
+            label_width=label_width,
+        ):
+            print(line)
+    else:
+        print("Unknown format; use plain or table.", file=sys.stderr)
+        return 2
+
     if summary_by_tag:
         buckets = []
         for tag, bucket in summary_by_tag.items():
@@ -103,29 +242,33 @@ def handle_report_tag(args) -> int:
             buckets.append((tag, bad_bucket, pr))
         buckets.sort(key=lambda t: (-t[1], (t[2] if t[2] is not None else 1.1)))
         print("Top bad groups (by tag):")
+        headers = ["tag", "bad", "pass_rate"]
+        rows = []
         for tag, bad_bucket, pr in buckets[:5]:
-            pr_disp = f"{pr*100:.1f}%" if isinstance(pr, (int, float)) else "n/a"
-            print(f"- {tag}: bad={bad_bucket} pass_rate={pr_disp}")
+            pr_disp = _format_pass_rate(pr if isinstance(pr, (int, float)) else None)
+            rows.append([tag, str(bad_bucket), pr_disp])
+        for line in _format_table_rows(
+            headers, rows, align_right={"bad", "pass_rate"}, use_color=use_color, indent="  ", label=""
+        ):
+            print(line)
         if args.verbose:
             print("Full summary_by_tag:")
             print(json.dumps(summary_by_tag, ensure_ascii=False, indent=2))
-    bad = bad_statuses(str(fail_on), require_assert)
-    failing = [res for res in results.values() if res.status in bad]
-    failing = sorted(failing, key=lambda r: r.id)[:10]
     if failing:
         print("Failing cases (top 10):")
         for res in failing:
-            print(f"- {res.id}: {res.status} ({_reason_text(res)}) [{res.artifacts_dir}]")
-    tag_dir = eff_results_path.parent
+            status_text = f"{res.status:<9}"
+            color = _color_for_metric(res.status) or ("red" if res.status in bad else None)
+            status_disp = _color(status_text, color or "", use_color=use_color)
+            print(f"- {res.id:<20} {status_disp} {_reason_text(res)} [{res.artifacts_dir}]")
     print("Paths:")
-    print(f"- effective_results_path: {eff_results_path}")
-    print(f"- effective_meta_path:    {eff_meta_path}")
-    diff_history_path = tag_dir / "effective_changes.jsonl"
-    print(f"- effective_diff_history_path: {diff_history_path}")
+    path_labels = ["effective_results_path", "effective_meta_path", "effective_diff_history_path"]
+    label_width = max(len(name) for name in path_labels)
+    print(f"- {'effective_results_path'.ljust(label_width)}: {eff_results_path}")
+    print(f"- {'effective_meta_path'.ljust(label_width)}: {eff_meta_path}")
+    print(f"- {'effective_diff_history_path'.ljust(label_width)}: {diff_history_path}")
 
-    history_limit = max(0, int(args.changes)) if hasattr(args, "changes") else 1
     if history_limit > 0:
-        history_entries = _load_effective_diff_history(tag_dir, limit=history_limit)
         if history_entries:
             print(f"Last {len(history_entries)} effective change(s):")
             for entry in history_entries:

--- a/examples/demo_qa/commands/report.py
+++ b/examples/demo_qa/commands/report.py
@@ -8,32 +8,7 @@ from typing import Optional
 from ..runner import bad_statuses, load_results, summarize
 from ..runs.effective import _load_effective_diff_history
 from ..runs.layout import _effective_paths
-
-
-ANSI = {
-    "reset": "\x1b[0m",
-    "red": "\x1b[31m",
-    "green": "\x1b[32m",
-    "yellow": "\x1b[33m",
-    "gray": "\x1b[90m",
-}
-
-
-def _color(text: str, color: str | None, *, use_color: bool) -> str:
-    if not use_color or not color:
-        return text
-    prefix = ANSI.get(color)
-    if not prefix:
-        return text
-    return f"{prefix}{text}{ANSI['reset']}"
-
-
-def _should_use_color(mode: str, *, stream) -> bool:
-    if mode == "always":
-        return True
-    if mode == "never":
-        return False
-    return bool(getattr(stream, "isatty", lambda: False)())
+from ..term import color, fmt_num, fmt_pct, render_table, should_use_color, truncate
 
 
 def _resolve_run_dir_arg(run_arg: Path, artifacts_dir: Path) -> Optional[Path]:
@@ -81,48 +56,6 @@ def _reason_text(res) -> str:
     return ""
 
 
-def _format_pass_rate(value: float | None) -> str:
-    return f"{value*100:.1f}%" if value is not None else "n/a"
-
-
-def _format_table_rows(
-    headers: list[str],
-    rows: list[list[str]],
-    *,
-    align_right: set[str],
-    use_color: bool,
-    color_map: dict[str, str] | None = None,
-    indent: str = "",
-    label: str | None = None,
-    label_width: int = 0,
-) -> list[str]:
-    widths = [len(header) for header in headers]
-    for row in rows:
-        for idx, cell in enumerate(row):
-            widths[idx] = max(widths[idx], len(cell))
-
-    def _format_row(row: list[str], *, colorize: bool) -> str:
-        cells: list[str] = []
-        for idx, cell in enumerate(row):
-            header = headers[idx]
-            formatted = cell.rjust(widths[idx]) if header in align_right else cell.ljust(widths[idx])
-            color = (color_map or {}).get(header) if colorize else None
-            if color:
-                formatted = _color(formatted, color, use_color=use_color)
-            cells.append(formatted)
-        return "  ".join(cells)
-
-    lines: list[str] = []
-    label_prefix = ""
-    if label is not None:
-        label_prefix = f"{label:<{label_width}}" if label_width else label
-        lines.append(f"{indent}{label_prefix}  {_format_row(headers, colorize=False)}")
-        label_prefix = f"{'':<{label_width}}" if label_width else ""
-    for row in rows:
-        lines.append(f"{indent}{label_prefix}  {_format_row(row, colorize=True)}")
-    return lines
-
-
 def _color_for_metric(name: str) -> str | None:
     if name == "ok":
         return "green"
@@ -136,7 +69,7 @@ def _color_for_metric(name: str) -> str | None:
 def handle_report_tag(args) -> int:
     format_mode = getattr(args, "format", "table")
     color_mode = getattr(args, "color", "auto")
-    use_color = _should_use_color(color_mode, stream=sys.stdout)
+    use_color = should_use_color(color_mode, stream=sys.stdout)
     artifacts_dir = args.data / ".runs"
     eff_results_path, eff_meta_path = _effective_paths(artifacts_dir, args.tag)
     if not eff_results_path.exists() or not eff_meta_path.exists():
@@ -158,8 +91,8 @@ def handle_report_tag(args) -> int:
     planned = meta.get("planned_total")
     executed = meta.get("executed_total")
     missed = meta.get("missed_total")
-    executed_pct_value = (executed / planned * 100) if planned else None
-    executed_pct = f"{executed_pct_value:.1f}%" if executed_pct_value is not None else "n/a"
+    executed_ratio = (executed / planned) if planned else None
+    executed_pct = fmt_pct(executed_ratio)
     ok = counts.get("ok", 0)
     mismatch = counts.get("mismatch", 0)
     failed = counts.get("failed", 0)
@@ -168,7 +101,7 @@ def handle_report_tag(args) -> int:
     skipped = counts.get("skipped", 0)
     non_skipped = (counts.get("total", 0) or 0) - (skipped or 0)
     pass_rate = (ok / non_skipped) if non_skipped else None
-    pass_rate_display = _format_pass_rate(pass_rate)
+    pass_rate_display = fmt_pct(pass_rate)
     bad = bad_statuses(str(fail_on), require_assert)
     bad_total = sum(counts.get(status, 0) or 0 for status in bad)
     summary_by_tag = meta.get("counts", {}).get("summary_by_tag") or counts.get("summary_by_tag") or {}
@@ -184,52 +117,57 @@ def handle_report_tag(args) -> int:
     if format_mode == "plain":
         print(f"Tag: {args.tag}")
         print(f"Coverage: planned={planned} executed={executed} missed={missed} ({executed_pct} executed)")
-        ok_disp = _color(str(ok), _color_for_metric("ok") or "", use_color=use_color)
-        mismatch_disp = _color(str(mismatch), _color_for_metric("mismatch") or "", use_color=use_color)
-        failed_disp = _color(str(failed), _color_for_metric("failed") or "", use_color=use_color)
-        error_disp = _color(str(error), _color_for_metric("error") or "", use_color=use_color)
-        unchecked_disp = _color(str(unchecked), _color_for_metric("unchecked") or "", use_color=use_color)
-        bad_disp = _color(str(bad_total), _color_for_metric("bad") or "", use_color=use_color)
+        ok_disp = color(fmt_num(ok), _color_for_metric("ok"), use_color=use_color)
+        mismatch_disp = color(fmt_num(mismatch), _color_for_metric("mismatch"), use_color=use_color)
+        failed_disp = color(fmt_num(failed), _color_for_metric("failed"), use_color=use_color)
+        error_disp = color(fmt_num(error), _color_for_metric("error"), use_color=use_color)
+        unchecked_disp = color(fmt_num(unchecked), _color_for_metric("unchecked"), use_color=use_color)
+        bad_disp = color(fmt_num(bad_total), _color_for_metric("bad"), use_color=use_color)
         print(
             "Quality: "
             f"ok={ok_disp} mismatch={mismatch_disp} failed={failed_disp} error={error_disp} "
             f"unchecked={unchecked_disp} bad={bad_disp} pass_rate={pass_rate_display}"
         )
     elif format_mode == "table":
-        label_width = max(len("Coverage"), len("Quality"))
         print(f"Tag: {args.tag}")
         coverage_headers = ["planned", "executed", "missed", "executed%"]
-        coverage_rows = [[str(planned), str(executed), str(missed), executed_pct]]
-        for line in _format_table_rows(
-            coverage_headers,
-            coverage_rows,
-            align_right=set(coverage_headers),
-            use_color=use_color,
-            label="Coverage",
-            label_width=label_width,
-        ):
-            print(line)
+        coverage_rows = [[fmt_num(planned), fmt_num(executed), fmt_num(missed), executed_pct]]
+        print("Coverage:")
+        print(
+            render_table(
+                coverage_headers,
+                coverage_rows,
+                align_right={0, 1, 2, 3},
+                indent="  ",
+            )
+        )
         quality_headers = ["ok", "mismatch", "failed", "error", "unchecked", "bad", "pass_rate"]
+        pass_rate_color = None
+        if pass_rate is not None:
+            if pass_rate >= 0.9:
+                pass_rate_color = "green"
+            elif pass_rate >= 0.6:
+                pass_rate_color = "yellow"
+            else:
+                pass_rate_color = "red"
         quality_row = [
-            str(ok),
-            str(mismatch),
-            str(failed),
-            str(error),
-            str(unchecked),
-            str(bad_total),
-            pass_rate_display,
+            color(fmt_num(ok), _color_for_metric("ok"), use_color=use_color),
+            color(fmt_num(mismatch), _color_for_metric("mismatch"), use_color=use_color),
+            color(fmt_num(failed), _color_for_metric("failed"), use_color=use_color),
+            color(fmt_num(error), _color_for_metric("error"), use_color=use_color),
+            color(fmt_num(unchecked), _color_for_metric("unchecked"), use_color=use_color),
+            color(fmt_num(bad_total), _color_for_metric("bad"), use_color=use_color),
+            color(pass_rate_display, pass_rate_color, use_color=use_color),
         ]
-        quality_colors = {name: _color_for_metric(name) for name in quality_headers}
-        for line in _format_table_rows(
-            quality_headers,
-            [quality_row],
-            align_right=set(quality_headers),
-            use_color=use_color,
-            color_map=quality_colors,
-            label="Quality",
-            label_width=label_width,
-        ):
-            print(line)
+        print("Quality:")
+        print(
+            render_table(
+                quality_headers,
+                [quality_row],
+                align_right={0, 1, 2, 3, 4, 5, 6},
+                indent="  ",
+            )
+        )
     else:
         print("Unknown format; use plain or table.", file=sys.stderr)
         return 2
@@ -245,12 +183,16 @@ def handle_report_tag(args) -> int:
         headers = ["tag", "bad", "pass_rate"]
         rows = []
         for tag, bad_bucket, pr in buckets[:5]:
-            pr_disp = _format_pass_rate(pr if isinstance(pr, (int, float)) else None)
-            rows.append([tag, str(bad_bucket), pr_disp])
-        for line in _format_table_rows(
-            headers, rows, align_right={"bad", "pass_rate"}, use_color=use_color, indent="  ", label=""
-        ):
-            print(line)
+            pr_disp = fmt_pct(pr if isinstance(pr, (int, float)) else None)
+            rows.append([tag, fmt_num(bad_bucket), pr_disp])
+        print(
+            render_table(
+                headers,
+                rows,
+                align_right={1, 2},
+                indent="  ",
+            )
+        )
         if args.verbose:
             print("Full summary_by_tag:")
             print(json.dumps(summary_by_tag, ensure_ascii=False, indent=2))
@@ -258,8 +200,8 @@ def handle_report_tag(args) -> int:
         print("Failing cases (top 10):")
         for res in failing:
             status_text = f"{res.status:<9}"
-            color = _color_for_metric(res.status) or ("red" if res.status in bad else None)
-            status_disp = _color(status_text, color or "", use_color=use_color)
+            color_name = _color_for_metric(res.status) or ("red" if res.status in bad else None)
+            status_disp = color(status_text, color_name, use_color=use_color)
             print(f"- {res.id:<20} {status_disp} {_reason_text(res)} [{res.artifacts_dir}]")
     print("Paths:")
     path_labels = ["effective_results_path", "effective_meta_path", "effective_diff_history_path"]

--- a/examples/demo_qa/commands/report.py
+++ b/examples/demo_qa/commands/report.py
@@ -177,19 +177,21 @@ def handle_report_tag(args) -> int:
         for tag, bucket in summary_by_tag.items():
             bad_bucket = sum((bucket.get(status, 0) or 0) for status in bad)
             pr = bucket.get("pass_rate")
-            buckets.append((tag, bad_bucket, pr))
+            buckets.append((tag, bad_bucket, pr, bucket))
         buckets.sort(key=lambda t: (-t[1], (t[2] if t[2] is not None else 1.1)))
         print("Top bad groups (by tag):")
-        headers = ["tag", "bad", "pass_rate"]
+        headers = ["tag", "bad", "ok", "total", "pass_rate"]
         rows = []
-        for tag, bad_bucket, pr in buckets[:5]:
+        for tag, bad_bucket, pr, bucket in buckets[:5]:
             pr_disp = fmt_pct(pr if isinstance(pr, (int, float)) else None)
-            rows.append([tag, fmt_num(bad_bucket), pr_disp])
+            row_total = bucket.get("total") if isinstance(bucket, dict) else None
+            row_ok = bucket.get("ok") if isinstance(bucket, dict) else None
+            rows.append([tag, fmt_num(bad_bucket), fmt_num(row_ok), fmt_num(row_total), pr_disp])
         print(
             render_table(
                 headers,
                 rows,
-                align_right={1, 2},
+                align_right={1, 2, 3, 4},
                 indent="  ",
             )
         )

--- a/examples/demo_qa/commands/tags.py
+++ b/examples/demo_qa/commands/tags.py
@@ -174,7 +174,7 @@ def _format_table(rows: Iterable[TagInfo], *, use_color: bool) -> str:
     return render_table(
         headers,
         table_rows,
-        align_right={2, 3, 4, 5},
+        align_right={3, 4, 5},
         col_max={1: 25, 6: 80},
     )
 

--- a/examples/demo_qa/commands/tags.py
+++ b/examples/demo_qa/commands/tags.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ..runner import bad_statuses
+
+
+@dataclass
+class TagInfo:
+    name: str
+    updated_at: str
+    updated_sort: float
+    planned: str
+    executed: str
+    missed: str
+    bad: str
+    pass_rate: str
+    last_run_id: str
+    note: str
+
+
+def _parse_ts(value: str | None) -> Optional[float]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value).timestamp()
+    except Exception:
+        return None
+
+
+def _format_pct(value: float | None) -> str:
+    return f"{value*100:.1f}%" if value is not None else "n/a"
+
+
+def _match_pattern(name: str, pattern: str | None) -> bool:
+    if not pattern:
+        return True
+    if pattern.startswith("re:"):
+        try:
+            return re.search(pattern[3:], name) is not None
+        except re.error:
+            return False
+    return fnmatch.fnmatch(name, pattern)
+
+
+def _load_meta(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_run_note(run_dir: Path) -> tuple[str, str]:
+    if not run_dir.exists():
+        return "", ""
+    summary_path = run_dir / "summary.json"
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            note = summary.get("note") or ""
+            run_id = summary.get("run_id") or run_dir.name
+            return run_id, note
+        except Exception:
+            pass
+    run_meta = run_dir / "run_meta.json"
+    if run_meta.exists():
+        try:
+            meta = json.loads(run_meta.read_text(encoding="utf-8"))
+            note = meta.get("note") or ""
+            run_id = meta.get("run_id") or run_dir.name
+            return run_id, note
+        except Exception:
+            pass
+    return run_dir.name, ""
+
+
+def _collect_tag_info(tag_dir: Path) -> Optional[TagInfo]:
+    meta_path = tag_dir / "effective_meta.json"
+    results_path = tag_dir / "effective_results.jsonl"
+    if not meta_path.exists() and not results_path.exists():
+        return None
+    meta = _load_meta(meta_path) or {}
+    counts = meta.get("counts") or {}
+
+    planned = meta.get("planned_total")
+    executed = meta.get("executed_total")
+    missed = meta.get("missed_total")
+    planned_str = str(planned) if planned is not None else "n/a"
+    executed_str = str(executed) if executed is not None else "n/a"
+    missed_str = str(missed) if missed is not None else "n/a"
+
+    fail_on = meta.get("fail_on", "bad")
+    require_assert = bool(meta.get("require_assert", False))
+    bad_status = bad_statuses(str(fail_on), require_assert)
+    bad_total = sum(counts.get(status, 0) or 0 for status in bad_status)
+    bad_str = str(bad_total) if counts else "n/a"
+
+    ok = counts.get("ok", 0) or 0
+    skipped = counts.get("skipped", 0) or 0
+    total = counts.get("total", 0) or 0
+    non_skipped = total - skipped
+    pass_rate = (ok / non_skipped) if non_skipped else None
+    pass_rate_str = _format_pct(pass_rate)
+
+    updated_at = meta.get("updated_at") or ""
+    updated_sort = _parse_ts(updated_at)
+    if updated_sort is None:
+        updated_sort = meta_path.stat().st_mtime if meta_path.exists() else results_path.stat().st_mtime
+        updated_at = (
+            datetime.fromtimestamp(updated_sort, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+            if updated_sort
+            else "n/a"
+        )
+
+    built_from = meta.get("built_from_runs") or []
+    last_run_id = "n/a"
+    note = meta.get("note") or ""
+    if built_from:
+        last_path = Path(sorted(str(p) for p in built_from)[-1])
+        run_id, run_note = _load_run_note(last_path)
+        last_run_id = run_id or "n/a"
+        note = note or run_note
+
+    return TagInfo(
+        name=tag_dir.name,
+        updated_at=updated_at or "n/a",
+        updated_sort=updated_sort or 0,
+        planned=planned_str,
+        executed=executed_str,
+        missed=missed_str,
+        bad=bad_str,
+        pass_rate=pass_rate_str,
+        last_run_id=last_run_id,
+        note=note or "",
+    )
+
+
+def _format_table(rows: Iterable[TagInfo]) -> list[str]:
+    headers = ["tag", "updated_at", "plan/exe/miss", "bad", "pass_rate", "last_run_id", "note"]
+    data = []
+    for row in rows:
+        data.append(
+            [
+                row.name,
+                row.updated_at,
+                f"{row.planned}/{row.executed}/{row.missed}",
+                row.bad,
+                row.pass_rate,
+                row.last_run_id,
+                row.note,
+            ]
+        )
+    widths = [len(h) for h in headers]
+    for row in data:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    lines = []
+    header_line = "  ".join(h.ljust(widths[idx]) for idx, h in enumerate(headers))
+    lines.append(header_line)
+    for row in data:
+        lines.append("  ".join(str(cell).ljust(widths[idx]) for idx, cell in enumerate(row)))
+    return lines
+
+
+def handle_tags_list(args) -> int:
+    artifacts_dir = args.data / ".runs"
+    tags_dir = artifacts_dir / "runs" / "tags"
+    if not tags_dir.exists():
+        print("No tags found.")
+        return 0
+
+    tag_infos: list[TagInfo] = []
+    for child in sorted(tags_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if not _match_pattern(child.name, args.pattern):
+            continue
+        info = _collect_tag_info(child)
+        if info:
+            tag_infos.append(info)
+
+    if not tag_infos:
+        print("No tags found.")
+        return 0
+
+    sort_by = getattr(args, "sort", "updated")
+    if sort_by == "name":
+        tag_infos.sort(key=lambda t: t.name)
+    else:
+        tag_infos.sort(key=lambda t: (-t.updated_sort, t.name))
+
+    limit = getattr(args, "limit", None)
+    if limit is not None:
+        try:
+            limit_int = int(limit)
+            if limit_int > 0:
+                tag_infos = tag_infos[:limit_int]
+        except Exception:
+            pass
+
+    for line in _format_table(tag_infos):
+        print(line)
+    return 0
+
+
+__all__ = ["handle_tags_list"]

--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -706,6 +706,11 @@ def diff_runs(
 
     base_counts = summarize(base_by_id.values())
     new_counts = summarize(new_by_id.values())
+    base_total_cases = len(base_by_id)
+    new_total_cases = len(new_by_id)
+    overlap_ids = set(base_by_id) & set(new_by_id)
+    base_only_count = base_total_cases - len(overlap_ids)
+    new_only_count = new_total_cases - len(overlap_ids)
     base_med = _median_duration(base_by_id)
     new_med = _median_duration(new_by_id)
     base_avg = base_counts.get("avg_total_s")
@@ -737,6 +742,10 @@ def diff_runs(
         "still_fail": still_fail,
         "changed_status": changed_status,
         "new_cases": new_cases,
+        "base_total_cases": base_total_cases,
+        "new_total_cases": new_total_cases,
+        "base_only_count": base_only_count,
+        "new_only_count": new_only_count,
         "base_counts": base_counts,
         "new_counts": new_counts,
         "counts_delta": count_deltas,
@@ -815,6 +824,10 @@ class DiffReport(TypedDict):
     still_fail: list[DiffCaseChange]
     changed_status: list[DiffStatusChange]
     new_cases: list[str]
+    base_total_cases: int
+    new_total_cases: int
+    base_only_count: int
+    new_only_count: int
     base_counts: Dict[str, object]
     new_counts: Dict[str, object]
     counts_delta: Dict[str, int | float | None]

--- a/examples/demo_qa/runs/effective.py
+++ b/examples/demo_qa/runs/effective.py
@@ -130,6 +130,23 @@ def _load_effective_diff(tag_dir: Path) -> Optional[dict]:
     return last
 
 
+def _load_effective_diff_history(tag_dir: Path, *, limit: int) -> list[dict]:
+    path = tag_dir / "effective_changes.jsonl"
+    if not path.exists() or limit <= 0:
+        return []
+    entries: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except Exception:
+                continue
+    return entries[-limit:]
+
+
 def _update_effective_snapshot(
     *,
     artifacts_dir: Path,
@@ -198,6 +215,7 @@ __all__ = [
     "_build_effective_diff",
     "_load_effective_results",
     "_load_effective_diff",
+    "_load_effective_diff_history",
     "_update_effective_snapshot",
     "_write_effective_results",
 ]

--- a/examples/demo_qa/term.py
+++ b/examples/demo_qa/term.py
@@ -44,14 +44,17 @@ def truncate(text: object | None, max_len: int) -> str:
     plain = strip_ansi(s)
     if len(plain) <= max_len:
         return s
-    if max_len == 1:
-        truncated_plain = plain[:1]
-    else:
-        truncated_plain = plain[: max_len - 1] + "…"
-    match = re.match(r"^(\x1b\[[0-9;]*m)(.*)(\x1b\[0m)$", s)
-    if match:
-        prefix, _, suffix = match.groups()
-        return f"{prefix}{truncated_plain}{suffix}"
+    truncated_plain = plain[:1] if max_len == 1 else plain[: max_len - 1] + "…"
+    prefix = ""
+    pos = 0
+    while True:
+        match = _ANSI_RE.match(s, pos)
+        if not match or match.start() != pos:
+            break
+        prefix += match.group()
+        pos = match.end()
+    if prefix:
+        return f"{prefix}{truncated_plain}{ANSI['reset']}"
     return truncated_plain
 
 

--- a/examples/demo_qa/term.py
+++ b/examples/demo_qa/term.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+ANSI: dict[str, str] = {
+    "reset": "\x1b[0m",
+    "red": "\x1b[31m",
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "gray": "\x1b[90m",
+}
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def should_use_color(mode: str, stream) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def color(text: str, name: str | None, use_color: bool) -> str:
+    if not name or not use_color:
+        return text
+    prefix = ANSI.get(name)
+    if not prefix:
+        return text
+    return f"{prefix}{text}{ANSI['reset']}"
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def truncate(text: object | None, max_len: int) -> str:
+    if text is None:
+        return "-"
+    if max_len <= 0:
+        return ""
+    s = str(text)
+    plain = strip_ansi(s)
+    if len(plain) <= max_len:
+        return s
+    if max_len == 1:
+        truncated_plain = plain[:1]
+    else:
+        truncated_plain = plain[: max_len - 1] + "…"
+    match = re.match(r"^(\x1b\[[0-9;]*m)(.*)(\x1b\[0m)$", s)
+    if match:
+        prefix, _, suffix = match.groups()
+        return f"{prefix}{truncated_plain}{suffix}"
+    return truncated_plain
+
+
+def fmt_pct(x: float | None, digits: int = 1) -> str:
+    return f"{x*100:.{digits}f}%" if x is not None else "-"
+
+
+def fmt_num(x: int | float | None) -> str:
+    if x is None:
+        return "-"
+    if isinstance(x, float) and x.is_integer():
+        return str(int(x))
+    return str(x)
+
+
+def _pad(text: str, width: int, *, right: bool) -> str:
+    visible = len(strip_ansi(text))
+    pad = max(width - visible, 0)
+    return f"{' ' * pad}{text}" if right else f"{text}{' ' * pad}"
+
+
+def render_table(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    align_right: set[int] | None = None,
+    indent: str = "",
+    col_max: dict[int, int] | None = None,
+) -> str:
+    align_right = align_right or set()
+    col_max = col_max or {}
+
+    processed: list[list[str]] = []
+    for row in rows:
+        processed_row: list[str] = []
+        for idx, cell in enumerate(row):
+            cell_text = "-" if cell is None else str(cell)
+            if idx in col_max:
+                cell_text = truncate(cell_text, col_max[idx])
+            processed_row.append(cell_text)
+        processed.append(processed_row)
+
+    widths = [len(strip_ansi(h)) for h in headers]
+    for row in processed:
+        for idx, cell in enumerate(row):
+            if idx >= len(widths):
+                widths.append(0)
+            widths[idx] = max(widths[idx], len(strip_ansi(cell)))
+
+    def _format_row(row: Iterable[str]) -> str:
+        cells = []
+        for idx, cell in enumerate(row):
+            right = idx in align_right
+            cells.append(_pad(cell, widths[idx], right=right))
+        return f"{indent}" + "  ".join(cells)
+
+    lines = [_format_row(headers)]
+    for row in processed:
+        lines.append(_format_row(row))
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ANSI",
+    "color",
+    "should_use_color",
+    "strip_ansi",
+    "truncate",
+    "fmt_pct",
+    "fmt_num",
+    "render_table",
+]

--- a/examples/demo_qa/tests/test_demo_qa_batch_effective_flags.py
+++ b/examples/demo_qa/tests/test_demo_qa_batch_effective_flags.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from examples.demo_qa.batch import handle_batch
+from examples.demo_qa.cli import build_parser
+
+
+def _base_args(tmp_path: Path) -> list[str]:
+    data_dir = tmp_path / "data"
+    schema = data_dir / "schema.json"
+    cases = data_dir / "cases.jsonl"
+    # Paths need not exist because validation should short-circuit before file access.
+    return ["batch", "--data", str(data_dir), "--schema", str(schema), "--cases", str(cases), "--events", "off"]
+
+
+def test_only_failed_effective_requires_tag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args = build_parser().parse_args(_base_args(tmp_path) + ["--only-failed-effective"])
+
+    exit_code = handle_batch(args)
+    captured = capsys.readouterr().err
+
+    assert exit_code == 2
+    assert "--tag is required" in captured
+
+
+def test_only_missed_effective_requires_tag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args = build_parser().parse_args(_base_args(tmp_path) + ["--only-missed-effective"])
+
+    exit_code = handle_batch(args)
+    captured = capsys.readouterr().err
+
+    assert exit_code == 2
+    assert "--tag is required" in captured
+
+
+def test_only_failed_effective_rejects_only_failed_from(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args = build_parser().parse_args(
+        _base_args(tmp_path)
+        + [
+            "--only-failed-effective",
+            "--tag",
+            "demo",
+            "--only-failed-from",
+            str(tmp_path / "prev.jsonl"),
+        ]
+    )
+
+    exit_code = handle_batch(args)
+    captured = capsys.readouterr().err
+
+    assert exit_code == 2
+    assert "not compatible with --only-failed-from" in captured

--- a/examples/demo_qa/tests/test_demo_qa_batch_effective_flags.py
+++ b/examples/demo_qa/tests/test_demo_qa_batch_effective_flags.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from examples.demo_qa import batch
 from examples.demo_qa.batch import handle_batch
 from examples.demo_qa.cli import build_parser
+from examples.demo_qa.runner import Case, RunResult
+from examples.demo_qa.runs.scope import _scope_hash, _scope_payload
 
 
 def _base_args(tmp_path: Path) -> list[str]:
@@ -53,3 +58,161 @@ def test_only_failed_effective_rejects_only_failed_from(tmp_path: Path, capsys: 
 
     assert exit_code == 2
     assert "not compatible with --only-failed-from" in captured
+
+
+def _stub_settings():
+    llm = SimpleNamespace(
+        base_url=None,
+        plan_model="p",
+        synth_model="s",
+        plan_temperature=0.0,
+        synth_temperature=0.0,
+        timeout_s=None,
+        retries=None,
+    )
+    return SimpleNamespace(llm=llm)
+
+
+def _stub_run_one(case: Case, runner, artifacts_root: Path, *args, **kwargs) -> RunResult:
+    return RunResult(
+        id=case.id,
+        question=case.question or "",
+        status="ok",
+        checked=True,
+        reason=None,
+        details=None,
+        artifacts_dir=str(artifacts_root),
+        duration_ms=0,
+        tags=[],
+    )
+
+
+def _write_cases(tmp_path: Path, cases: list[Case]) -> Path:
+    path = tmp_path / "cases.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for case in cases:
+            f.write(f'{{"id": "{case.id}", "question": "q"}}\n')
+    return path
+
+
+def test_only_failed_effective_uses_effective_baseline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    schema = data_dir / "schema.json"
+    schema.parent.mkdir(parents=True, exist_ok=True)
+    schema.write_text("{}", encoding="utf-8")
+    cases = [
+        Case(id="ok", question=""),
+        Case(id="err", question=""),
+        Case(id="mis", question=""),
+    ]
+    cases_path = _write_cases(tmp_path, cases)
+    cases_hash = batch._hash_file(cases_path)
+    scope_hash = _scope_hash(_scope_payload(cases_hash=cases_hash, include_tags=None, exclude_tags=None, include_ids=None, exclude_ids=None))
+
+    effective_results = {
+        "ok": RunResult(id="ok", question="", status="ok", checked=True, reason=None, details=None, artifacts_dir="", duration_ms=0, tags=[]),
+        "err": RunResult(id="err", question="", status="error", checked=True, reason=None, details=None, artifacts_dir="", duration_ms=0, tags=[]),
+        "mis": RunResult(id="mis", question="", status="mismatch", checked=True, reason=None, details=None, artifacts_dir="", duration_ms=0, tags=[]),
+    }
+
+    def _load_effective_results_stub(artifacts_dir: Path, tag: str):
+        eff_path = artifacts_dir / "runs" / "tags" / tag / "effective_results.jsonl"
+        return effective_results, {"cases_hash": cases_hash, "scope_hash": scope_hash, "planned_case_ids": list(effective_results)}, eff_path
+
+    monkeypatch.setattr(batch, "load_settings", lambda config_path=None, data_dir=None: (_stub_settings(), None))
+    monkeypatch.setattr(batch, "build_provider", lambda *a, **k: (SimpleNamespace(name="p"), None))
+    monkeypatch.setattr(batch, "build_llm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(batch, "build_agent", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(batch, "configure_logging", lambda **kwargs: None)
+    monkeypatch.setattr(batch, "_load_effective_results", _load_effective_results_stub)
+    monkeypatch.setattr(batch, "_load_run_meta", lambda *a, **k: {"run_id": "eff", "run_status": "SUCCESS", "results_complete": True})
+    monkeypatch.setattr(batch, "_load_latest_run", lambda *a, **k: (_ for _ in ()).throw(AssertionError("overlay should not be used")))  # type: ignore[arg-type]
+    monkeypatch.setattr(batch, "_load_latest_any_results", lambda *a, **k: (_ for _ in ()).throw(AssertionError("overlay should not be used")))  # type: ignore[arg-type]
+    monkeypatch.setattr(batch, "run_one", _stub_run_one)
+
+    args = build_parser().parse_args(
+        [
+            "batch",
+            "--data",
+            str(data_dir),
+            "--schema",
+            str(schema),
+            "--cases",
+            str(cases_path),
+            "--events",
+            "off",
+            "--tag",
+            "demo",
+            "--only-failed-effective",
+        ]
+    )
+
+    exit_code = handle_batch(args)
+    assert exit_code == 0
+
+    run_meta_path = next((data_dir / ".runs" / "runs").rglob("run_meta.json"))
+    run_meta = json.loads(run_meta_path.read_text(encoding="utf-8"))
+    assert sorted(run_meta["selected_case_ids"]) == ["err", "mis"]
+
+
+def test_only_missed_effective_uses_effective_baseline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    schema = data_dir / "schema.json"
+    schema.parent.mkdir(parents=True, exist_ok=True)
+    schema.write_text("{}", encoding="utf-8")
+    cases = [
+        Case(id="present", question=""),
+        Case(id="missing1", question=""),
+        Case(id="missing2", question=""),
+    ]
+    cases_path = _write_cases(tmp_path, cases)
+    cases_hash = batch._hash_file(cases_path)
+    scope_hash = _scope_hash(_scope_payload(cases_hash=cases_hash, include_tags=None, exclude_tags=None, include_ids=None, exclude_ids=None))
+
+    effective_results = {
+        "present": RunResult(id="present", question="", status="ok", checked=True, reason=None, details=None, artifacts_dir="", duration_ms=0, tags=[]),
+    }
+
+    def _load_effective_results_stub(artifacts_dir: Path, tag: str):
+        eff_path = artifacts_dir / "runs" / "tags" / tag / "effective_results.jsonl"
+        meta = {
+            "cases_hash": cases_hash,
+            "scope_hash": scope_hash,
+            "planned_case_ids": [case.id for case in cases],
+        }
+        return effective_results, meta, eff_path
+
+    monkeypatch.setattr(batch, "load_settings", lambda config_path=None, data_dir=None: (_stub_settings(), None))
+    monkeypatch.setattr(batch, "build_provider", lambda *a, **k: (SimpleNamespace(name="p"), None))
+    monkeypatch.setattr(batch, "build_llm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(batch, "build_agent", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(batch, "configure_logging", lambda **kwargs: None)
+    monkeypatch.setattr(batch, "_load_effective_results", _load_effective_results_stub)
+    monkeypatch.setattr(batch, "_load_run_meta", lambda *a, **k: {"run_id": "eff", "run_status": "SUCCESS", "results_complete": True})
+    monkeypatch.setattr(batch, "_load_latest_run", lambda *a, **k: (_ for _ in ()).throw(AssertionError("overlay should not be used")))  # type: ignore[arg-type]
+    monkeypatch.setattr(batch, "_load_latest_any_results", lambda *a, **k: (_ for _ in ()).throw(AssertionError("overlay should not be used")))  # type: ignore[arg-type]
+    monkeypatch.setattr(batch, "run_one", _stub_run_one)
+
+    args = build_parser().parse_args(
+        [
+            "batch",
+            "--data",
+            str(data_dir),
+            "--schema",
+            str(schema),
+            "--cases",
+            str(cases_path),
+            "--events",
+            "off",
+            "--tag",
+            "demo",
+            "--only-missed-effective",
+        ]
+    )
+
+    exit_code = handle_batch(args)
+    assert exit_code == 0
+
+    run_meta_path = next((data_dir / ".runs" / "runs").rglob("run_meta.json"))
+    run_meta = json.loads(run_meta_path.read_text(encoding="utf-8"))
+    assert sorted(run_meta["selected_case_ids"]) == ["missing1", "missing2"]

--- a/examples/demo_qa/tests/test_demo_qa_compare_cli.py
+++ b/examples/demo_qa/tests/test_demo_qa_compare_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _install_pydantic_settings_stub() -> None:
+    if "pydantic_settings" in sys.modules:
+        return
+    module = types.ModuleType("pydantic_settings")
+
+    class _BaseSettings:
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def _settings_config_dict(**kwargs: object) -> dict:
+        return dict(**kwargs)
+
+    module.BaseSettings = _BaseSettings
+    module.SettingsConfigDict = _settings_config_dict
+
+    sources = types.ModuleType("pydantic_settings.sources")
+
+    class _TomlConfigSettingsSource:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    sources.TomlConfigSettingsSource = _TomlConfigSettingsSource
+
+    sys.modules["pydantic_settings"] = module
+    sys.modules["pydantic_settings.sources"] = sources
+
+
+_install_pydantic_settings_stub()
+
+from examples.demo_qa.batch import handle_compare
+from examples.demo_qa.cli import build_parser
+from examples.demo_qa.runner import RunResult
+from examples.demo_qa.runs.io import write_results
+from examples.demo_qa.runs.layout import _effective_paths
+
+
+def _make_result(case_id: str, status: str) -> RunResult:
+    return RunResult(
+        id=case_id,
+        question="q",
+        status=status,
+        checked=True,
+        reason=None,
+        details=None,
+        artifacts_dir="/tmp",
+        duration_ms=0,
+        tags=[],
+    )
+
+
+def _write_effective_snapshot(data_dir: Path, tag: str, results: list[RunResult]) -> Path:
+    artifacts_dir = data_dir / ".runs"
+    results_path, meta_path = _effective_paths(artifacts_dir, tag)
+    write_results(results_path, results)
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps({"tag": tag}), encoding="utf-8")
+    return results_path
+
+
+def test_compare_resolves_effective_snapshots(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir = tmp_path / "data"
+    _write_effective_snapshot(data_dir, "baseline", [_make_result("case-1", "ok")])
+    _write_effective_snapshot(data_dir, "baseline_v2", [_make_result("case-1", "failed")])
+
+    args = build_parser().parse_args(
+        ["compare", "--data", str(data_dir), "--base-tag", "baseline", "--new-tag", "baseline_v2"]
+    )
+    exit_code = handle_compare(args)
+    captured = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "case-1" in captured
+
+
+def test_compare_reports_missing_effective_snapshot(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir = tmp_path / "data"
+    args = build_parser().parse_args(["compare", "--data", str(data_dir), "--base-tag", "missing", "--new-tag", "next"])
+
+    exit_code = handle_compare(args)
+    captured = capsys.readouterr().err
+
+    assert exit_code == 2
+    assert "No effective snapshot found" in captured

--- a/examples/demo_qa/tests/test_demo_qa_compare_cli.py
+++ b/examples/demo_qa/tests/test_demo_qa_compare_cli.py
@@ -93,3 +93,13 @@ def test_compare_reports_missing_effective_snapshot(tmp_path: Path, capsys: pyte
 
     assert exit_code == 2
     assert "No effective snapshot found" in captured
+
+
+def test_compare_requires_data_for_tag(capsys: pytest.CaptureFixture[str]) -> None:
+    args = build_parser().parse_args(["compare", "--base-tag", "a", "--new-tag", "b"])
+
+    exit_code = handle_compare(args)
+    captured = capsys.readouterr().err
+
+    assert exit_code == 2
+    assert "--data is required" in captured

--- a/examples/demo_qa/tests/test_demo_qa_compare_cli.py
+++ b/examples/demo_qa/tests/test_demo_qa_compare_cli.py
@@ -103,3 +103,16 @@ def test_compare_requires_data_for_tag(capsys: pytest.CaptureFixture[str]) -> No
 
     assert exit_code == 2
     assert "--data is required" in captured
+
+
+def test_compare_rejects_mixed_base_args(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    base = tmp_path / "base.jsonl"
+    new = tmp_path / "new.jsonl"
+    base.write_text("{}", encoding="utf-8")
+    new.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_parser().parse_args(["compare", "--base", str(base), "--base-tag", "tag", "--new", str(new)])
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr().err
+    assert "argument --base-tag: not allowed with argument --base" in captured

--- a/examples/demo_qa/tests/test_demo_qa_report_tag.py
+++ b/examples/demo_qa/tests/test_demo_qa_report_tag.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+from examples.demo_qa.commands.report import handle_report_tag
+from examples.demo_qa.runner import RunResult
+from examples.demo_qa.runs.io import write_results
+from examples.demo_qa.runs.layout import _effective_paths
+
+
+def _make_result(case_id: str, status: str) -> RunResult:
+    return RunResult(
+        id=case_id,
+        question="q",
+        status=status,
+        checked=True,
+        reason=None,
+        details=None,
+        artifacts_dir="/tmp",
+        duration_ms=0,
+        tags=["group"],
+    )
+
+
+def _write_effective(data_dir: Path) -> tuple[Path, Path]:
+    eff_results_path, eff_meta_path = _effective_paths(data_dir / ".runs", "demo")
+    results = [_make_result("ok", "ok"), _make_result("bad", "failed"), _make_result("err", "error")]
+    write_results(eff_results_path, results)
+    counts = {
+        "total": 3,
+        "ok": 1,
+        "failed": 1,
+        "error": 1,
+        "mismatch": 0,
+        "skipped": 0,
+        "unchecked": 0,
+        "summary_by_tag": {"group": {"total": 3, "ok": 1, "failed": 1, "error": 1, "mismatch": 0, "skipped": 0, "unchecked": 0, "pass_rate": 0.333}},
+    }
+    eff_meta_path.parent.mkdir(parents=True, exist_ok=True)
+    eff_meta_path.write_text(
+        json.dumps(
+            {
+                "tag": "demo",
+                "planned_total": 4,
+                "executed_total": 3,
+                "missed_total": 1,
+                "counts": counts,
+                "fail_on": "bad",
+                "require_assert": False,
+                "effective_results_path": str(eff_results_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    changes_path = eff_results_path.parent / "effective_changes.jsonl"
+    changes_path.write_text(
+        json.dumps({"timestamp": "t1", "run_id": "r1", "note": "n1", "regressed": [], "fixed": [], "changed_bad": [], "new_cases": ["c1"]})
+        + "\n"
+        + json.dumps({"timestamp": "t2", "run_id": "r2", "note": "n2", "regressed": [{"id": "x"}], "fixed": [{"id": "y"}], "changed_bad": [], "new_cases": []})
+        + "\n",
+        encoding="utf-8",
+    )
+    return eff_results_path, changes_path
+
+
+def test_report_tag_short_output(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=1)
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Coverage:" in out
+    assert "Quality:" in out
+    assert "effective_results_path" in out
+    assert "Last 1 effective change" in out
+
+
+def test_report_tag_changes_limit(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=2)
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "r1" in out
+    assert "r2" in out

--- a/examples/demo_qa/tests/test_demo_qa_report_tag.py
+++ b/examples/demo_qa/tests/test_demo_qa_report_tag.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 from examples.demo_qa.commands.report import handle_report_tag
 from examples.demo_qa.runner import RunResult
@@ -73,8 +73,10 @@ def test_report_tag_short_output(tmp_path, capsys):
     out = capsys.readouterr().out
 
     assert exit_code == 0
-    assert "Coverage:" in out
-    assert "Quality:" in out
+    assert "Coverage" in out
+    assert "planned" in out
+    assert "Quality" in out
+    assert "Top bad groups (by tag):" in out
     assert "effective_results_path" in out
     assert "Last 1 effective change" in out
 
@@ -89,3 +91,26 @@ def test_report_tag_changes_limit(tmp_path, capsys):
     assert exit_code == 0
     assert "r1" in out
     assert "r2" in out
+
+
+def test_report_tag_plain_output(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=1, format="plain", color="never")
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Coverage: planned=4 executed=3 missed=1 (75.0% executed)" in out
+    assert "Quality: ok=1 mismatch=0 failed=1 error=1 unchecked=0 bad=2 pass_rate=33.3%" in out
+
+
+def test_report_tag_color_never(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=1, color="never")
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "\x1b[" not in out

--- a/examples/demo_qa/tests/test_demo_qa_stats.py
+++ b/examples/demo_qa/tests/test_demo_qa_stats.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _write_history(tmp_path: Path, entries: list[dict]) -> Path:
+    history_path = tmp_path / ".runs" / "history.jsonl"
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+    return history_path
+
+
+def _install_fake_pydantic_settings() -> None:
+    if "pydantic_settings" in sys.modules:
+        return
+    from pydantic import BaseModel
+
+    fake_settings = types.ModuleType("pydantic_settings")
+    fake_settings.BaseSettings = BaseModel
+    fake_settings.SettingsConfigDict = dict
+    fake_sources = types.ModuleType("pydantic_settings.sources")
+    fake_sources.TomlConfigSettingsSource = object
+    sys.modules["pydantic_settings"] = fake_settings
+    sys.modules["pydantic_settings.sources"] = fake_sources
+
+
+def test_stats_output_includes_metadata_and_truncates_notes(tmp_path: Path, capsys) -> None:
+    _install_fake_pydantic_settings()
+    handle_stats = importlib.import_module("examples.demo_qa.batch").handle_stats
+    long_note = (
+        "This is a very long note that should be truncated because it exceeds the maximum width "
+        "of the column in the stats output."
+    )
+    entries = [
+        {
+            "run_id": "run123",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "run_status": "FAILED",
+            "tag": "demo-tag",
+            "note": long_note,
+            "fail_count": 5,
+            "pass_rate": 0.5,
+            "planned_total": 10,
+            "executed_total": 8,
+        }
+    ]
+    _write_history(tmp_path, entries)
+    args = SimpleNamespace(history=None, data=tmp_path, last=10, group_by=None, color="never")
+
+    exit_code = handle_stats(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert lines, "Expected stats output"
+    header = lines[0]
+    assert "timestamp" in header
+    assert "run_id" in header
+    assert "status" in header
+    assert "tag" in header
+    assert "note" in header
+    row = lines[1]
+    assert "run123" in row
+    assert "FAILED" in row
+    assert "demo-tag" in row
+    assert "80.0%" in row  # coverage
+    assert "50.0%" in row  # pass rate
+    assert "…" in row  # truncated note
+    assert long_note not in row
+    assert "\x1b[" not in out

--- a/examples/demo_qa/tests/test_demo_qa_tags.py
+++ b/examples/demo_qa/tests/test_demo_qa_tags.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _install_fake_pydantic_settings() -> None:
+    if "pydantic_settings" in sys.modules:
+        return
+    from pydantic import BaseModel
+
+    fake_settings = types.ModuleType("pydantic_settings")
+    fake_settings.BaseSettings = BaseModel
+    fake_settings.SettingsConfigDict = dict
+    fake_sources = types.ModuleType("pydantic_settings.sources")
+    fake_sources.TomlConfigSettingsSource = object
+    sys.modules["pydantic_settings"] = fake_settings
+    sys.modules["pydantic_settings.sources"] = fake_sources
+
+
+def _write_meta(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_tags_list_outputs_columns_and_filters(tmp_path: Path, capsys) -> None:
+    _install_fake_pydantic_settings()
+    tags_module = importlib.import_module("examples.demo_qa.commands.tags")
+    handle_tags_list = tags_module.handle_tags_list
+
+    artifacts = tmp_path / ".runs"
+    tag_a = artifacts / "runs" / "tags" / "alpha"
+    tag_b = artifacts / "runs" / "tags" / "beta"
+    run_dir = artifacts / "runs" / "20240101_cases"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_meta.json").write_text(json.dumps({"run_id": "r1", "note": "hello note"}), encoding="utf-8")
+
+    _write_meta(
+        tag_a / "effective_meta.json",
+        {
+            "tag": "alpha",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "planned_total": 10,
+            "executed_total": 8,
+            "missed_total": 2,
+            "counts": {"ok": 8, "total": 10, "skipped": 0},
+            "built_from_runs": [str(run_dir)],
+        },
+    )
+    _write_meta(
+        tag_b / "effective_meta.json",
+        {
+            "tag": "beta",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "planned_total": 5,
+            "executed_total": 5,
+            "missed_total": 0,
+            "counts": {"ok": 5, "total": 5, "skipped": 0},
+        },
+    )
+
+    args = SimpleNamespace(data=tmp_path, tags_command="list", pattern="a*", limit=None, sort="name")
+    exit_code = handle_tags_list(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert len(lines) == 2  # header + one row due to pattern
+    header = lines[0]
+    assert "tag" in header and "updated_at" in header and "plan/exe/miss" in header
+    row = lines[1]
+    assert "alpha" in row
+    assert "10/8/2" in row
+    assert "80.0%" in row
+    assert "r1" in row
+    assert "hello note" in row
+    assert "beta" not in out

--- a/examples/demo_qa/tests/test_demo_qa_term.py
+++ b/examples/demo_qa/tests/test_demo_qa_term.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from examples.demo_qa.term import color, render_table, strip_ansi
+
+
+def test_render_table_aligns_colored_cells() -> None:
+    headers = ["name", "num"]
+    rows = [
+        [color("alpha", "red", use_color=True), color("2", "green", use_color=True)],
+        [color("beta", "yellow", use_color=True), color("10", "green", use_color=True)],
+    ]
+    output = render_table(headers, rows, align_right={1})
+    lines = output.splitlines()
+    plain = [strip_ansi(line) for line in lines]
+
+    assert len(lines) == 3
+    assert any("\x1b[" in line for line in lines[1:])
+    num_start = plain[0].index("num")
+    assert plain[1].index("2") == num_start + len("num") - len("2")
+    assert plain[2].index("10") == num_start + len("num") - len("10")


### PR DESCRIPTION
## Summary
- add tag-based tag resolution to the compare CLI so effective snapshots can be diffed by tag
- add a compare-tag Makefile target with sensible defaults and required data checks
- cover tag-based compare flows with CLI tests

## Testing
- python -m pytest examples/demo_qa/tests/test_demo_qa_compare_cli.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596795d54c832f9d34796f72019d7e)