### PR TITLE
Improve plan_normalize replay dependency handling

### DIFF
--- a/src/fetchgraph/planning/normalize/plan_normalizer.py
+++ b/src/fetchgraph/planning/normalize/plan_normalizer.py
@@ -221,9 +221,9 @@ class PlanNormalizer:
                             selectors_schema=self.schema_registry[spec.provider],
                         )
                     )
-                requires = []
+                requires = None
                 if not self._provider_info_snapshot_sufficient(provider_info_snapshot):
-                    requires.append({"kind": "extra", "id": "planner_input_v1"})
+                    requires = [{"kind": "extra", "id": "planner_input_v1"}]
                 input_payload = {
                     "spec": {
                         "provider": spec.provider,
@@ -257,7 +257,7 @@ class PlanNormalizer:
                         "selectors_valid_after": after_ok,
                         "rule_trace": rule_trace,
                     },
-                    requires=requires or None,
+                    requires=requires,
                     note=note,
                 )
             if use == selectors_before:
@@ -303,9 +303,6 @@ class PlanNormalizer:
             return False
         selectors_schema = snapshot.get("selectors_schema")
         if isinstance(selectors_schema, dict) and selectors_schema:
-            return True
-        capabilities = snapshot.get("capabilities")
-        if isinstance(capabilities, list) and capabilities:
             return True
         return False
 

--- a/src/fetchgraph/planning/normalize/plan_normalizer.py
+++ b/src/fetchgraph/planning/normalize/plan_normalizer.py
@@ -221,6 +221,9 @@ class PlanNormalizer:
                             selectors_schema=self.schema_registry[spec.provider],
                         )
                     )
+                requires = []
+                if not self._provider_info_snapshot_sufficient(provider_info_snapshot):
+                    requires.append({"kind": "extra", "id": "planner_input_v1"})
                 input_payload = {
                     "spec": {
                         "provider": spec.provider,
@@ -254,6 +257,7 @@ class PlanNormalizer:
                         "selectors_valid_after": after_ok,
                         "rule_trace": rule_trace,
                     },
+                    requires=requires or None,
                     note=note,
                 )
             if use == selectors_before:
@@ -292,6 +296,18 @@ class PlanNormalizer:
             payload["selectors_before"] = selectors_before
             payload["selectors_after"] = selectors_after
         return json.dumps(payload, ensure_ascii=False, default=str)
