### PR TITLE
Fix relational selector validation

### DIFF
--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -477,8 +477,9 @@ def fixture_green(
                 raise AssertionError(_format_fixture_diff(out, expected))
             replay_id = root_case.get("id") if isinstance(root_case, dict) else None
             validator = REPLAY_VALIDATORS.get(replay_id)
-            if validator is not None:
-                validator(out)
+            if validator is None:
+                raise AssertionError(f"No validator registered for replay id={replay_id!r}")
+            validator(out)
         except Exception as exc:
             tx.rollback()
             if fixed_expected_path.exists():

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .diff_utils import first_diff_path
 from .fixture_layout import FixtureLayout, find_case_bundles
 from .runtime import load_case_bundle, run_case
+from .validators import REPLAY_VALIDATORS
 
 
 @dataclass(frozen=True)
@@ -474,6 +475,10 @@ def fixture_green(
             expected = json.loads(fixed_expected_path.read_text(encoding="utf-8"))
             if out != expected:
                 raise AssertionError(_format_fixture_diff(out, expected))
+            replay_id = root_case.get("id") if isinstance(root_case, dict) else None
+            validator = REPLAY_VALIDATORS.get(replay_id)
+            if validator is not None:
+                validator(out)
         except Exception as exc:
             tx.rollback()
             if fixed_expected_path.exists():

--- a/src/fetchgraph/tracer/validators.py
+++ b/src/fetchgraph/tracer/validators.py
@@ -4,6 +4,8 @@ from pydantic import TypeAdapter
 
 from fetchgraph.relational.models import RelationalRequest
 
+RELATIONAL_PROVIDERS = {"demo_qa", "relational"}
+
 
 def validate_plan_normalize_spec_v1(out: dict) -> None:
     if not isinstance(out, dict):
@@ -11,11 +13,24 @@ def validate_plan_normalize_spec_v1(out: dict) -> None:
     out_spec = out.get("out_spec")
     if not isinstance(out_spec, dict):
         raise AssertionError("Output must contain out_spec dict")
+    provider = out_spec.get("provider")
     selectors = out_spec.get("selectors")
     if selectors is None:
         raise AssertionError("out_spec.selectors is required")
     if not isinstance(selectors, dict):
         raise AssertionError("out_spec.selectors must be a dict")
-    if "root_entity" not in selectors:
+    is_relational = (
+        provider in RELATIONAL_PROVIDERS
+        or (isinstance(provider, str) and provider.startswith("relational"))
+        or any(key in selectors for key in ("root_entity", "relations", "entity"))
+    )
+    if not is_relational:
         return
+    if "root_entity" not in selectors:
+        if "entity" in selectors:
+            raise AssertionError(
+                "Relational selectors missing required key 'root_entity' "
+                "(looks like you produced 'entity' instead)."
+            )
+        raise AssertionError("Relational selectors missing required key 'root_entity'")
     TypeAdapter(RelationalRequest).validate_python(selectors)

--- a/src/fetchgraph/tracer/validators.py
+++ b/src/fetchgraph/tracer/validators.py
@@ -34,3 +34,8 @@ def validate_plan_normalize_spec_v1(out: dict) -> None:
             )
         raise AssertionError("Relational selectors missing required key 'root_entity'")
     TypeAdapter(RelationalRequest).validate_python(selectors)
+
+
+REPLAY_VALIDATORS = {
+    "plan_normalize.spec_v1": validate_plan_normalize_spec_v1,
+}

--- a/tests/test_replay_fixed.py
+++ b/tests/test_replay_fixed.py
@@ -10,6 +10,7 @@ import fetchgraph.tracer.handlers  # noqa: F401
 import tests.helpers.handlers_resource_read  # noqa: F401
 from fetchgraph.tracer.runtime import load_case_bundle, run_case
 from fetchgraph.tracer.diff_utils import first_diff_path
+from fetchgraph.tracer.validators import REPLAY_VALIDATORS
 from tests.helpers.replay_dx import format_json, ids_from_path, truncate, truncate_limits
 
 REPLAY_CASES_ROOT = Path(__file__).parent / "fixtures" / "replay_cases"
@@ -75,6 +76,10 @@ def test_replay_fixed_cases(case_path: Path) -> None:
             ]
         )
         pytest.fail(message, pytrace=False)
