### PR TITLE
Align tracer tooling with unified Tracer v2 spec (logging, export, resolve, fixtures, CLI, handlers)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ TRACER_OUT_DIR ?= $(TRACER_ROOT)/$(BUCKET)
 RUN_DIR ?=
 ALLOW_BAD_JSON ?=
 OVERWRITE ?= 0
+SELECT ?= latest
+SELECT_INDEX ?=
+REQUIRE_UNIQUE ?= 0
 SCOPE ?= both
 WITH_RESOURCES ?= 1
 ALL ?=
@@ -92,6 +95,7 @@ DRY ?= 0
 VALIDATE ?= 0
 OVERWRITE_EXPECTED ?= 0
 MOVE_TRACES ?= 0
+GIT ?= auto
 
 # ==============================================================================
 # 6) Настройки LLM-конфига (редактирование/просмотр)
@@ -391,11 +395,14 @@ tracer-export:
 	  --case "$(CASE)" \
 	  --data "$(REPLAY_IDATA)" \
 	  --provider "$(PROVIDER)" \
+	  --select "$(SELECT)" \
 	  $(if $(RUN_ID),--run-id "$(RUN_ID)",) \
 	  $(if $(CASE_DIR),--case-dir "$(CASE_DIR)",) \
 	  $(if $(RUN_DIR),--run-dir "$(RUN_DIR)",) \
 	  $(if $(EVENTS),--events "$(EVENTS)",) \
 	  $(if $(TAG),--tag "$(TAG)",) \
+	  $(if $(SELECT_INDEX),--select-index "$(SELECT_INDEX)",) \
+	  $(if $(filter 1 true yes on,$(REQUIRE_UNIQUE)),--require-unique,) \
 	  $(if $(filter 1 true yes on,$(OVERWRITE)),--overwrite,) \
 	  $(if $(filter 1 true yes on,$(ALLOW_BAD_JSON)),--allow-bad-json,)
 
@@ -410,7 +417,7 @@ tracer-ls:
 	  $(if $(RUN_DIR),--run-dir "$(RUN_DIR)",) \
 	  $(if $(EVENTS),--events "$(EVENTS)",) \
 	  $(if $(strip $(TAG)),--tag "$(TAG)",) \
-	  --list-matches
+	  --list-runs
 
 fixture-green:
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make fixture-green CASE=tests/fixtures/replay_cases/known_bad/fixture.case.json (или CASE=fixture_stem)" && exit 1)
@@ -421,6 +428,7 @@ fixture-green:
 	$(PYTHON) -m fetchgraph.tracer.cli fixture-green --case "$$case_path" --root "$(TRACER_ROOT)" \
 	  $(if $(filter 1 true yes on,$(VALIDATE)),--validate,) \
 	  $(if $(filter 1 true yes on,$(OVERWRITE_EXPECTED)),--overwrite-expected,) \
+	  --git "$(GIT)" \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
 fixture-rm:
@@ -429,6 +437,7 @@ fixture-rm:
 	  $(if $(strip $(NAME)),--name "$(NAME)",) \
 	  $(if $(strip $(PATTERN)),--pattern "$(PATTERN)",) \
 	  $(if $(strip $(SCOPE)),--scope "$(SCOPE)",) \
+	  --git "$(GIT)" \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
 fixture-fix:
@@ -436,10 +445,12 @@ fixture-fix:
 	@test -n "$(strip $(NEW_NAME))" || (echo "NEW_NAME обязателен: make fixture-fix NAME=old_stem NEW_NAME=new_stem" && exit 1)
 	@$(PYTHON) -m fetchgraph.tracer.cli fixture-fix --root "$(TRACER_ROOT)" --bucket "$(BUCKET)" \
 	  --name "$(NAME)" --new-name "$(NEW_NAME)" \
+	  --git "$(GIT)" \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
 fixture-migrate:
 	@$(PYTHON) -m fetchgraph.tracer.cli fixture-migrate --root "$(TRACER_ROOT)" --bucket "$(BUCKET)" \
+	  --git "$(GIT)" \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
 

--- a/src/fetchgraph/planning/normalize/plan_normalizer.py
+++ b/src/fetchgraph/planning/normalize/plan_normalizer.py
@@ -210,6 +210,13 @@ class PlanNormalizer:
                         "selectors": use,
                     },
                 }
