### PR TITLE
Add GitHub Actions workflow to run pytest on pull requests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: pytest
+
+on:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev]"
+
+      - name: Run pytest (not slow, not known_bad)
+        env:
+          PYTHONPATH: .:src
+        run: python -m pytest -q -m "not slow and not known_bad"


### PR DESCRIPTION
### Motivation
- Ensure pull requests run the same `pytest` invocation as the pre-commit hook by adding a CI workflow that executes tests with the `not slow` and `not known_bad` markers.

### Description
- Add `.github/workflows/pytest.yml` which triggers on `pull_request`, sets up Python 3.11, installs dev dependencies with `python -m pip install -e ".[dev]"`, sets `PYTHONPATH` to `.:src`, and runs `python -m pytest -q -m "not slow and not known_bad"`.

### Testing
- No automated tests were run as part of this change; the new workflow will run `python -m pytest -q -m "not slow and not known_bad"` automatically on future pull requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973838e78d4832fa14a33a0b099df7a)