### PR TITLE
Stop PlanNormalizer synthesizing required_context; always merge via setdefault and normalize text lists

### DIFF
--- a/src/fetchgraph/core/context.py
+++ b/src/fetchgraph/core/context.py
@@ -486,9 +486,8 @@ class BaseGraphAgent:
             by_provider.setdefault(b.spec.provider, b.spec)
         for s in plan.context_plan or []:
             by_provider[s.provider] = s
-        if not plan.context_plan:
-            for p in plan.required_context or []:
-                by_provider.setdefault(p, ContextFetchSpec(provider=p, mode="full"))
+        for p in plan.required_context or []:
+            by_provider.setdefault(p, ContextFetchSpec(provider=p, mode="full"))
         specs = list(by_provider.values())
         logger.debug(
             "Merged baseline with plan: context_plan_nodes=%d, baseline_specs=%d, "

--- a/src/fetchgraph/planning/normalize/plan_normalizer.py
+++ b/src/fetchgraph/planning/normalize/plan_normalizer.py
@@ -24,8 +24,6 @@ class NormalizedPlan(Plan):
 class PlanNormalizerOptions:
     allow_unknown_providers: bool = False
     coerce_provider_case: bool = True
-    fill_missing_context_plan: bool = True
-    add_required_context_specs: bool = True
     dedupe_required_context: bool = True
     dedupe_context_plan: bool = True
     trim_text_fields: bool = True
@@ -95,18 +93,10 @@ class PlanNormalizer:
         required_context = self._normalize_required_context(plan.required_context, notes)
         context_plan = self._normalize_context_plan(plan.context_plan, notes)
 
-        if self.options.add_required_context_specs:
-            context_plan = self._ensure_required_specs(
-                required_context, context_plan, notes
-            )
-
-        if self.options.fill_missing_context_plan and not context_plan:
-            context_plan = [
-                ContextFetchSpec(provider=p, mode=self.options.default_mode)
-                for p in required_context
-            ]
-            if required_context:
-                notes.append("context_plan_filled_from_required_context")
+        # IMPORTANT:
+        # Do NOT synthesize ContextFetchSpec from required_context here.
+        # Baseline/plan merge owns "ensure required providers exist" logic,
+        # and must do it in a baseline-safe way (never overriding baseline selectors/mode).
 
         context_plan = self._normalize_specs(context_plan, notes)
 
@@ -300,9 +290,9 @@ class PlanNormalizer:
         values: Optional[Iterable[Any]],
         notes: List[str],
         label: str,
-    ) -> Optional[List[str]]:
+    ) -> List[str]:
         if values is None:
-            return None
+            return []
         normalized: List[str] = []
         for raw in values:
             if not isinstance(raw, str):

--- a/src/fetchgraph/planning/normalize/plan_normalizer.py
+++ b/src/fetchgraph/planning/normalize/plan_normalizer.py
@@ -265,26 +265,6 @@ class PlanNormalizer:
             )
         return normalized
 
