### PR TITLE
Deprecate --run-id; use explicit --run-dir/--case-dir for run/case resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ PROVIDER ?=
 BUCKET ?= known_bad
 REPLAY_ID ?=
 EVENTS ?=
-RUN_ID ?=
 CASE_DIR ?=
 TRACER_ROOT ?= tests/fixtures/replay_cases
 TRACER_OUT_DIR ?= $(TRACER_ROOT)/$(BUCKET)
@@ -173,9 +172,9 @@ help:
 	@echo "  make tags [PATTERN=*] DATA=... - показать список тегов"
 	@echo "  make case-run  CASE=case_42 - прогнать один кейс"
 	@echo "  make case-open CASE=case_42 - открыть артефакты кейса"
-	@echo "  make tracer-export REPLAY_ID=... CASE=... [EVENTS=...] [RUN_ID=...] [CASE_DIR=...] [DATA=...] [PROVIDER=...] [BUCKET=...] [SPEC_IDX=...] [OVERWRITE=1] [ALLOW_BAD_JSON=1]"
+	@echo "  make tracer-export REPLAY_ID=... CASE=... [EVENTS=...] [RUN_DIR=...] [CASE_DIR=...] [DATA=...] [PROVIDER=...] [BUCKET=...] [SPEC_IDX=...] [OVERWRITE=1] [ALLOW_BAD_JSON=1]"
 	@echo "    PROVIDER фильтрует replay_case.meta.provider (обычно spec.provider: sql, relational, ...)"
-	@echo "  make tracer-ls CASE=... [DATA=...] [TAG=...] [RUN_ID=...] [CASE_DIR=...]"
+	@echo "  make tracer-ls CASE=... [DATA=...] [TAG=...] [RUN_DIR=...] [CASE_DIR=...]"
 	@echo "  make known-bad - запустить backlog-suite для known_bad (ожидаемо красный)"
 	@echo "  make known-bad-one NAME=fixture_stem - запустить один known_bad кейс"
 	@echo "  (или напрямую: $(PYTHON) -m fetchgraph.tracer.cli export-case-bundle ...)"
@@ -401,7 +400,6 @@ tracer-export:
 	  --data "$(REPLAY_IDATA)" \
 	  $(if $(strip $(SPEC_IDX)),--spec-idx "$(SPEC_IDX)",) \
 	  $(if $(strip $(PROVIDER)),--provider "$(PROVIDER)",) \
-	  $(if $(RUN_ID),--run-id "$(RUN_ID)",) \
 	  $(if $(CASE_DIR),--case-dir "$(CASE_DIR)",) \
 	  $(if $(RUN_DIR),--run-dir "$(RUN_DIR)",) \
 	  $(if $(EVENTS),--events "$(EVENTS)",) \
@@ -415,7 +413,6 @@ tracer-ls:
 	  --case "$(CASE)" \
 	  --data "$(REPLAY_IDATA)" \
 	  --out "$(TRACER_OUT_DIR)" \
-	  $(if $(RUN_ID),--run-id "$(RUN_ID)",) \
 	  $(if $(CASE_DIR),--case-dir "$(CASE_DIR)",) \
 	  $(if $(RUN_DIR),--run-dir "$(RUN_DIR)",) \
 	  $(if $(EVENTS),--events "$(EVENTS)",) \

--- a/src/fetchgraph/tracer/fetchgraph_tracer.md
+++ b/src/fetchgraph/tracer/fetchgraph_tracer.md
@@ -234,8 +234,8 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 2) Иначе (auto-resolve через `.runs`):
    - обязателен `--case <CASE_ID>` и `--data <DATA_DIR>`
    - дальше выбираем конкретный run/case:
-     - `--case-dir <PATH>` или `--run-dir <PATH>` — явный путь
-     - `--run-id <RUN_ID>` — выбрать запуск и кейс внутри него
+     - `--case-dir <PATH>` — явный путь к кейсу
+     - `--run-dir <PATH>` — явный путь к run (кейс выбирается из `run_dir/cases`)
      - либо “самый свежий” по стратегии `--pick-run` (+ опционально `--tag`)
 
 Поддерживаемые имена файлов events (быстрый поиск):  