+                rule_trace = [
+                    {
+                        "rule": f"SelectorNormalizationRule:{rule_kind}",
+                        "matched": after_ok,
+                        "reason": decision,
+                    }
+                ]
                 log_replay_case(
                     replay_logger,
                     id="plan_normalize.spec_v1",
@@ -223,6 +230,7 @@ class PlanNormalizer:
                     diag={
                         "selectors_valid_before": before_ok,
                         "selectors_valid_after": after_ok,
+                        "rule_trace": rule_trace,
                     },
                     note=note,
                 )

--- a/src/fetchgraph/replay/handlers/__init__.py
+++ b/src/fetchgraph/replay/handlers/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from .plan_normalize import replay_plan_normalize_spec_v1
+from .resource_read import replay_resource_read
 
-__all__ = ["replay_plan_normalize_spec_v1"]
+__all__ = ["replay_plan_normalize_spec_v1", "replay_resource_read"]

--- a/src/fetchgraph/replay/handlers/resource_read.py
+++ b/src/fetchgraph/replay/handlers/resource_read.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..runtime import REPLAY_HANDLERS, ReplayContext
+
+
+def replay_resource_read(inp: dict, ctx: ReplayContext) -> dict:
+    resource_id = inp.get("resource_id")
+    if not isinstance(resource_id, str) or not resource_id:
+        raise ValueError("resource_id is required for resource.read")
+    resource = ctx.resources.get(resource_id)
+    if not isinstance(resource, dict):
+        raise KeyError(f"Resource not found: {resource_id}")
+    data_ref = resource.get("data_ref")
+    if not isinstance(data_ref, dict):
+        raise ValueError(f"Resource {resource_id} is missing data_ref")
+    file_name = data_ref.get("file")
+    if not isinstance(file_name, str) or not file_name:
+        raise ValueError(f"Resource {resource_id} data_ref.file is required")
+    resolved = ctx.resolve_resource_path(Path(file_name))
+    return {"content": resolved.read_text(encoding="utf-8")}
+
+
+REPLAY_HANDLERS["resource.read"] = replay_resource_read

--- a/src/fetchgraph/replay/log.py
+++ b/src/fetchgraph/replay/log.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, Protocol
 
+MAX_TRACE_LENGTH = 20_000
+
 
 class EventLoggerLike(Protocol):
     def emit(self, event: Dict[str, object]) -> None: ...