+
+    @staticmethod
+    def _provider_info_snapshot_sufficient(snapshot: Optional[Dict[str, Any]]) -> bool:
+        if not isinstance(snapshot, dict):
+            return False
+        selectors_schema = snapshot.get("selectors_schema")
+        if isinstance(selectors_schema, dict) and selectors_schema:
+            return True
+        capabilities = snapshot.get("capabilities")
+        if isinstance(capabilities, list) and capabilities:
+            return True
+        return False
 
     def _normalize_required_context(
         self, values: Iterable[str], notes: List[str]

--- a/src/fetchgraph/replay/export.py
+++ b/src/fetchgraph/replay/export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import collections
 import filecmp
 import hashlib
 import json
@@ -335,10 +336,10 @@ def resolve_requires(
 
     resolved_resources: Dict[str, dict] = {}
     resolved_extras: Dict[str, dict] = {}
-    pending = list(normalized_requires)
+    pending = collections.deque(normalized_requires)
     seen: set[tuple[str, str]] = set()
     while pending:
-        req = pending.pop(0)
+        req = pending.popleft()
         kind = req.get("kind")
         rid = req.get("id")
         if not isinstance(kind, str) or not isinstance(rid, str):

--- a/src/fetchgraph/replay/handlers/plan_normalize.py
+++ b/src/fetchgraph/replay/handlers/plan_normalize.py
@@ -26,6 +26,7 @@ def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
     provider_catalog: Dict[str, ProviderInfo] = {}
     provider_info_source = "minimal_fallback"
     provider_snapshot = inp.get("provider_info_snapshot")
+    provider_snapshot_present = isinstance(provider_snapshot, dict)
     if isinstance(provider_snapshot, dict):
         provider_catalog[provider] = ProviderInfo(**provider_snapshot)
         provider_info_source = "snapshot"
@@ -84,7 +85,11 @@ def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
         "notes_last": notes[-1] if notes else None,
     }
     if provider_info_source == "minimal_fallback":
-        out_payload["diag"] = {"provider_info_source": provider_info_source}
+        out_payload["diag"] = {
+            "provider_info_source": provider_info_source,
+            "missing_planner_input": "planner_input_v1" not in ctx.extras,
+            "provider_snapshot_present": provider_snapshot_present,
+        }
     return out_payload
 
 

--- a/src/fetchgraph/replay/handlers/plan_normalize.py
+++ b/src/fetchgraph/replay/handlers/plan_normalize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Dict
 
 from pydantic import TypeAdapter
@@ -14,6 +15,8 @@ from ...relational.models import RelationalRequest
 from ...relational.normalize import normalize_relational_selectors
 from ..runtime import REPLAY_HANDLERS, ReplayContext
 
+logger = logging.getLogger(__name__)
+
 
 def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
     spec_dict = dict(inp["spec"])
@@ -21,9 +24,11 @@ def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
     rules = inp.get("normalizer_rules") or inp.get("normalizer_registry") or {}
     provider = spec_dict["provider"]
     provider_catalog: Dict[str, ProviderInfo] = {}
+    provider_info_source = "minimal_fallback"
     provider_snapshot = inp.get("provider_info_snapshot")
     if isinstance(provider_snapshot, dict):
         provider_catalog[provider] = ProviderInfo(**provider_snapshot)
+        provider_info_source = "snapshot"
     else:
         planner = ctx.extras.get("planner_input_v1") or {}
         planner_input = planner.get("input") if isinstance(planner, dict) else {}
@@ -32,6 +37,7 @@ def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
             catalog_raw = planner_input.get("provider_catalog") or {}
         if provider in catalog_raw and isinstance(catalog_raw[provider], dict):
             provider_catalog[provider] = ProviderInfo(**catalog_raw[provider])
+            provider_info_source = "planner_input"
         else:
             provider_catalog[provider] = ProviderInfo(name=provider, capabilities=[])
 
@@ -60,10 +66,26 @@ def replay_plan_normalize_spec_v1(inp: dict, ctx: ReplayContext) -> dict:
         "mode": out.mode,
         "selectors": out.selectors,
     }
