### PR TITLE
Handle optional Path/dict values in tracer resolution and replay export

### DIFF
--- a/src/fetchgraph/replay/export.py
+++ b/src/fetchgraph/replay/export.py
@@ -230,8 +230,10 @@ def index_requires(
 def _format_replay_case_ref(replay_case: dict | None) -> str:
     if not isinstance(replay_case, dict):
         return ""
-    replay_id = replay_case.get("id")
-    meta = replay_case.get("meta") if isinstance(replay_case.get("meta"), dict) else {}
+    replay_case_dict: dict = replay_case
+    replay_id = replay_case_dict.get("id")
+    meta_value = replay_case_dict.get("meta")
+    meta = meta_value if isinstance(meta_value, dict) else {}
     provider = meta.get("provider")
     spec_idx = meta.get("spec_idx")
     details = []
@@ -299,7 +301,8 @@ def _extract_extra_requires(
     schema_ref = extra.get("schema_ref")
     if isinstance(schema_ref, str) and schema_ref:
         requirements.append({"kind": "resource", "id": schema_ref})
-    extra_input = extra.get("input") if isinstance(extra.get("input"), dict) else {}
+    input_value = extra.get("input")
+    extra_input = input_value if isinstance(input_value, dict) else {}
     schema_ref = extra_input.get("schema_ref")
     if isinstance(schema_ref, str) and schema_ref:
         requirements.append({"kind": "resource", "id": schema_ref})

--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -295,6 +295,8 @@ def main(argv: list[str] | None = None) -> int:
                         run_dir_source = "derived from case_dir"
                     else:
                         run_dir = args.run_dir
+                        if run_dir is None:
+                            raise ValueError("run_dir was not resolved.")
                         case_dir = _resolve_case_dir_from_run_dir(run_dir=run_dir, case_id=args.case)
                         selection_rule = "explicit RUN_DIR"
                         run_dir_source = "explicit RUN_DIR"

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -127,13 +127,15 @@ def resolve_run_dir_from_run_id(*, data_dir: Path, runs_subdir: str, run_id: str
             run_folder_value = entry.get("run_folder")
             if not run_dir_value and not run_folder_value:
                 continue
-            candidate = None
+            candidate: Path | None = None
             if run_dir_value:
                 candidate = Path(run_dir_value)
                 if not candidate.is_absolute():
                     candidate = runs_root / candidate
             if candidate is None and run_folder_value:
                 candidate = runs_root / str(run_folder_value)
+            if candidate is None:
+                continue
             if candidate.exists():
                 return candidate
             history_candidates.append(candidate)


### PR DESCRIPTION
### Motivation
- Fix cases where `Path | None` or optional dict values were passed to functions or accessed directly, which caused static type errors and could lead to None dereferences.
- Make the resolution flow more robust when history entries or CLI flags do not produce a resolved `run_dir`.

### Description
- Added an explicit guard in `src/fetchgraph/tracer/cli.py` to raise a clear `ValueError` when `run_dir` is `None` before calling `_resolve_case_dir_from_run_dir`.
- Updated `src/fetchgraph/tracer/resolve.py` to type `candidate` as `Path | None` and skip entries where `candidate` remains `None` so `.exists()` is not called on `None`.
- Tightened optional handling in `src/fetchgraph/replay/export.py` by introducing local variables (`replay_case_dict`, `meta_value`, `input_value`) and using `isinstance` checks before accessing nested dicts.
- Changes address the pyright-reported issues around optional member access and argument types without altering external behavior.

### Testing
- No automated tests were run as part of this change.
- The edits were aimed at resolving static type errors reported by the type checker, though the type checker was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ef1ee19c832f993c374e353af031)