### PR TITLE
Restore legacy relational import shims

### DIFF
--- a/src/fetchgraph/json_types.py
+++ b/src/fetchgraph/json_types.py
@@ -1,0 +1,11 @@
+"""Legacy compatibility aliases for JSON selector types.
+
+The canonical definitions live in :mod:`fetchgraph.relational.types`. This
+module preserves the historical import path used prior to the relational
+package refactor.
+"""
+
+from .relational.types import JSONDict, JSONPrimitive, JSONValue, SelectorsDict
+
+__all__ = ["JSONPrimitive", "JSONValue", "JSONDict", "SelectorsDict"]
+

--- a/src/fetchgraph/relational_base.py
+++ b/src/fetchgraph/relational_base.py
@@ -1,0 +1,6 @@
+"""Legacy compatibility shim for the relational base provider."""
+
+from .relational.providers import RelationalDataProvider
+
+__all__ = ["RelationalDataProvider"]
+

--- a/src/fetchgraph/relational_composite.py
+++ b/src/fetchgraph/relational_composite.py
@@ -1,0 +1,6 @@
+"""Legacy compatibility shim for composite relational provider."""
+
+from .relational.providers import CompositeRelationalProvider
+
+__all__ = ["CompositeRelationalProvider"]
+

--- a/src/fetchgraph/relational_models.py
+++ b/src/fetchgraph/relational_models.py
@@ -1,0 +1,12 @@
+"""Legacy compatibility layer for relational models.
+
+The current implementations live under :mod:`fetchgraph.relational.models`.
+Importing from this module continues to work for consumers pinned to the old
+paths.
+"""
+
+from .relational import models as _models
+from .relational.models import *  # noqa: F401,F403
+
+__all__ = _models.__all__
+

--- a/src/fetchgraph/relational_models.py
+++ b/src/fetchgraph/relational_models.py
@@ -7,6 +7,6 @@ paths.
 
 from .relational import models as _models
 from .relational.models import *  # noqa: F401,F403
+from .relational.models import QueryResult
 
-__all__ = _models.__all__
-
+__all__ = [*_models.__all__, "QueryResult"]

--- a/src/fetchgraph/relational_pandas.py
+++ b/src/fetchgraph/relational_pandas.py
@@ -1,0 +1,6 @@
+"""Legacy compatibility shim for the pandas relational provider."""
+
+from .relational.providers import PandasRelationalDataProvider
+
+__all__ = ["PandasRelationalDataProvider"]
+

--- a/src/fetchgraph/relational_provider.py
+++ b/src/fetchgraph/relational_provider.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Compatibility layer exposing relational provider components.
+
+Legacy import paths (e.g., ``fetchgraph.relational_provider``) now forward to
+the reorganized modules under :mod:`fetchgraph.relational`.
+"""
+
+import importlib.util
+
+from .relational import models as _relational_models
+from .relational.models import *  # noqa: F401,F403
+from .relational.providers import (
+    CompositeRelationalProvider,
+    RelationalDataProvider,
+    SqlRelationalDataProvider,
+)
+from .relational.semantic import SemanticBackend
+
+_maybe_pandas = importlib.util.find_spec("pandas")
+if _maybe_pandas:
+    from .relational.providers import PandasRelationalDataProvider
+else:  # pragma: no cover - optional dependency path
+    PandasRelationalDataProvider = None  # type: ignore[assignment]
+
+__all__ = [
+    *_relational_models.__all__,
+    "RelationalDataProvider",
+    "SqlRelationalDataProvider",
+    "CompositeRelationalProvider",
+    "SemanticBackend",
+]
+
+if _maybe_pandas:
+    __all__.append("PandasRelationalDataProvider")
+

--- a/src/fetchgraph/relational_sql.py
+++ b/src/fetchgraph/relational_sql.py
@@ -1,0 +1,6 @@
+"""Legacy compatibility shim for the SQL relational provider."""
+
+from .relational.providers import SqlRelationalDataProvider
+
+__all__ = ["SqlRelationalDataProvider"]
+

--- a/src/fetchgraph/semantic_backend.py
+++ b/src/fetchgraph/semantic_backend.py
@@ -1,0 +1,12 @@
+"""Legacy compatibility shim for semantic backends.
+
+The canonical implementations reside in :mod:`fetchgraph.relational.semantic`.
+This module preserves the historical import path used prior to the relational
+package refactor.
+"""
+
+from .relational import semantic as _semantic
+from .relational.semantic import *  # noqa: F401,F403
+
+__all__ = _semantic.__all__
+


### PR DESCRIPTION
## Summary
- add thin compatibility modules for legacy `fetchgraph.relational_*` and `semantic_backend` import paths
- alias JSON selector type definitions to the previous `json_types` module name

## Testing
- pytest tests/test_relational_base.py tests/test_relational_pandas.py tests/test_relational_sql.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a068bcdf4832f85fe2cb0bc2c9a4a)