### PR TITLE
Tighten type guards in diff and replay validation

### DIFF
--- a/src/fetchgraph/tracer/diff_utils.py
+++ b/src/fetchgraph/tracer/diff_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 def first_diff_path(left: object, right: object, *, prefix: str = "") -> str | None:
     if type(left) is not type(right):
         return prefix or "<root>"
-    if isinstance(left, dict):
+    if isinstance(left, dict) and isinstance(right, dict):
         left_keys = set(left.keys())
         right_keys = set(right.keys())
         for key in sorted(left_keys | right_keys):
@@ -15,7 +15,7 @@ def first_diff_path(left: object, right: object, *, prefix: str = "") -> str | N
             if diff is not None:
                 return diff
         return None
-    if isinstance(left, list):
+    if isinstance(left, list) and isinstance(right, list):
         if len(left) != len(right):
             return f"{prefix}.length" if prefix else "length"
         for idx, (l_item, r_item) in enumerate(zip(left, right), start=1):

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -476,6 +476,8 @@ def fixture_green(
             if out != expected:
                 raise AssertionError(_format_fixture_diff(out, expected))
             replay_id = root_case.get("id") if isinstance(root_case, dict) else None
+            if not isinstance(replay_id, str):
+                raise AssertionError("Case bundle has missing or non-string replay id.")
             validator = REPLAY_VALIDATORS.get(replay_id)
             if validator is None:
                 raise AssertionError(f"No validator registered for replay id={replay_id!r}")

--- a/tests/test_replay_fixed.py
+++ b/tests/test_replay_fixed.py
@@ -77,6 +77,8 @@ def test_replay_fixed_cases(case_path: Path) -> None:
         )
         pytest.fail(message, pytrace=False)
     replay_id = root.get("id") if isinstance(root, dict) else None
+    if not isinstance(replay_id, str):
+        pytest.fail("Case bundle has missing or non-string replay id.", pytrace=False)
     validator = REPLAY_VALIDATORS.get(replay_id)
     if validator is None:
         pytest.fail(


### PR DESCRIPTION
### Motivation
- Pyright reported unsafe attribute/index access and iterable/len usages because values were typed as `object`, so comparisons needed precise narrowing.
- Replay fixture code assumed `root_case["id"]` could be used as a string key for validator lookup which caused type-safety issues when the id was missing or not a string.

### Description
- In `src/fetchgraph/tracer/diff_utils.py` narrow dict/list comparisons by checking both `left` and `right` with `isinstance(..., dict)` and `isinstance(..., list)` before using mapping/list operations. 
- In `src/fetchgraph/tracer/fixture_tools.py` validate that `replay_id` is a `str` and raise `AssertionError` if it is missing or not a string before looking up `REPLAY_VALIDATORS`.
- In `tests/test_replay_fixed.py` mirror the stricter runtime behavior by failing the test with `pytest.fail` when the case bundle `id` is missing or not a string.

### Testing
- No automated tests were executed as part of this change.
- The changes are narrowly scoped to address static type-narrowing issues and to enforce string-typed replay ids for validator lookup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774fd5c234832fb2150d3781bfda7d)