### PR TITLE
Add validator for resource_read.v1 replay cases

### DIFF
--- a/src/fetchgraph/tracer/validators.py
+++ b/src/fetchgraph/tracer/validators.py
@@ -36,6 +36,15 @@ def validate_plan_normalize_spec_v1(out: dict) -> None:
     TypeAdapter(RelationalRequest).validate_python(selectors)
 
 
+def validate_resource_read_v1(out: dict) -> None:
+    if not isinstance(out, dict):
+        raise AssertionError("Output must be a dict")
+    text = out.get("text")
+    if not isinstance(text, str):
+        raise AssertionError("Output must include text string")
+
+
 REPLAY_VALIDATORS = {
     "plan_normalize.spec_v1": validate_plan_normalize_spec_v1,
+    "resource_read.v1": validate_resource_read_v1,
 }


### PR DESCRIPTION
### Motivation
- Fix a failing fixed-replay test caused by `resource_read.v1` not being present in `REPLAY_VALIDATORS`, which made `test_replay_fixed_cases` abort with a missing-validator error.

### Description
- Add `validate_resource_read_v1` in `src/fetchgraph/tracer/validators.py` and register it in `REPLAY_VALIDATORS` to ensure replay outputs are a dict and include a `text` string.

### Testing
- Ran `pytest tests/test_replay_fixed.py::test_replay_fixed_cases` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69771dba34d0832fae3136e338d3e2da)