### PR TITLE
Add formatting and color controls to demo QA tag report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ NOTE  ?=
 CASE  ?=
 LIMIT ?= 50
 CHANGES ?= 10
+NEW_TAG ?=
+PATTERN ?=
 
 ONLY_FAILED_FROM ?=
 ONLY_MISSED_FROM ?=
@@ -90,7 +92,7 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
         batch batch-tag batch-failed batch-failed-from \
         batch-missed batch-missed-from batch-failed-tag batch-missed-tag \
         batch-fail-fast batch-max-fails \
-        stats history-case report-tag case-run case-open compare compare-tag
+        stats history-case report-tag report-tag-changes tags case-run case-open compare compare-tag
 
 # ==============================================================================
 # help (на русском)
@@ -128,11 +130,13 @@ help:
 	@echo "  make batch-fail-fast      - быстрый smoke (остановиться на первом фейле)"
 	@echo "  make batch-max-fails MAX_FAILS=5 - остановиться после N фейлов"
 	@echo "  make stats                - stats по последним 10 прогонов"
+	@echo "  make tags                 - список тегов (effective snapshots)"
 	@echo ""
 	@echo "Диагностика / анализ:"
 	@echo "  make history-case CASE=case_42 [TAG=...] [LIMIT=50] - история по кейсу"
 	@echo "  make report-tag TAG=...    - сводка по тегу (effective snapshot)"
 	@echo "  make report-tag-changes TAG=... [CHANGES=10] - сводка + последние изменения effective snapshot"
+	@echo "  make tags [PATTERN=*] DATA=... - показать список тегов"
 	@echo "  make case-run  CASE=case_42 - прогнать один кейс"
 	@echo "  make case-open CASE=case_42 - открыть артефакты кейса"
 	@echo ""
@@ -284,6 +288,9 @@ batch-missed-tag: ensure-runs-dir
 # stats (последние 10)
 stats: check
 	@$(CLI) stats --data "$(DATA)" --last 10
+
+tags: check
+	@$(CLI) tags list --data "$(DATA)" $(if $(strip $(PATTERN)),--pattern "$(PATTERN)",) $(if $(strip $(LIMIT)),--limit $(LIMIT),)
 
 # 8) История по кейсу (TAG опционален)
 history-case: check

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -171,6 +171,7 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--history", type=Path, default=None, help="Path to history.jsonl (default: <data>/.runs/history.jsonl)")
     stats_p.add_argument("--last", type=int, default=10, help="How many recent runs to show")
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
+    stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
 
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -208,6 +208,8 @@ def build_parser() -> argparse.ArgumentParser:
     tag_report.add_argument("--tag", type=str, required=True, help="Tag to report")
     tag_report.add_argument("--verbose", action="store_true", help="Print full counts and summary_by_tag")
     tag_report.add_argument("--changes", type=int, default=1, help="How many effective changes to show (default: 1)")
+    tag_report.add_argument("--format", choices=["plain", "table"], default="table", help="Output format")
+    tag_report.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode")
     run_report = report_sub.add_parser("run", help="Report a specific run folder or run_id")
     run_report.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
     run_report.add_argument("--run", type=Path, required=True, help="Run dir or run_id under runs/")

--- a/examples/demo_qa/cli.py
+++ b/examples/demo_qa/cli.py
@@ -26,6 +26,7 @@ from .batch import (  # noqa: E402
 )  # noqa: E402
 from .commands.history import handle_history_case  # noqa: E402
 from .commands.report import handle_report_run, handle_report_tag  # noqa: E402
+from .commands.tags import handle_tags_list  # noqa: E402
 from .data_gen import generate_and_save  # noqa: E402
 
 
@@ -173,6 +174,14 @@ def build_parser() -> argparse.ArgumentParser:
     stats_p.add_argument("--group-by", choices=["config_hash"], default=None, help="Group stats by config hash")
     stats_p.add_argument("--color", choices=["auto", "always", "never"], default="auto", help="ANSI color mode for stats table")
 
