### PR TITLE
Respect events flag when creating case loggers

### DIFF
--- a/examples/demo_qa/runner.py
+++ b/examples/demo_qa/runner.py
@@ -392,7 +392,7 @@ def run_one(
 
     run_dir.mkdir(parents=True, exist_ok=True)
     events_path = run_dir / "events.jsonl"
-    case_logger = event_logger.for_case(case.id, events_path) if event_logger else EventLogger(events_path, run_id, case.id)
+    case_logger = event_logger.for_case(case.id, events_path) if event_logger else None
     if case_logger:
         case_logger.emit({"type": "run_started", "case_id": case.id, "run_dir": str(run_dir)})
         case_logger.emit({"type": "case_started", "case_id": case.id, "run_dir": str(run_dir)})
@@ -481,7 +481,11 @@ def run_one(
             status="error",
             checked=case.has_asserts,
             reason=error_message,
-            details={"error": error_message, "traceback": tb, "events_path": str(events_path)},
+            details={
+                "error": error_message,
+                "traceback": tb,
+                **({"events_path": str(events_path)} if case_logger else {}),
+            },
             artifacts_dir=str(run_dir),
             duration_ms=0,
             tags=list(case.tags),


### PR DESCRIPTION
### Motivation
- `run_one` previously auto-created a per-case `EventLogger` when `event_logger` was `None`, causing events to be written even when the CLI path explicitly disables events (e.g. `--events off`).
- This could produce large unintended trace files or expose data users opted out of logging.

### Description
- Stop auto-creating a case logger by changing the creation to `case_logger = event_logger.for_case(case.id, events_path) if event_logger else None` in `examples/demo_qa/runner.py` so logging only occurs when an `event_logger` is provided.
- Only include the `events_path` metadata in error `details` when `case_logger` is active by conditionally adding `{"events_path": str(events_path)}`.
- The change is local to `run_one` in `examples/demo_qa/runner.py` and preserves existing behavior when an `event_logger` is supplied.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f7e8a9b8832f88e4dd6d6b4d3656)