+    replay_id = root.get("id") if isinstance(root, dict) else None
+    validator = REPLAY_VALIDATORS.get(replay_id)
+    if validator is not None:
+        validator(out)
     assert out == expected
 
 

--- a/tests/test_replay_fixed.py
+++ b/tests/test_replay_fixed.py
@@ -78,8 +78,12 @@ def test_replay_fixed_cases(case_path: Path) -> None:
         pytest.fail(message, pytrace=False)
     replay_id = root.get("id") if isinstance(root, dict) else None
     validator = REPLAY_VALIDATORS.get(replay_id)
-    if validator is not None:
-        validator(out)
+    if validator is None:
+        pytest.fail(
+            f"No validator registered for replay id={replay_id!r}. Add it to REPLAY_VALIDATORS.",
+            pytrace=False,
+        )
+    validator(out)
     assert out == expected
 
 

--- a/tests/test_replay_known_bad_backlog.py
+++ b/tests/test_replay_known_bad_backlog.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import json
 import traceback
 from pathlib import Path
-from typing import Callable
-
 import pytest
 from pydantic import ValidationError
 
 import fetchgraph.tracer.handlers  # noqa: F401
 from fetchgraph.tracer.runtime import load_case_bundle, run_case
-from fetchgraph.tracer.validators import validate_plan_normalize_spec_v1
+from fetchgraph.tracer.validators import REPLAY_VALIDATORS
 from tests.helpers.replay_dx import (
     build_rerun_hints,
     debug_enabled,
@@ -24,11 +22,6 @@ from tests.helpers.replay_dx import (
 
 REPLAY_CASES_ROOT = Path(__file__).parent / "fixtures" / "replay_cases"
 KNOWN_BAD_DIR = REPLAY_CASES_ROOT / "known_bad"
-
-VALIDATORS: dict[str, Callable[[dict], None]] = {
-    "plan_normalize.spec_v1": validate_plan_normalize_spec_v1,
-}
-
 
 def _iter_known_bad_paths() -> list[Path]:
     if not KNOWN_BAD_DIR.exists():
@@ -93,10 +86,10 @@ def test_known_bad_backlog(bundle_path: Path) -> None:
     if not isinstance(replay_id, str) or not replay_id:
         pytest.fail("Replay id missing or invalid in bundle root.", pytrace=False)
     replay_id_str: str = replay_id
-    validator = VALIDATORS.get(replay_id_str)
+    validator = REPLAY_VALIDATORS.get(replay_id_str)
     if validator is None:
         pytest.fail(
-            f"No validator registered for replay id={replay_id!r}. Add it to VALIDATORS.",
+            f"No validator registered for replay id={replay_id!r}. Add it to REPLAY_VALIDATORS.",
             pytrace=False,
         )
     input_limit, meta_limit = truncate_limits()


### PR DESCRIPTION
### Motivation
- Ensure relational outputs are detected and validated strictly so missing `root_entity` is treated as an error instead of silently returning.
- Avoid passing malformed relational selectors to Pydantic without a clear hint for common mistakes (e.g. producing `entity` instead of `root_entity`).

### Description
- Update `src/fetchgraph/tracer/validators.py` to add `RELATIONAL_PROVIDERS` and detect relational outputs using `out_spec.provider` or presence of relational keys in selectors.
- For relational requests, raise an `AssertionError` when `root_entity` is missing and provide a clear hint when `entity` is present.
- After the explicit `root_entity` check call `TypeAdapter(RelationalRequest).validate_python(selectors)` to let Pydantic perform full validation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697712887008832fbd4c88bd88cce441)