+    tags_p = sub.add_parser("tags", help="Tag utilities")
+    tags_sub = tags_p.add_subparsers(dest="tags_command", required=True)
+    tags_list = tags_sub.add_parser("list", help="List known tags")
+    tags_list.add_argument("--data", type=Path, required=True, help="Data dir containing .runs")
+    tags_list.add_argument("--pattern", type=str, default=None, help="Glob or regex to filter tag names")
+    tags_list.add_argument("--limit", type=int, default=None, help="Maximum number of tags to display")
+    tags_list.add_argument("--sort", choices=["name", "updated"], default="updated", help="Sort order")
+
     compare_p = sub.add_parser("compare", help="Compare two batch result files")
     compare_p.add_argument("--data", type=Path, default=None, help="Data dir containing .runs (for tag-based compare)")
     base_group = compare_p.add_mutually_exclusive_group(required=False)
@@ -245,6 +254,11 @@ def main() -> None:
     elif args.command == "history":
         if args.history_command == "case":
             code = handle_history_case(args)
+        else:
+            code = 1
+    elif args.command == "tags":
+        if args.tags_command == "list":
+            code = handle_tags_list(args)
         else:
             code = 1
     elif args.command == "report":

--- a/examples/demo_qa/commands/report.py
+++ b/examples/demo_qa/commands/report.py
@@ -6,8 +6,34 @@ from pathlib import Path
 from typing import Optional
 
 from ..runner import bad_statuses, load_results, summarize
-from ..runs.effective import _load_effective_diff, _load_effective_diff_history
+from ..runs.effective import _load_effective_diff_history
 from ..runs.layout import _effective_paths
+
+
+ANSI = {
+    "reset": "\x1b[0m",
+    "red": "\x1b[31m",
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "gray": "\x1b[90m",
+}
+
+
+def _color(text: str, color: str | None, *, use_color: bool) -> str:
+    if not use_color or not color:
+        return text
+    prefix = ANSI.get(color)
+    if not prefix:
+        return text
+    return f"{prefix}{text}{ANSI['reset']}"
+
+
+def _should_use_color(mode: str, *, stream) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
 
 
 def _resolve_run_dir_arg(run_arg: Path, artifacts_dir: Path) -> Optional[Path]:
@@ -55,7 +81,62 @@ def _reason_text(res) -> str:
     return ""
 
 
+def _format_pass_rate(value: float | None) -> str:
+    return f"{value*100:.1f}%" if value is not None else "n/a"
+
+
+def _format_table_rows(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    align_right: set[str],
+    use_color: bool,
+    color_map: dict[str, str] | None = None,
+    indent: str = "",
+    label: str | None = None,
+    label_width: int = 0,
+) -> list[str]:
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def _format_row(row: list[str], *, colorize: bool) -> str:
+        cells: list[str] = []
+        for idx, cell in enumerate(row):
+            header = headers[idx]
+            formatted = cell.rjust(widths[idx]) if header in align_right else cell.ljust(widths[idx])
+            color = (color_map or {}).get(header) if colorize else None
+            if color:
+                formatted = _color(formatted, color, use_color=use_color)
+            cells.append(formatted)
+        return "  ".join(cells)
+
+    lines: list[str] = []
+    label_prefix = ""
+    if label is not None:
+        label_prefix = f"{label:<{label_width}}" if label_width else label
+        lines.append(f"{indent}{label_prefix}  {_format_row(headers, colorize=False)}")
+        label_prefix = f"{'':<{label_width}}" if label_width else ""
+    for row in rows:
+        lines.append(f"{indent}{label_prefix}  {_format_row(row, colorize=True)}")
+    return lines
+
+
+def _color_for_metric(name: str) -> str | None:
+    if name == "ok":
+        return "green"
+    if name in {"bad", "error", "failed"}:
+        return "red"
+    if name in {"mismatch", "unchecked"}:
+        return "yellow"
+    return None
+
+
 def handle_report_tag(args) -> int:
+    format_mode = getattr(args, "format", "table")
+    color_mode = getattr(args, "color", "auto")
+    use_color = _should_use_color(color_mode, stream=sys.stdout)
     artifacts_dir = args.data / ".runs"
     eff_results_path, eff_meta_path = _effective_paths(artifacts_dir, args.tag)
     if not eff_results_path.exists() or not eff_meta_path.exists():
