### PR TITLE
Resolve tracer --run-id from history/run_meta and improve CLI semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ help:
 	@echo "  make tracer-export REPLAY_ID=... CASE=... [EVENTS=...] [RUN_ID=...] [CASE_DIR=...] [DATA=...] [PROVIDER=...] [BUCKET=...] [SPEC_IDX=...] [OVERWRITE=1] [ALLOW_BAD_JSON=1]"
 	@echo "    PROVIDER фильтрует replay_case.meta.provider (обычно spec.provider: sql, relational, ...)"
 	@echo "  make tracer-ls CASE=... [DATA=...] [TAG=...] [RUN_ID=...] [CASE_DIR=...]"
+	@echo "    RUN_ID берётся из make stats/history-case"
 	@echo "  make known-bad - запустить backlog-suite для known_bad (ожидаемо красный)"
 	@echo "  make known-bad-one NAME=fixture_stem - запустить один known_bad кейс"
 	@echo "  (или напрямую: $(PYTHON) -m fetchgraph.tracer.cli export-case-bundle ...)"

--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -373,6 +373,8 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"run_dir_source: {run_dir_source}")
                 print(f"Resolved case_dir: {case_dir}")
                 print(f"Resolved events.jsonl: {events_path}")
+                if args.events and run_dir is None:
+                    print("Note: run_dir not provided; file resources cannot be exported.")
                 if auto_resolve and args.case and args.data:
                     infos, _ = scan_case_runs(
                         case_id=args.case,

--- a/src/fetchgraph/tracer/fetchgraph_tracer.md
+++ b/src/fetchgraph/tracer/fetchgraph_tracer.md
@@ -233,9 +233,10 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 
 2) Иначе (auto-resolve через `.runs`):
    - обязателен `--case <CASE_ID>` и `--data <DATA_DIR>`
+   - `--run-id` требует `--data` и не комбинируется с `--run-dir/--case-dir`
    - дальше выбираем конкретный run/case:
      - `--case-dir <PATH>` или `--run-dir <PATH>` — явный путь
-     - `--run-id <RUN_ID>` — выбрать запуск и кейс внутри него
+     - `--run-id <RUN_ID>` — выбрать запуск по meta run_id (берётся из stats/history) и кейс внутри него
      - либо “самый свежий” по стратегии `--pick-run` (+ опционально `--tag`)
 
 Поддерживаемые имена файлов events (быстрый поиск):  
@@ -257,7 +258,7 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 - `--debug` — детальный вывод кандидатов (или `DEBUG=1`)
 
 Полезно:
-- `--print-resolve` — распечатать, во что именно разрешилось (`run_dir`, `events_path`).
+- `--print-resolve` — распечатать входные флаги и резолв (`run_dir`, `case_dir`, `events_path`, `selection_method`).
 
 #### 6.1.3 Replay-case selection flags (когда в events много replay_case)
 

--- a/src/fetchgraph/tracer/fetchgraph_tracer.md
+++ b/src/fetchgraph/tracer/fetchgraph_tracer.md
@@ -229,7 +229,7 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 Приоритет разрешения:
 
 1) `--events` — явный путь к events/trace файлу.  
-   `run_dir` берется из `--case-dir` или `--run-dir` (если нужны file-resources).
+   `run_dir` берется из `--case-dir` или `--run-dir` (если нужны file-resources); `--case-dir` и `--run-dir` вместе не допускаются.
 
 2) Иначе (auto-resolve через `.runs`):
    - обязателен `--case <CASE_ID>` и `--data <DATA_DIR>`

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -101,6 +101,66 @@ def resolve_case_events(
     )
 
 
+def resolve_run_dir_from_run_id(*, data_dir: Path, runs_subdir: str, run_id: str) -> Path:
+    if not run_id:
+        raise ValueError("run_id is required")
+    if not data_dir:
+        raise ValueError("data_dir is required")
+    history_path = data_dir / ".runs" / "history.jsonl"
+    history_candidates: list[Path] = []
+    if history_path.exists():
+        entries: list[dict] = []
+        with history_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        for entry in reversed(entries):
+            if str(entry.get("run_id")) != run_id:
+                continue
+            run_dir_value = entry.get("run_dir") or entry.get("run_folder")
+            if not run_dir_value:
+                continue
+            candidate = Path(run_dir_value)
+            if candidate.exists():
+                return candidate
+            history_candidates.append(candidate)
+
+    runs_root = (data_dir / runs_subdir).resolve()
+    if not runs_root.exists():
+        raise FileNotFoundError(f"Runs directory does not exist: {runs_root}")
+    matched: list[Path] = []
+    for run_dir in _iter_run_dirs(runs_root):
+        meta_path = run_dir / "run_meta.json"
+        if not meta_path.exists():
+            continue
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if str(payload.get("run_id")) != run_id:
+            continue
+        matched.append(run_dir)
+    if matched:
+        matched.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return matched[0]
+
+    hint = ""
+    if history_candidates:
+        hint = f"History entries pointed to: {', '.join(str(p) for p in history_candidates)}"
+    raise LookupError(
+        "Run id could not be resolved.\n"
+        f"run_id: {run_id}\n"
+        f"history_path: {history_path}\n"
+        f"runs_root: {runs_root}\n"
+        f"{hint}".rstrip()
+    )
+
+
 def _iter_run_dirs(runs_root: Path) -> Iterable[Path]:
     candidates = [p for p in runs_root.iterdir() if p.is_dir()]
     return sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True)