@@ -34,6 +36,9 @@ def log_replay_case(
             raise ValueError("observed_error.type must be a non-empty string")
         if not isinstance(observed_error.get("message"), str) or not observed_error.get("message"):
             raise ValueError("observed_error.message must be a non-empty string")
+        trace = observed_error.get("trace")
+        if isinstance(trace, str) and len(trace) > MAX_TRACE_LENGTH:
+            observed_error["trace"] = trace[:MAX_TRACE_LENGTH]
     if meta is not None and not isinstance(meta, dict):
         raise ValueError("meta must be a dict when provided")
     if note is not None and not isinstance(note, str):
@@ -73,3 +78,6 @@ def log_replay_case(
         event["diag"] = diag
     logger.emit(event)
 
+
+def log_replay_point(*args: object, **kwargs: object) -> None:
+    log_replay_case(*args, **kwargs)

--- a/src/fetchgraph/replay/runtime.py
+++ b/src/fetchgraph/replay/runtime.py
@@ -26,7 +26,7 @@ def run_case(root: dict, ctx: ReplayContext) -> dict:
     replay_id = root["id"]
     if replay_id not in REPLAY_HANDLERS:
         raise KeyError(
-            f"No handler for replay id={replay_id!r}. "
+            f"Replay handler not registered for id={replay_id!r}. "
             "Did you import fetchgraph.tracer.handlers?"
         )
     handler = REPLAY_HANDLERS[replay_id]

--- a/src/fetchgraph/tracer/handlers/__init__.py
+++ b/src/fetchgraph/tracer/handlers/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from fetchgraph.replay.handlers.plan_normalize import replay_plan_normalize_spec_v1
+from fetchgraph.replay.handlers.resource_read import replay_resource_read
 
-__all__ = ["replay_plan_normalize_spec_v1"]
+__all__ = ["replay_plan_normalize_spec_v1", "replay_resource_read"]

--- a/src/fetchgraph/tracer/log.py
+++ b/src/fetchgraph/tracer/log.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from fetchgraph.replay.log import EventLoggerLike, log_replay_case
+from fetchgraph.replay.log import EventLoggerLike, log_replay_case, log_replay_point
 
-__all__ = ["EventLoggerLike", "log_replay_case"]
+__all__ = ["EventLoggerLike", "log_replay_case", "log_replay_point"]

--- a/tests/fixtures/replay_cases/fixed/resource_read.case.json
+++ b/tests/fixtures/replay_cases/fixed/resource_read.case.json
@@ -1,0 +1,31 @@
+{
+  "extras": {},
+  "resources": {
+    "rid1": {
+      "data_ref": {
+        "file": "resources/resource_read/rid1/data.txt"
+      },
+      "id": "rid1",
+      "type": "replay_resource"
+    }
+  },
+  "root": {
+    "id": "resource.read",
+    "input": {
+      "resource_id": "rid1"
+    },
+    "observed": {
+      "content": "hello resource\n"
+    },
+    "type": "replay_case",
+    "v": 2
+  },
+  "schema": "fetchgraph.tracer.case_bundle",
+  "source": {
+    "events_path": "events.jsonl",
+    "line": 1,
+    "run_id": "resource-read-test",
+    "timestamp": "2024-01-01T00:00:00Z"
+  },
+  "v": 1
+}

--- a/tests/fixtures/replay_cases/fixed/resource_read.expected.json
+++ b/tests/fixtures/replay_cases/fixed/resource_read.expected.json
@@ -1,0 +1,3 @@
+{
+  "content": "hello resource\n"
+}

--- a/tests/fixtures/replay_cases/fixed/resources/resource_read/rid1/data.txt
+++ b/tests/fixtures/replay_cases/fixed/resources/resource_read/rid1/data.txt
@@ -1,0 +1,1 @@
+hello resource

--- a/tests/test_replay_export_selection.py
+++ b/tests/test_replay_export_selection.py
@@ -22,7 +22,7 @@ def test_iter_events_allow_bad_json(tmp_path: Path) -> None:
     events_path = tmp_path / "events.jsonl"
     events_path.write_text('{"type":"ok"}\n{bad json}\n{"type":"ok2"}\n', encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Invalid JSON on line 2"):
+    with pytest.raises(ValueError, match="Invalid JSON on line 2:"):
         list(iter_events(events_path, allow_bad_json=False))
 
     events = list(iter_events(events_path, allow_bad_json=True))

--- a/tests/test_replay_fixtures.py
+++ b/tests/test_replay_fixtures.py
@@ -84,6 +84,10 @@ def _format_case_debug(
     root_id = root.get("id") if isinstance(root, dict) else None
     root_meta = root.get("meta") if isinstance(root, dict) else None
     root_input = root.get("input") if isinstance(root, dict) else None
+    root_diag = root.get("diag") if isinstance(root, dict) else None
+    rule_trace = None
+    if isinstance(root_diag, dict):
+        rule_trace = root_diag.get("rule_trace")
     lines = [
         "Replay fixture diagnostics:",
         f"case_id: {case_id}",
@@ -91,6 +95,7 @@ def _format_case_debug(
         f"root.id: {root_id!r}",
         f"root.meta: {format_json(root_meta)}",
         f"root.input: {format_json(root_input)}",
+        f"root.diag.rule_trace: {format_json(rule_trace)}",
     ]
     if out is not None:
         lines.append(f"handler.out: {format_json(out)}")

--- a/tests/test_replay_resource_access.py
+++ b/tests/test_replay_resource_access.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import fetchgraph.tracer.handlers  # noqa: F401
+from fetchgraph.tracer.runtime import load_case_bundle, run_case
+
+
+def test_replay_resource_read_uses_fixture_file() -> None:
+    case_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "replay_cases"
+        / "fixed"
+        / "resource_read.case.json"
+    )
+    expected_path = case_path.with_name("resource_read.expected.json")
+    root, ctx = load_case_bundle(case_path)
+    out = run_case(root, ctx)
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    assert out == expected

--- a/tests/test_replay_runtime.py
+++ b/tests/test_replay_runtime.py
@@ -8,5 +8,5 @@ from fetchgraph.replay.runtime import ReplayContext, run_case
 def test_run_case_missing_handler_message() -> None:
     root = {"id": "unknown.handler", "input": {}}
     ctx = ReplayContext()
-    with pytest.raises(KeyError, match="Did you import fetchgraph.tracer.handlers\\?"):
+    with pytest.raises(KeyError, match="Replay handler not registered.*Did you import fetchgraph.tracer.handlers\\?"):
         run_case(root, ctx)

--- a/tests/test_tracer_auto_resolve.py
+++ b/tests/test_tracer_auto_resolve.py
@@ -36,9 +36,9 @@ def _make_case_dir(
     if with_events:
         _touch(case_dir / "events.jsonl")
     payload = {"status": status}
-    if tag:
-        payload["tag"] = tag
     _write_json(case_dir / "status.json", payload)
+    if tag:
+        _write_json(run_dir / "run_meta.json", {"tag": tag})
     return case_dir
 
 

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -39,7 +39,7 @@ def test_fixture_green_requires_observed(tmp_path: Path) -> None:
     _write_bundle(case_path, payload)
 
     with pytest.raises(ValueError, match="root.observed is missing"):
-        fixture_green(case_path=case_path, out_root=root)
+        fixture_green(case_path=case_path, out_root=root, git_mode="off")
 
 
 def test_fixture_green_moves_case_and_resources(tmp_path: Path) -> None:
@@ -59,7 +59,7 @@ def test_fixture_green_moves_case_and_resources(tmp_path: Path) -> None:
     )
     _write_bundle(case_path, payload)
 
-    fixture_green(case_path=case_path, out_root=root)
+    fixture_green(case_path=case_path, out_root=root, git_mode="off")
 
     fixed_case = root / "fixed" / "case.case.json"
     expected_path = root / "fixed" / "case.expected.json"
@@ -94,7 +94,7 @@ def test_fixture_fix_renames_and_updates_resource_paths(tmp_path: Path) -> None:
     expected_path = root / bucket / "old.expected.json"
     expected_path.write_text("{}", encoding="utf-8")
 
-    fixture_fix(root=root, name="old", new_name="new", bucket=bucket, dry_run=False)
+    fixture_fix(root=root, name="old", new_name="new", bucket=bucket, dry_run=False, git_mode="off")
 
     new_case = root / bucket / "new.case.json"
     new_expected = root / bucket / "new.expected.json"
@@ -126,7 +126,7 @@ def test_fixture_migrate_moves_resources(tmp_path: Path) -> None:
     )
     _write_bundle(case_path, payload)
 
-    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
+    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False, git_mode="off")
     assert bundles_updated == 1
     assert files_moved == 1
     data = json.loads(case_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
### Motivation
- Bring tracer runtime/replay/export/fixture tooling into alignment with the unified Tracer v2 spec: observed-first events, reproducible case bundles, resource handling, UX for multi-matches and bad JSON, and git-aware fixture operations.
- Add diagnostics (rule-trace) and a resource-access handler so replay fixtures can exercise file resources and handler diagnostics end-to-end.

### Description
- Extended runtime logging in `fetchgraph.replay.log`: added `MAX_TRACE_LENGTH` truncation for error traces and a deprecated alias `log_replay_point` for `log_replay_case`.
- Improved runner message in `fetchgraph.replay.runtime.run_case` to suggest importing `fetchgraph.tracer.handlers` when handlers are missing.
- Enhanced event parsing and export in `fetchgraph.replay.export`: `iter_events` reports truncated excerpts and supports `allow_bad_json` with a summary warning, `copy_resource_files` and export now support `overwrite` semantics to clean resources, and multi-match selection emits stronger warnings when inputs differ.
- Advanced auto-resolve and tag/missed detection in `fetchgraph.tracer.resolve`: added robust status/tag extraction from run/case files and events, skip missed cases, and tag-matching heuristics (run_dir name / events grep).
- CLI updates in `fetchgraph.tracer.cli` and `Makefile`: added/renamed flags (`--run-select-index`, `--list-runs`, reuse `--select-index` for replay match), `--git` controls, `--select` wiring, and extra diagnostic printing options.
- Git-aware fixture tooling in `fetchgraph.tracer.fixture_tools`: `fixture-green`, `fixture-rm`, `fixture-fix`, and `fixture-migrate` support `git` modes (`auto|on|off`) and perform `git mv` / `git rm` when appropriate; added safe helpers for atomic writes and git operations.
- Added rule-trace diagnostics to plan normalizer logging (`plan_normalize`) so handlers emit `diag.rule_trace` entries.
- Added a new replay handler `resource.read` in `fetchgraph.replay.handlers.resource_read` that reads resource files through `ReplayContext.resolve_resource_path` and registered it in tracer handler imports.
- Added fixture, expected and data file for resource access and a test `tests/test_replay_resource_access.py` verifying handler reads fixture files correctly; small test adjustments to match new messages/excerpts.

### Testing
- Ran the pytest subset: `pytest tests/test_replay_export_selection.py tests/test_tracer_auto_resolve.py tests/test_tracer_fixture_tools.py tests/test_replay_fixtures.py tests/test_replay_resource_access.py tests/test_replay_runtime.py`; results: 17 passed, 1 skipped.
- Existing replay/fixture tests updated where needed to match new behavior (excerpts, trace newline normalization, git-mode args).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976397f0948832fb5a19356b8208bb9)