### PR TITLE
Make expected checks case-insensitive and normalize list/set elements

### DIFF
--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -210,6 +210,14 @@ def _stringify(value: object | None) -> str | None:
     return str(value)
 
 
+def _normalize_text(value: str) -> str:
+    return value.strip().casefold()
+
+
+def _normalize_strings(values: Iterable[object]) -> list[str]:
+    return [_normalize_text(str(value)) for value in values]
+
+
 def _match_expected(case: Case, answer: str | None) -> ExpectedCheck | None:
     if not case.has_asserts:
         return None
@@ -218,7 +226,15 @@ def _match_expected(case: Case, answer: str | None) -> ExpectedCheck | None:
         return ExpectedCheck(mode="none", expected=expected_value, passed=False, detail="no answer")
     if case.expected is not None:
         expected_str = _stringify(case.expected) or ""
-        passed = answer.strip() == expected_str.strip()
+        if isinstance(case.expected, (list, tuple, set)):
+            expected_items = _normalize_strings(case.expected)
+            answer_items = _normalize_strings(answer) if isinstance(answer, (list, tuple, set)) else []
+            if isinstance(case.expected, set) or isinstance(answer, set):
+                passed = set(expected_items) == set(answer_items)
+            else:
+                passed = expected_items == answer_items
+        else:
+            passed = _normalize_text(answer) == _normalize_text(expected_str)
         detail = None if passed else f"expected={expected_str!r}, got={answer!r}"
         return ExpectedCheck(mode="exact", expected=expected_str, passed=passed, detail=detail)
     if case.expected_regex is not None:
@@ -229,7 +245,7 @@ def _match_expected(case: Case, answer: str | None) -> ExpectedCheck | None:
         return ExpectedCheck(mode="regex", expected=expected_regex, passed=passed, detail=detail)
     if case.expected_contains is not None:
         expected_contains = _stringify(case.expected_contains) or ""
-        passed = expected_contains in answer
+        passed = _normalize_text(expected_contains) in _normalize_text(answer)
         detail = None if passed else f"expected to contain {expected_contains!r}"
         return ExpectedCheck(mode="contains", expected=expected_contains, passed=passed, detail=detail)
     return None

--- a/examples/demo_qa/tests/test_demo_qa_runner.py
+++ b/examples/demo_qa/tests/test_demo_qa_runner.py
@@ -32,7 +32,7 @@ def test_match_expected_coerces_non_string_expected_values() -> None:
 def test_match_expected_contains_pass_and_fail() -> None:
     case = Case(id="c2", question="Q", expected_contains="bar")
 
-    match = _match_expected(case, "value bar baz")
+    match = _match_expected(case, "value BAR baz")
     assert match is not None
     assert match.passed is True
 
@@ -45,6 +45,26 @@ def test_match_expected_contains_pass_and_fail() -> None:
     assert missing_answer is not None
     assert missing_answer.passed is False
     assert missing_answer.detail == "no answer"
+
+
+def test_match_expected_equals_is_case_insensitive() -> None:
+    case = Case(id="c3", question="Q", expected="Alpha")
+
+    match = _match_expected(case, "alpha")
+    assert match is not None
+    assert match.passed is True
+
+
+def test_match_expected_list_comparison_normalizes_elements() -> None:
+    case = Case(id="c4", question="Q", expected=["Foo", "Bar"])
+
+    match = _match_expected(case, cast(str, ["foo", "bar"]))
+    assert match is not None
+    assert match.passed is True
+
+    mismatch = _match_expected(case, cast(str, ["foo", "baz"]))
+    assert mismatch is not None
+    assert mismatch.passed is False
 
 
 def test_diff_runs_tracks_regressions_and_improvements() -> None:


### PR DESCRIPTION
### Motivation
- Make the runner's expectation checks robust to casing differences for `contains` and `equals` comparisons and to minor formatting differences in list/set elements.
- Keep error messages showing the original (un-normalized) strings while performing comparisons using normalized values.

### Description
- Added normalization helpers ` _normalize_text` and `_normalize_strings` in `examples/demo_qa/runner.py` and updated `_match_expected` to use them for comparisons.
- For `contains` checks, compare `norm(expected) in norm(actual)` by using `_normalize_text` on both sides.
- For `equals` checks, perform `norm(expected) == norm(actual)` and added support for list/tuple/set comparisons by normalizing elements and comparing lists or sets as appropriate while still reporting original strings in `ExpectedCheck.detail`.
- Added unit tests in `examples/demo_qa/tests/test_demo_qa_runner.py` covering case-insensitive `contains`, case-insensitive `equals`, and normalized list comparisons (`test_match_expected_contains_pass_and_fail`, `test_match_expected_equals_is_case_insensitive`, `test_match_expected_list_comparison_normalizes_elements`).

### Testing
- No automated test suite was executed as part of this change (no `pytest` run in the rollout).
- New unit tests were added but not run: `test_match_expected_equals_is_case_insensitive` and `test_match_expected_list_comparison_normalizes_elements` in `examples/demo_qa/tests/test_demo_qa_runner.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714666ae24832fac4e9195389165cb)