-    def _ensure_required_specs(
-        self,
-        required: Iterable[str],
-        context_plan: List[ContextFetchSpec],
-        notes: List[str],
-    ) -> List[ContextFetchSpec]:
-        existing = {spec.provider for spec in context_plan}
-        added = 0
-        for provider in required:
-            if provider in existing:
-                continue
-            context_plan.append(
-                ContextFetchSpec(provider=provider, mode=self.options.default_mode)
-            )
-            existing.add(provider)
-            added += 1
-        if added:
-            notes.append(f"context_plan_required_added:{added}")
-        return context_plan
-
     def _normalize_text_list(
         self,
         values: Optional[Iterable[Any]],

--- a/tests/test_context_merge.py
+++ b/tests/test_context_merge.py
@@ -1,0 +1,73 @@
+from fetchgraph.core.context import BaseGraphAgent, ContextPacker
+from fetchgraph.core.models import BaselineSpec, ContextFetchSpec, Plan
+
+
+def _make_agent(baseline):
+    packer = ContextPacker(max_tokens=10, summarizer_llm=lambda text: text)
+    return BaseGraphAgent(
+        llm_plan=None,
+        llm_synth=lambda feature_name, ctx, plan: "",
+        domain_parser=lambda raw: raw,
+        saver=lambda name, obj: None,
+        providers={},
+        verifiers=[],
+        packer=packer,
+        baseline=baseline,
+    )
+
+
+def _get_spec(specs, provider):
+    return next(spec for spec in specs if spec.provider == provider)
+
+
+def test_merge_baseline_preserved_when_context_plan_missing():
+    baseline_spec = ContextFetchSpec(
+        provider="X", selectors={"a": 1}, mode="filter"
+    )
+    agent = _make_agent([BaselineSpec(spec=baseline_spec)])
+    plan = Plan(required_context=["X"])
+
+    merged = agent._merge_baseline_with_plan(plan)
+
+    merged_spec = _get_spec(merged, "X")
+    assert merged_spec.model_dump() == baseline_spec.model_dump()
+
+
+def test_merge_baseline_preserved_when_context_plan_empty():
+    baseline_spec = ContextFetchSpec(
+        provider="X", selectors={"a": 1}, mode="filter"
+    )
+    agent = _make_agent([BaselineSpec(spec=baseline_spec)])
+    plan = Plan(required_context=["X"], context_plan=[])
+
+    merged = agent._merge_baseline_with_plan(plan)
+
+    merged_spec = _get_spec(merged, "X")
+    assert merged_spec.model_dump() == baseline_spec.model_dump()
+
+
+def test_merge_required_context_materializes_without_baseline():
+    agent = _make_agent(baseline=[])
+    plan = Plan(required_context=["X"])
+
+    merged = agent._merge_baseline_with_plan(plan)
+
+    merged_spec = _get_spec(merged, "X")
+    assert merged_spec.provider == "X"
+    assert merged_spec.mode == "full"
+    assert merged_spec.selectors in ({}, None)
+    assert getattr(merged_spec, "max_tokens", None) is None
+
+
+def test_required_context_materializes_even_when_context_plan_non_empty():
+    agent = _make_agent(baseline=[])
+    plan = Plan(
+        required_context=["X"],
+        context_plan=[ContextFetchSpec(provider="A", mode="full")],
+    )
+
+    merged = agent._merge_baseline_with_plan(plan)
+    providers = {spec.provider for spec in merged}
+
+    assert "A" in providers
+    assert "X" in providers


### PR DESCRIPTION
### Motivation
- Prevent overwriting baseline `ContextFetchSpec` entries by moving required-provider synthesis out of the normalizer and into the baseline/plan merge logic.
- Ensure downstream code and templates always receive list values for `adr_queries` and `constraints` so they never get `None`.
- Add regression coverage to guarantee that `required_context` is materialized even when `context_plan` is non-empty.

### Description
- Removed synthesis of `ContextFetchSpec` from `PlanNormalizer.normalize()` and added a comment that baseline/plan merge must handle required providers in a baseline-safe way.
- Removed unused flags from `PlanNormalizerOptions` related to filling/mutating `context_plan` and `required_context`.
- Changed `BaseGraphAgent._merge_baseline_with_plan` to always `setdefault` entries from `plan.required_context`, materializing missing providers as `ContextFetchSpec(provider=p, mode="full")` while preserving any baseline specs.
- Updated `PlanNormalizer._normalize_text_list` to always return a `List[str]` (returning an empty list when input is `None`), and used it for `adr_queries` and `constraints` so normalized plans never contain `None` for those fields.
- Added `tests/test_context_merge.py` with four regression tests covering baseline preservation and required_context materialization, including the case where `context_plan` is non-empty.

### Testing
- Added unit tests in `tests/test_context_merge.py` covering baseline preservation when `context_plan` is missing or empty, materialization of `required_context` when no baseline exists, and materialization when `context_plan` is non-empty.
- No automated tests were executed as part of this update, so there are no test run results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697120969ab8832f839d6354e5e083c0)