@@ -74,12 +155,11 @@ def handle_report_tag(args) -> int:
     counts = meta.get("counts") or summarize(results.values())
     fail_on = meta.get("fail_on", "bad")
     require_assert = bool(meta.get("require_assert", False))
-    print(f"Tag: {args.tag}")
     planned = meta.get("planned_total")
     executed = meta.get("executed_total")
     missed = meta.get("missed_total")
-    executed_pct = f"{(executed / planned * 100):.1f}%" if planned else "n/a"
-    print(f"Coverage: planned={planned} executed={executed} missed={missed} ({executed_pct} executed)")
+    executed_pct_value = (executed / planned * 100) if planned else None
+    executed_pct = f"{executed_pct_value:.1f}%" if executed_pct_value is not None else "n/a"
     ok = counts.get("ok", 0)
     mismatch = counts.get("mismatch", 0)
     failed = counts.get("failed", 0)
@@ -88,13 +168,72 @@ def handle_report_tag(args) -> int:
     skipped = counts.get("skipped", 0)
     non_skipped = (counts.get("total", 0) or 0) - (skipped or 0)
     pass_rate = (ok / non_skipped) if non_skipped else None
-    pass_rate_display = f"{pass_rate*100:.1f}%" if pass_rate is not None else "n/a"
+    pass_rate_display = _format_pass_rate(pass_rate)
     bad = bad_statuses(str(fail_on), require_assert)
     bad_total = sum(counts.get(status, 0) or 0 for status in bad)
-    print(f"Quality: ok={ok} mismatch={mismatch} failed={failed} error={error} unchecked={unchecked} bad={bad_total} pass_rate={pass_rate_display}")
-    if args.verbose:
-        print("Counts:", counts)
     summary_by_tag = meta.get("counts", {}).get("summary_by_tag") or counts.get("summary_by_tag") or {}
+    bad = bad_statuses(str(fail_on), require_assert)
+    failing = [res for res in results.values() if res.status in bad]
+    failing = sorted(failing, key=lambda r: r.id)[:10]
+    tag_dir = eff_results_path.parent
+    diff_history_path = tag_dir / "effective_changes.jsonl"
+
+    history_limit = max(0, int(args.changes)) if hasattr(args, "changes") else 1
+    history_entries = _load_effective_diff_history(tag_dir, limit=history_limit) if history_limit > 0 else []
+
+    if format_mode == "plain":
+        print(f"Tag: {args.tag}")
+        print(f"Coverage: planned={planned} executed={executed} missed={missed} ({executed_pct} executed)")
+        ok_disp = _color(str(ok), _color_for_metric("ok") or "", use_color=use_color)
+        mismatch_disp = _color(str(mismatch), _color_for_metric("mismatch") or "", use_color=use_color)
+        failed_disp = _color(str(failed), _color_for_metric("failed") or "", use_color=use_color)
+        error_disp = _color(str(error), _color_for_metric("error") or "", use_color=use_color)
+        unchecked_disp = _color(str(unchecked), _color_for_metric("unchecked") or "", use_color=use_color)
+        bad_disp = _color(str(bad_total), _color_for_metric("bad") or "", use_color=use_color)
+        print(
+            "Quality: "
+            f"ok={ok_disp} mismatch={mismatch_disp} failed={failed_disp} error={error_disp} "
+            f"unchecked={unchecked_disp} bad={bad_disp} pass_rate={pass_rate_display}"
+        )
+    elif format_mode == "table":
+        label_width = max(len("Coverage"), len("Quality"))
+        print(f"Tag: {args.tag}")
+        coverage_headers = ["planned", "executed", "missed", "executed%"]
+        coverage_rows = [[str(planned), str(executed), str(missed), executed_pct]]
+        for line in _format_table_rows(
+            coverage_headers,
+            coverage_rows,
+            align_right=set(coverage_headers),
+            use_color=use_color,
+            label="Coverage",
+            label_width=label_width,
+        ):
+            print(line)
+        quality_headers = ["ok", "mismatch", "failed", "error", "unchecked", "bad", "pass_rate"]
+        quality_row = [
+            str(ok),
+            str(mismatch),
+            str(failed),
+            str(error),
+            str(unchecked),
+            str(bad_total),
+            pass_rate_display,
+        ]
+        quality_colors = {name: _color_for_metric(name) for name in quality_headers}
+        for line in _format_table_rows(
+            quality_headers,
+            [quality_row],
+            align_right=set(quality_headers),
+            use_color=use_color,
+            color_map=quality_colors,
+            label="Quality",
+            label_width=label_width,
+        ):
+            print(line)
+    else:
+        print("Unknown format; use plain or table.", file=sys.stderr)
+        return 2
+
     if summary_by_tag:
         buckets = []
         for tag, bucket in summary_by_tag.items():