--- a/tests/test_tracer_run_id_resolve.py
+++ b/tests/test_tracer_run_id_resolve.py
@@ -22,7 +22,16 @@ def _make_run_case(data_dir: Path, run_dir_name: str, case_id: str) -> tuple[Pat
     case_dir = run_dir / "cases" / f"{case_id}_x"
     case_dir.mkdir(parents=True, exist_ok=True)
     events_path = case_dir / "events.jsonl"
-    _write_jsonl(events_path, {"type": "replay_case", "id": "replay_1", "input": {}})
+    _write_jsonl(
+        events_path,
+        {
+            "type": "replay_case",
+            "id": "replay_1",
+            "v": 2,
+            "input": {},
+            "observed": {},
+        },
+    )
     return run_dir, case_dir
 
 

--- a/tests/test_tracer_run_id_resolve.py
+++ b/tests/test_tracer_run_id_resolve.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fetchgraph.tracer import cli
+
+
+def _write_jsonl(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _write_history_entry(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload) + "\n")
+
+
+def _make_run_case(data_dir: Path, run_dir_name: str, case_id: str) -> tuple[Path, Path]:
+    run_dir = data_dir / ".runs" / "runs" / run_dir_name
+    case_dir = run_dir / "cases" / f"{case_id}_x"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    events_path = case_dir / "events.jsonl"
+    _write_jsonl(events_path, {"type": "replay_case", "id": "replay_1", "input": {}})
+    return run_dir, case_dir
+
+
+def test_export_case_bundle_resolves_run_id_from_history(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    out_dir = tmp_path / "out"
+    run_dir, _ = _make_run_case(data_dir, "run_folder", "agg_003")
+    history_path = data_dir / ".runs" / "history.jsonl"
+    _write_history_entry(history_path, {"run_id": "abc123", "run_dir": str(run_dir)})
+
+    exit_code = cli.main(
+        [
+            "export-case-bundle",
+            "--id",
+            "replay_1",
+            "--out",
+            str(out_dir),
+            "--case",
+            "agg_003",
+            "--data",
+            str(data_dir),
+            "--run-id",
+            "abc123",
+        ]
+    )
+
+    assert exit_code == 0
+    assert list(out_dir.glob("*.case.json"))
+
+
+def test_export_case_bundle_resolves_run_id_from_run_meta(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    out_dir = tmp_path / "out"
+    run_dir, _ = _make_run_case(data_dir, "run_folder_meta", "agg_003")
+    (run_dir / "run_meta.json").write_text(json.dumps({"run_id": "meta123"}), encoding="utf-8")
+
+    exit_code = cli.main(
+        [
+            "export-case-bundle",
+            "--id",
+            "replay_1",
+            "--out",
+            str(out_dir),
+            "--case",
+            "agg_003",
+            "--data",
+            str(data_dir),
+            "--run-id",
+            "meta123",
+        ]
+    )
+
+    assert exit_code == 0
+    assert list(out_dir.glob("*.case.json"))


### PR DESCRIPTION
### Motivation

- Make `--run-id` convenient again by allowing passing the meta `run_id` from `stats/history` rather than a folder name. 
- Prevent confusing flag combinations and ensure `--run-id` is validated and resolves deterministically.

### Description

- Add `resolve_run_dir_from_run_id` in `src/fetchgraph/tracer/resolve.py` to first consult `DATA/.runs/history.jsonl` and fall back to scanning `run_meta.json` files under `DATA/<runs_subdir>` to map a meta `run_id` to a `run_dir`.
- Update `src/fetchgraph/tracer/cli.py` to change CLI semantics: `--run-id` now means meta `run_id`, it requires `--data` and `--case`, and is disallowed together with `--run-dir`/`--case-dir`; resolution logic and `--print-resolve` output were extended to show input flags and `selection_method` and to set `case_dir`/`run_dir` correctly for downstream export.
- Replace `_resolve_case_dir_from_run_id` with `_resolve_case_dir_from_run_dir` to select the matching case dir inside a resolved run, and update docs/help in `src/fetchgraph/tracer/fetchgraph_tracer.md` and `Makefile` to clarify the new `RUN_ID` meaning.
- Add tests `tests/test_tracer_run_id_resolve.py` covering resolution from `history.jsonl` and from `run_meta.json` and wire the new resolver into CLI flow.

### Testing

- Ran `pytest tests/test_tracer_run_id_resolve.py`, which executed the two new tests and reported `2 passed`.
- Existing auto-resolve behavior (`--pick-run` default `latest_with_replay`) and explicit `--run-dir`/`--case-dir` overrides remain supported and unchanged by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d16644f8832fab0444bf6a2f8cb9)