@@ -257,7 +257,7 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 - `--debug` — детальный вывод кандидатов (или `DEBUG=1`)
 
 Полезно:
-- `--print-resolve` — распечатать, во что именно разрешилось (`run_dir`, `events_path`).
+- `--print-resolve` — распечатать, во что именно разрешилось (`run_dir`, `case_dir`, `events_path`, `selection_method`).
 
 #### 6.1.3 Replay-case selection flags (когда в events много replay_case)
 

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -545,7 +545,7 @@ def _format_missing_case_runs(
                     f"status={info.status!r} "
                     f"missed={info.is_missed}"
                 )
-        details.append("Tip: verify TAG or pass RUN_ID/CASE_DIR/EVENTS.")
+        details.append("Tip: verify TAG or pass RUN_DIR/CASE_DIR/EVENTS.")
     else:
-        details.append("Tip: pass TAG/RUN_ID/CASE_DIR/EVENTS for a narrower selection.")
+        details.append("Tip: pass TAG/RUN_DIR/CASE_DIR/EVENTS for a narrower selection.")
     return "\n".join(details)

--- a/tests/test_tracer_cli_resolve.py
+++ b/tests/test_tracer_cli_resolve.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fetchgraph.tracer import cli
+
+
+def _touch_case(run_dir: Path, case_id: str, suffix: str, *, mtime: float) -> Path:
+    case_dir = run_dir / "cases" / f"{case_id}_{suffix}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    (case_dir / "events.jsonl").write_text("{}", encoding="utf-8")
+    os.utime(case_dir, (mtime, mtime))
+    return case_dir
+
+
+def test_resolve_case_dir_from_run_dir_selects_latest(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    _touch_case(run_dir, "case_1", "old", mtime=1)
+    newest = _touch_case(run_dir, "case_1", "new", mtime=2)
+
+    resolved = cli._resolve_case_dir_from_run_dir(run_dir, "case_1")
+    assert resolved == newest


### PR DESCRIPTION
### Motivation
- Remove ambiguous `--run-id` behavior which implicitly treated the id as a run directory selector and replace it with explicit `--run-dir` / `--case-dir` selection. 
- Keep the automatic `latest_with_replay` resolution unchanged while making explicit choices unambiguous. 
- Improve diagnostics so users can reliably copy `CASE_DIR=...` from CLI output and reproduce exports.

### Description
- CLI: mark `--run-id` as deprecated in `src/fetchgraph/tracer/cli.py` and make it fail with a clear stderr message when used, routing explicit selection through `--run-dir` or `--case-dir` instead. 
- Implement explicit resolution flow in `cli.py`: prefer `--case-dir`, then `--run-dir` (which selects a case from `run_dir/cases`), otherwise fall back to auto-resolve (`latest_with_replay` unaffected); expose a new `selection_method` printed by `--print-resolve`. 
- Replace `_resolve_case_dir_from_run_id(...)` with `_resolve_case_dir_from_run_dir(...)` and add helper `_run_dir_from_case_dir(...)` to map case->run, and update error/tip messages to reference `RUN_DIR/CASE_DIR/EVENTS`. 
- Update Makefile help and invocation to remove `RUN_ID` flags and highlight `RUN_DIR`/`CASE_DIR`, and refresh docs in `src/fetchgraph/tracer/fetchgraph_tracer.md`. 
- Add unit test `tests/test_tracer_cli_resolve.py` covering resolution of the latest case dir under a given `run_dir` via `_resolve_case_dir_from_run_dir`.

### Testing
- Ran `pytest tests/test_tracer_cli_resolve.py`, and the new test `test_resolve_case_dir_from_run_dir_selects_latest` passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977cc24d72c832f99537abe5d08a602)