@@ -103,29 +242,33 @@ def handle_report_tag(args) -> int:
             buckets.append((tag, bad_bucket, pr))
         buckets.sort(key=lambda t: (-t[1], (t[2] if t[2] is not None else 1.1)))
         print("Top bad groups (by tag):")
+        headers = ["tag", "bad", "pass_rate"]
+        rows = []
         for tag, bad_bucket, pr in buckets[:5]:
-            pr_disp = f"{pr*100:.1f}%" if isinstance(pr, (int, float)) else "n/a"
-            print(f"- {tag}: bad={bad_bucket} pass_rate={pr_disp}")
+            pr_disp = _format_pass_rate(pr if isinstance(pr, (int, float)) else None)
+            rows.append([tag, str(bad_bucket), pr_disp])
+        for line in _format_table_rows(
+            headers, rows, align_right={"bad", "pass_rate"}, use_color=use_color, indent="  ", label=""
+        ):
+            print(line)
         if args.verbose:
             print("Full summary_by_tag:")
             print(json.dumps(summary_by_tag, ensure_ascii=False, indent=2))
-    bad = bad_statuses(str(fail_on), require_assert)
-    failing = [res for res in results.values() if res.status in bad]
-    failing = sorted(failing, key=lambda r: r.id)[:10]
     if failing:
         print("Failing cases (top 10):")
         for res in failing:
-            print(f"- {res.id}: {res.status} ({_reason_text(res)}) [{res.artifacts_dir}]")
-    tag_dir = eff_results_path.parent
+            status_text = f"{res.status:<9}"
+            color = _color_for_metric(res.status) or ("red" if res.status in bad else None)
+            status_disp = _color(status_text, color or "", use_color=use_color)
+            print(f"- {res.id:<20} {status_disp} {_reason_text(res)} [{res.artifacts_dir}]")
     print("Paths:")
-    print(f"- effective_results_path: {eff_results_path}")
-    print(f"- effective_meta_path:    {eff_meta_path}")
-    diff_history_path = tag_dir / "effective_changes.jsonl"
-    print(f"- effective_diff_history_path: {diff_history_path}")
+    path_labels = ["effective_results_path", "effective_meta_path", "effective_diff_history_path"]
+    label_width = max(len(name) for name in path_labels)
+    print(f"- {'effective_results_path'.ljust(label_width)}: {eff_results_path}")
+    print(f"- {'effective_meta_path'.ljust(label_width)}: {eff_meta_path}")
+    print(f"- {'effective_diff_history_path'.ljust(label_width)}: {diff_history_path}")
 
-    history_limit = max(0, int(args.changes)) if hasattr(args, "changes") else 1
     if history_limit > 0:
-        history_entries = _load_effective_diff_history(tag_dir, limit=history_limit)
         if history_entries:
             print(f"Last {len(history_entries)} effective change(s):")
             for entry in history_entries:

--- a/examples/demo_qa/commands/tags.py
+++ b/examples/demo_qa/commands/tags.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ..runner import bad_statuses
+
+
+@dataclass
+class TagInfo:
+    name: str
+    updated_at: str
+    updated_sort: float
+    planned: str
+    executed: str
+    missed: str
+    bad: str
+    pass_rate: str
+    last_run_id: str
+    note: str
+
+
+def _parse_ts(value: str | None) -> Optional[float]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value).timestamp()
+    except Exception:
+        return None
+
+
+def _format_pct(value: float | None) -> str:
+    return f"{value*100:.1f}%" if value is not None else "n/a"
+
+
+def _match_pattern(name: str, pattern: str | None) -> bool:
+    if not pattern:
+        return True
+    if pattern.startswith("re:"):
+        try:
+            return re.search(pattern[3:], name) is not None
+        except re.error:
+            return False
+    return fnmatch.fnmatch(name, pattern)
+
+
+def _load_meta(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_run_note(run_dir: Path) -> tuple[str, str]:
+    if not run_dir.exists():
+        return "", ""
+    summary_path = run_dir / "summary.json"
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            note = summary.get("note") or ""
+            run_id = summary.get("run_id") or run_dir.name
+            return run_id, note
+        except Exception:
+            pass
+    run_meta = run_dir / "run_meta.json"
+    if run_meta.exists():
+        try:
+            meta = json.loads(run_meta.read_text(encoding="utf-8"))
+            note = meta.get("note") or ""
+            run_id = meta.get("run_id") or run_dir.name
+            return run_id, note
+        except Exception:
+            pass
+    return run_dir.name, ""
+
+
+def _collect_tag_info(tag_dir: Path) -> Optional[TagInfo]:
+    meta_path = tag_dir / "effective_meta.json"
+    results_path = tag_dir / "effective_results.jsonl"
+    if not meta_path.exists() and not results_path.exists():
+        return None
+    meta = _load_meta(meta_path) or {}
+    counts = meta.get("counts") or {}
+
+    planned = meta.get("planned_total")
+    executed = meta.get("executed_total")
+    missed = meta.get("missed_total")
+    planned_str = str(planned) if planned is not None else "n/a"
+    executed_str = str(executed) if executed is not None else "n/a"
+    missed_str = str(missed) if missed is not None else "n/a"
+
+    fail_on = meta.get("fail_on", "bad")
+    require_assert = bool(meta.get("require_assert", False))
+    bad_status = bad_statuses(str(fail_on), require_assert)
+    bad_total = sum(counts.get(status, 0) or 0 for status in bad_status)
+    bad_str = str(bad_total) if counts else "n/a"
+
+    ok = counts.get("ok", 0) or 0
+    skipped = counts.get("skipped", 0) or 0
+    total = counts.get("total", 0) or 0
+    non_skipped = total - skipped
+    pass_rate = (ok / non_skipped) if non_skipped else None
+    pass_rate_str = _format_pct(pass_rate)
+
+    updated_at = meta.get("updated_at") or ""
+    updated_sort = _parse_ts(updated_at)
+    if updated_sort is None:
+        updated_sort = meta_path.stat().st_mtime if meta_path.exists() else results_path.stat().st_mtime
+        updated_at = (
+            datetime.fromtimestamp(updated_sort, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+            if updated_sort
+            else "n/a"
+        )
+
+    built_from = meta.get("built_from_runs") or []
+    last_run_id = "n/a"
+    note = meta.get("note") or ""
+    if built_from:
+        last_path = Path(sorted(str(p) for p in built_from)[-1])
+        run_id, run_note = _load_run_note(last_path)
+        last_run_id = run_id or "n/a"
+        note = note or run_note
+
+    return TagInfo(
+        name=tag_dir.name,
+        updated_at=updated_at or "n/a",
+        updated_sort=updated_sort or 0,
+        planned=planned_str,
+        executed=executed_str,
+        missed=missed_str,
+        bad=bad_str,
+        pass_rate=pass_rate_str,
+        last_run_id=last_run_id,
+        note=note or "",
+    )
+
+
+def _format_table(rows: Iterable[TagInfo]) -> list[str]:
+    headers = ["tag", "updated_at", "plan/exe/miss", "bad", "pass_rate", "last_run_id", "note"]
+    data = []
+    for row in rows:
+        data.append(
+            [
+                row.name,
+                row.updated_at,
+                f"{row.planned}/{row.executed}/{row.missed}",
+                row.bad,
+                row.pass_rate,
+                row.last_run_id,
+                row.note,
+            ]
+        )
+    widths = [len(h) for h in headers]
+    for row in data:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    lines = []
+    header_line = "  ".join(h.ljust(widths[idx]) for idx, h in enumerate(headers))
+    lines.append(header_line)
+    for row in data:
+        lines.append("  ".join(str(cell).ljust(widths[idx]) for idx, cell in enumerate(row)))
+    return lines
+
+
+def handle_tags_list(args) -> int:
+    artifacts_dir = args.data / ".runs"
+    tags_dir = artifacts_dir / "runs" / "tags"
+    if not tags_dir.exists():
+        print("No tags found.")
+        return 0
+
+    tag_infos: list[TagInfo] = []
+    for child in sorted(tags_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if not _match_pattern(child.name, args.pattern):
+            continue
+        info = _collect_tag_info(child)
+        if info:
+            tag_infos.append(info)
+
+    if not tag_infos:
+        print("No tags found.")
+        return 0
+
+    sort_by = getattr(args, "sort", "updated")
+    if sort_by == "name":
+        tag_infos.sort(key=lambda t: t.name)
+    else:
+        tag_infos.sort(key=lambda t: (-t.updated_sort, t.name))
+
+    limit = getattr(args, "limit", None)
+    if limit is not None:
+        try:
+            limit_int = int(limit)
+            if limit_int > 0:
+                tag_infos = tag_infos[:limit_int]
+        except Exception:
+            pass
+
+    for line in _format_table(tag_infos):
+        print(line)
+    return 0
+
+
+__all__ = ["handle_tags_list"]

--- a/examples/demo_qa/tests/test_demo_qa_report_tag.py
+++ b/examples/demo_qa/tests/test_demo_qa_report_tag.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 from examples.demo_qa.commands.report import handle_report_tag
 from examples.demo_qa.runner import RunResult
@@ -73,8 +73,10 @@ def test_report_tag_short_output(tmp_path, capsys):
     out = capsys.readouterr().out
 
     assert exit_code == 0
-    assert "Coverage:" in out
-    assert "Quality:" in out
+    assert "Coverage" in out
+    assert "planned" in out
+    assert "Quality" in out
+    assert "Top bad groups (by tag):" in out
     assert "effective_results_path" in out
     assert "Last 1 effective change" in out
 
@@ -89,3 +91,26 @@ def test_report_tag_changes_limit(tmp_path, capsys):
     assert exit_code == 0
     assert "r1" in out
     assert "r2" in out
+
+
+def test_report_tag_plain_output(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=1, format="plain", color="never")
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Coverage: planned=4 executed=3 missed=1 (75.0% executed)" in out
+    assert "Quality: ok=1 mismatch=0 failed=1 error=1 unchecked=0 bad=2 pass_rate=33.3%" in out
+
+
+def test_report_tag_color_never(tmp_path, capsys):
+    _write_effective(tmp_path)
+    args = SimpleNamespace(data=tmp_path, tag="demo", verbose=False, changes=1, color="never")
+
+    exit_code = handle_report_tag(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "\x1b[" not in out

--- a/examples/demo_qa/tests/test_demo_qa_stats.py
+++ b/examples/demo_qa/tests/test_demo_qa_stats.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _write_history(tmp_path: Path, entries: list[dict]) -> Path:
+    history_path = tmp_path / ".runs" / "history.jsonl"
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+    return history_path
+
+
+def _install_fake_pydantic_settings() -> None:
+    if "pydantic_settings" in sys.modules:
+        return
+    from pydantic import BaseModel
+
+    fake_settings = types.ModuleType("pydantic_settings")
+    fake_settings.BaseSettings = BaseModel
+    fake_settings.SettingsConfigDict = dict
+    fake_sources = types.ModuleType("pydantic_settings.sources")
+    fake_sources.TomlConfigSettingsSource = object
+    sys.modules["pydantic_settings"] = fake_settings
+    sys.modules["pydantic_settings.sources"] = fake_sources
+
+
+def test_stats_output_includes_metadata_and_truncates_notes(tmp_path: Path, capsys) -> None:
+    _install_fake_pydantic_settings()
+    handle_stats = importlib.import_module("examples.demo_qa.batch").handle_stats
+    long_note = (
+        "This is a very long note that should be truncated because it exceeds the maximum width "
+        "of the column in the stats output."
+    )
+    entries = [
+        {
+            "run_id": "run123",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "run_status": "FAILED",
+            "tag": "demo-tag",
+            "note": long_note,
+            "fail_count": 5,
+            "pass_rate": 0.5,
+            "planned_total": 10,
+            "executed_total": 8,
+        }
+    ]
+    _write_history(tmp_path, entries)
+    args = SimpleNamespace(history=None, data=tmp_path, last=10, group_by=None, color="never")
+
+    exit_code = handle_stats(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert lines, "Expected stats output"
+    header = lines[0]
+    assert "timestamp" in header
+    assert "run_id" in header
+    assert "status" in header
+    assert "tag" in header
+    assert "note" in header
+    row = lines[1]
+    assert "run123" in row
+    assert "FAILED" in row
+    assert "demo-tag" in row
+    assert "80.0%" in row  # coverage
+    assert "50.0%" in row  # pass rate
+    assert "…" in row  # truncated note
+    assert long_note not in row
+    assert "\x1b[" not in out

--- a/examples/demo_qa/tests/test_demo_qa_tags.py
+++ b/examples/demo_qa/tests/test_demo_qa_tags.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _install_fake_pydantic_settings() -> None:
+    if "pydantic_settings" in sys.modules:
+        return
+    from pydantic import BaseModel
+
+    fake_settings = types.ModuleType("pydantic_settings")
+    fake_settings.BaseSettings = BaseModel
+    fake_settings.SettingsConfigDict = dict
+    fake_sources = types.ModuleType("pydantic_settings.sources")
+    fake_sources.TomlConfigSettingsSource = object
+    sys.modules["pydantic_settings"] = fake_settings
+    sys.modules["pydantic_settings.sources"] = fake_sources
+
+
+def _write_meta(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_tags_list_outputs_columns_and_filters(tmp_path: Path, capsys) -> None:
+    _install_fake_pydantic_settings()
+    tags_module = importlib.import_module("examples.demo_qa.commands.tags")
+    handle_tags_list = tags_module.handle_tags_list
+
+    artifacts = tmp_path / ".runs"
+    tag_a = artifacts / "runs" / "tags" / "alpha"
+    tag_b = artifacts / "runs" / "tags" / "beta"
+    run_dir = artifacts / "runs" / "20240101_cases"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_meta.json").write_text(json.dumps({"run_id": "r1", "note": "hello note"}), encoding="utf-8")
+
+    _write_meta(
+        tag_a / "effective_meta.json",
+        {
+            "tag": "alpha",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "planned_total": 10,
+            "executed_total": 8,
+            "missed_total": 2,
+            "counts": {"ok": 8, "total": 10, "skipped": 0},
+            "built_from_runs": [str(run_dir)],
+        },
+    )
+    _write_meta(
+        tag_b / "effective_meta.json",
+        {
+            "tag": "beta",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "planned_total": 5,
+            "executed_total": 5,
+            "missed_total": 0,
+            "counts": {"ok": 5, "total": 5, "skipped": 0},
+        },
+    )
+
+    args = SimpleNamespace(data=tmp_path, tags_command="list", pattern="a*", limit=None, sort="name")
+    exit_code = handle_tags_list(args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert len(lines) == 2  # header + one row due to pattern
+    header = lines[0]
+    assert "tag" in header and "updated_at" in header and "plan/exe/miss" in header
+    row = lines[1]
+    assert "alpha" in row
+    assert "10/8/2" in row
+    assert "80.0%" in row
+    assert "r1" in row
+    assert "hello note" in row
+    assert "beta" not in out


### PR DESCRIPTION
## Summary
- add `--format` and `--color` options to the `report tag` command with defaults that emit aligned table output and auto color
- render coverage, quality, and top bad group sections as spaced tables and colorize key metrics and failing case statuses while maintaining ANSI-free output when requested
- expand tag report tests to cover plain output, color suppression, and updated table formatting expectations

## Testing
- pytest examples/demo_qa/tests/test_demo_qa_report_tag.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598670492c832fb8013dfa1a9e4a81)