-    return {
+    logger.info(
+        "replay_plan_normalize_spec_v1: replay_id=%s provider=%s provider_info_source=%s",
+        "plan_normalize.spec_v1",
+        provider,
+        provider_info_source,
+    )
+    if provider_info_source == "minimal_fallback":
+        logger.warning(
+            "replay_plan_normalize_spec_v1: provider_info_source=minimal_fallback "
+            "replay_id=%s provider=%s",
+            "plan_normalize.spec_v1",
+            provider,
+        )
+    out_payload = {
         "out_spec": out_spec,
         "notes_last": notes[-1] if notes else None,
     }
+    if provider_info_source == "minimal_fallback":
+        out_payload["diag"] = {"provider_info_source": provider_info_source}
+    return out_payload
 
 
 REPLAY_HANDLERS["plan_normalize.spec_v1"] = replay_plan_normalize_spec_v1

--- a/tests/test_replay_requires_plan_normalize.py
+++ b/tests/test_replay_requires_plan_normalize.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from fetchgraph.replay.export import export_replay_case_bundle
+from fetchgraph.replay.handlers.plan_normalize import replay_plan_normalize_spec_v1
+from fetchgraph.replay.runtime import ReplayContext
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+
+def test_export_bundle_resolves_planner_input_schema_ref(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    replay_case = {
+        "type": "replay_case",
+        "v": 2,
+        "id": "plan_normalize.spec_v1",
+        "meta": {"provider": "relational", "spec_idx": 0},
+        "input": {
+            "spec": {"provider": "relational", "mode": "full", "selectors": {"op": "query"}},
+            "options": {},
+            "normalizer_rules": {"relational": "relational_v1"},
+        },
+        "observed": {
+            "out_spec": {"provider": "relational", "mode": "full", "selectors": {"op": "query"}},
+        },
+        "requires": [{"kind": "extra", "id": "planner_input_v1"}],
+    }
+    planner_input = {
+        "type": "planner_input",
+        "id": "planner_input_v1",
+        "input": {
+            "provider_catalog": {
+                "relational": {
+                    "name": "relational",
+                    "selectors_schema": {"type": "object", "properties": {"op": {"type": "string"}}},
+                }
+            },
+            "schema_ref": "schema_v1",
+        },
+    }
+    schema_resource = {"type": "replay_resource", "id": "schema_v1", "data": {"schema": {"type": "object"}}}
+    _write_events(events_path, [replay_case, planner_input, schema_resource])
+
+    out_dir = tmp_path / "out"
+    bundle_path = export_replay_case_bundle(
+        events_path=events_path,
+        out_dir=out_dir,
+        replay_id="plan_normalize.spec_v1",
+    )
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    assert "planner_input_v1" in bundle["extras"]
+    assert "schema_v1" in bundle["resources"]
+
+
+def test_export_requires_missing_planner_input_raises(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    replay_case = {
+        "type": "replay_case",
+        "v": 2,
+        "id": "plan_normalize.spec_v1",
+        "meta": {"provider": "relational", "spec_idx": 2},
+        "input": {
+            "spec": {"provider": "relational", "mode": "full", "selectors": {"op": "query"}},
+            "options": {},
+            "normalizer_rules": {"relational": "relational_v1"},
+        },
+        "observed": {
+            "out_spec": {"provider": "relational", "mode": "full", "selectors": {"op": "query"}},
+        },
+        "requires": [{"kind": "extra", "id": "planner_input_v1"}],
+    }
+    _write_events(events_path, [replay_case])
+
+    with pytest.raises(KeyError) as excinfo:
+        export_replay_case_bundle(
+            events_path=events_path,
+            out_dir=tmp_path / "out",
+            replay_id="plan_normalize.spec_v1",
+        )
+    message = str(excinfo.value)
+    assert "planner_input_v1" in message
+    assert "plan_normalize.spec_v1" in message
+
+
+def test_replay_plan_normalize_uses_planner_input(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="fetchgraph.replay.handlers.plan_normalize")
+    inp = {
+        "spec": {"provider": "relational", "mode": "full", "selectors": {"op": "query"}},
+        "options": {},
+        "normalizer_rules": {"relational": "relational_v1"},
+    }
+    ctx = ReplayContext(
+        extras={
+            "planner_input_v1": {
+                "input": {
+                    "provider_catalog": {
+                        "relational": {
+                            "name": "relational",
+                            "selectors_schema": {"type": "object", "properties": {"op": {"type": "string"}}},
+                        }
+                    }
+                }
+            }
+        }
+    )
+    out = replay_plan_normalize_spec_v1(inp, ctx)
+    assert out["out_spec"]["provider"] == "relational"
+    assert "provider_info_source=planner_input" in caplog.text


### PR DESCRIPTION
### Motivation
- Make `plan_normalize.spec_v1` replay deterministic and avoid silent minimal `ProviderInfo` fallbacks when the original run had richer provider data. 
- Ensure exported case bundles include required extras/resources transitively (e.g., `planner_input_v1` and referenced schema resources) so replays reproduce original semantics. 
- Fail fast and surface clear diagnostics when required extras (notably `planner_input_v1`) are missing during export. 

### Description
- Update `PlanNormalizer` to compute `requires` for `log_replay_case` and emit `[{"kind":"extra","id":"planner_input_v1"}]` when the provider snapshot is deemed insufficient by the new `_provider_info_snapshot_sufficient` check (file: `src/fetchgraph/planning/normalize/plan_normalizer.py`).
- Extend replay export resolution to normalize requires, follow transitive requires inside extras (including `schema_ref` and `input.requires`), and include those resources/extras in the bundle (file: `src/fetchgraph/replay/export.py`).
- Make `resolve_requires` fail with a clear `KeyError` and actionable message when `planner_input_v1` is required but missing, and annotate missing resource errors with the originating replay case metadata (file: `src/fetchgraph/replay/export.py`).
- Improve replay handler `plan_normalize` logging to record `provider_info_source` (`snapshot` / `planner_input` / `minimal_fallback`) and include a `diag` warning when falling back to a minimal `ProviderInfo` (file: `src/fetchgraph/replay/handlers/plan_normalize.py`).
- Add unit tests covering export resolution and handler behavior for `planner_input_v1` and schema resource transitive inclusion (new test file: `tests/test_replay_requires_plan_normalize.py`).

### Testing
- Ran `pytest -q tests/test_replay_requires_plan_normalize.py` and all tests passed (3 passed). 
- The new tests validate that exported bundles include `planner_input_v1` and referenced `schema_v1`, that missing `planner_input_v1` raises a clear error, and that the replay handler uses `planner_input_v1` when present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b6739dfc832fa108760a56061b86)