### PR TITLE
Avoid duplicating resource_id in fixture migration and add regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
 # ==============================================================================
 # 8) PHONY
 # ==============================================================================
-.PHONY: help init show-config warn-config check ensure-runs-dir venv-check \
+.PHONY: help init show-config warn-config warn-missing-init warn-missing-tracer warn-missing-llm-config check ensure-runs-dir venv-check \
         llm-init llm-show llm-edit \
         chat \
         batch batch-tag batch-failed batch-failed-from \
@@ -277,10 +277,21 @@ venv-check:
 	  echo "INFO: venv не найден: $(VENV) (использую системный python: $$(command -v $(PYTHON) || echo 'python'))"; \
 	fi
 
-warn-config:
+warn-missing-init:
 	@if [ ! -f "$(CONFIG)" ]; then \
 	  echo "WARNING: local defaults not initialized (run: make init). Using Makefile defaults / environment vars."; \
 	fi
+
+warn-missing-tracer:
+	@command -v fetchgraph-tracer >/dev/null 2>&1 || \
+	  echo "WARNING: fetchgraph-tracer not installed. Run: pip install -e ."
+
+warn-missing-llm-config:
+	@if [ ! -f "$(LLM_TOML)" ]; then \
+	  echo "WARNING: LLM config not found (LLM_TOML='$(LLM_TOML)'). Run: make llm-init"; \
+	fi
+
+warn-config: warn-missing-init
 	@if [ -z "$(strip $(SCHEMA))" ]; then \
 	  echo "WARNING: SCHEMA is not set (SCHEMA='$(SCHEMA)')"; \
 	elif [ ! -f "$(SCHEMA)" ]; then \
@@ -330,7 +341,7 @@ llm-edit:
 # ==============================================================================
 # Алиасы под команды CLI
 # ==============================================================================
-chat: check
+chat: warn-missing-llm-config check
 	@$(CLI) chat --data "$(DATA)" --schema "$(SCHEMA)"
 
 # 1) Полный прогон всего набора
@@ -408,7 +419,7 @@ case-open: check
 	@test -n "$(strip $(CASE))" || (echo "Нужно задать CASE=case_42" && exit 1)
 	@$(CLI) case open "$(CASE)" --data "$(DATA)"
 
-tracer-export: warn-config
+tracer-export: warn-config warn-missing-tracer
 	@test -n "$(strip $(REPLAY_ID))" || (echo "REPLAY_ID обязателен: make tracer-export REPLAY_ID=plan_normalize.spec_v1" && exit 2)
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make tracer-export CASE=agg_003" && exit 2)
 	@case "$(BUCKET)" in fixed|known_bad) ;; *) echo "BUCKET должен быть fixed или known_bad для tracer-export" && exit 2 ;; esac
@@ -427,7 +438,7 @@ tracer-export: warn-config
 	  $(if $(filter 1 true yes on,$(OVERWRITE)),--overwrite,) \
 	  $(if $(filter 1 true yes on,$(ALLOW_BAD_JSON)),--allow-bad-json,)
 
-tracer-ls:
+tracer-ls: warn-missing-tracer
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make tracer-ls CASE=agg_003" && exit 2)
 	@fetchgraph-tracer export-case-bundle \
 	  --case "$(CASE)" \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ LIMIT_FLAG := $(if $(strip $(LIMIT)),--limit $(LIMIT),)
 # ==============================================================================
 # 8) PHONY
 # ==============================================================================
-.PHONY: help init show-config check ensure-runs-dir venv-check \
+.PHONY: help init show-config warn-config check ensure-runs-dir venv-check \
         llm-init llm-show llm-edit \
         chat \
         batch batch-tag batch-failed batch-failed-from \
@@ -277,10 +277,27 @@ venv-check:
 	  echo "INFO: venv не найден: $(VENV) (использую системный python: $$(command -v $(PYTHON) || echo 'python'))"; \
 	fi
 
-check:
+warn-config:
+	@if [ ! -f "$(CONFIG)" ]; then \
+	  echo "WARNING: local defaults not initialized (run: make init). Using Makefile defaults / environment vars."; \
+	fi
+	@if [ -z "$(strip $(SCHEMA))" ]; then \
+	  echo "WARNING: SCHEMA is not set (SCHEMA='$(SCHEMA)')"; \
+	elif [ ! -f "$(SCHEMA)" ]; then \
+	  echo "WARNING: SCHEMA path not found (SCHEMA='$(SCHEMA)')"; \
+	fi
+	@if [ -z "$(strip $(CASES))" ]; then \
+	  echo "WARNING: CASES is not set (CASES='$(CASES)')"; \
+	elif [ ! -f "$(CASES)" ]; then \
+	  echo "WARNING: CASES path not found (CASES='$(CASES)')"; \
+	fi
+
+check: warn-config
 	@test -n "$(strip $(DATA))"   || (echo "DATA не задан. Запусти: make init (или передай DATA=...)" && exit 1)
 	@test -n "$(strip $(SCHEMA))" || (echo "SCHEMA не задан. Запусти: make init (или передай SCHEMA=...)" && exit 1)
 	@test -n "$(strip $(CASES))"  || (echo "CASES не задан. Запусти: make init (или передай CASES=...)" && exit 1)
+	@test -f "$(SCHEMA)" || (echo "SCHEMA не найден: $(SCHEMA)" && exit 1)
+	@test -f "$(CASES)"  || (echo "CASES не найден: $(CASES)" && exit 1)
 
 ensure-runs-dir: check
 	@mkdir -p "$(DATA)/.runs"
@@ -391,7 +408,7 @@ case-open: check
 	@test -n "$(strip $(CASE))" || (echo "Нужно задать CASE=case_42" && exit 1)
 	@$(CLI) case open "$(CASE)" --data "$(DATA)"
 
-tracer-export:
+tracer-export: warn-config
 	@test -n "$(strip $(REPLAY_ID))" || (echo "REPLAY_ID обязателен: make tracer-export REPLAY_ID=plan_normalize.spec_v1" && exit 2)
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make tracer-export CASE=agg_003" && exit 2)
 	@case "$(BUCKET)" in fixed|known_bad) ;; *) echo "BUCKET должен быть fixed или known_bad для tracer-export" && exit 2 ;; esac
@@ -430,7 +447,7 @@ known-bad-one:
 	@test -n "$(strip $(NAME))" || (echo "NAME обязателен: make known-bad-one NAME=fixture_stem" && exit 2)
 	@pytest -m known_bad -k "$(NAME)" -vv
 
-fixture-green:
+fixture-green: warn-config
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make fixture-green CASE=agg_003 или CASE=path/to/fixture.case.json" && exit 1)
 	@case_value="$(CASE)"; \
 	if [ -f "$$case_value" ]; then \
@@ -451,11 +468,11 @@ fixture-green:
 	  $(if $(filter 1 true yes on,$(OVERWRITE_EXPECTED)),--overwrite-expected,) \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
-fixture-ls:
+fixture-ls: warn-config
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make fixture-ls CASE=agg_003" && exit 1)
 	@$(PYTHON) -m fetchgraph.tracer.cli fixture-ls --root "$(TRACER_ROOT)" --bucket "$(BUCKET)" --case-id "$(CASE)"
 
-fixture-rm:
+fixture-rm: warn-config
 	@case "$(BUCKET)" in fixed|known_bad|all) ;; *) echo "BUCKET должен быть fixed, known_bad или all для fixture-rm" && exit 1 ;; esac
 	@case_value="$(CASE)"; \
 	if [ -n "$$case_value" ]; then \
@@ -479,14 +496,14 @@ fixture-rm:
 	  $(if $(filter 1 true yes on,$(ALL)),--all,) \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
-fixture-fix:
+fixture-fix: warn-config
 	@test -n "$(strip $(NAME))" || (echo "NAME обязателен: make fixture-fix NAME=old_stem NEW_NAME=new_stem" && exit 1)
 	@test -n "$(strip $(NEW_NAME))" || (echo "NEW_NAME обязателен: make fixture-fix NAME=old_stem NEW_NAME=new_stem" && exit 1)
 	@$(PYTHON) -m fetchgraph.tracer.cli fixture-fix --root "$(TRACER_ROOT)" --bucket "$(BUCKET)" \
 	  --name "$(NAME)" --new-name "$(NEW_NAME)" \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
-fixture-migrate:
+fixture-migrate: warn-config
 	@case_value="$(CASE)"; \
 	if [ -n "$$case_value" ]; then \
 	  if [ -f "$$case_value" ]; then \
@@ -505,7 +522,7 @@ fixture-migrate:
 	  $(if $(filter 1 true yes on,$(ALL)),--all,) \
 	  $(if $(filter 1 true yes on,$(DRY)),--dry-run,)
 
-fixture-demote:
+fixture-demote: warn-config
 	@test -n "$(strip $(CASE))" || (echo "CASE обязателен: make fixture-demote CASE=agg_003" && exit 1)
 	@case_value="$(CASE)"; \
 	if [ -f "$$case_value" ]; then \

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -707,7 +707,14 @@ def fixture_migrate(
             rel = _safe_resource_path(file_name, stem=stem)
             if rel.parts[:3] == ("resources", stem, resource_id):
                 continue
-            if rel.parts[:1] == ("resources",) and len(rel.parts) >= 2:
+            # If the existing path is already under resources/<stem>/<resource_id>/...,
+            # strip the leading segments without duplicating resource_id on re-prefix.
+            if rel.parts[:1] == ("resources",) and len(rel.parts) >= 3:
+                if rel.parts[2] == resource_id:
+                    rel_tail = Path(*rel.parts[3:])
+                else:
+                    rel_tail = Path(*rel.parts[2:])
+            elif rel.parts[:1] == ("resources",) and len(rel.parts) >= 2:
                 rel_tail = Path(*rel.parts[2:])
             else:
                 rel_tail = rel

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -5,7 +5,7 @@ import json
 import shutil
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from .diff_utils import first_diff_path
 from .fixture_layout import FixtureLayout, find_case_bundles
@@ -47,10 +47,15 @@ def load_bundle_json(path: Path) -> dict:
 
 
 def _safe_resource_path(path: str, *, stem: str) -> Path:
-    rel = Path(path)
-    if rel.is_absolute() or ".." in rel.parts:
+    normalized = path.replace("\\", "/")
+    if ":" in normalized:
         raise ValueError(f"Invalid resource path in bundle {stem}: {path}")
-    return rel
+    if normalized.startswith(("/", "//")):
+        raise ValueError(f"Invalid resource path in bundle {stem}: {path}")
+    rel = PurePosixPath(normalized)
+    if ".." in rel.parts:
+        raise ValueError(f"Invalid resource path in bundle {stem}: {path}")
+    return Path(*rel.parts)
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -182,3 +182,51 @@ def test_fixture_migrate_resources_with_existing_resource_id_segment(tmp_path: P
     data = json.loads(case_path.read_text(encoding="utf-8"))
     assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/file.txt"
     assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()
+
+
+def test_fixture_migrate_normalizes_backslashes(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "case.case.json"
+    legacy_dir = root / bucket / "resources" / "old" / "rid1"
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = legacy_dir / "file.txt"
+    legacy_path.write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        },
+        resources={"rid1": {"data_ref": {"file": r"resources\\old\\rid1\\file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+
+    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
+    assert bundles_updated == 1
+    assert files_moved == 1
+    data = json.loads(case_path.read_text(encoding="utf-8"))
+    assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/file.txt"
+    assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()
+
+
+def test_fixture_migrate_rejects_windows_absolute_paths(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "case.case.json"
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        },
+        resources={"rid1": {"data_ref": {"file": r"C:\\tmp\\file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+
+    with pytest.raises(ValueError, match="Invalid resource path"):
+        fixture_migrate(root=root, bucket=bucket, dry_run=False)

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -154,3 +154,31 @@ def test_fixture_migrate_moves_resources(tmp_path: Path) -> None:
     data = json.loads(case_path.read_text(encoding="utf-8"))
     assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/legacy/file.txt"
     assert (root / bucket / "resources" / "case" / "rid1" / "legacy" / "file.txt").exists()
+
+
+def test_fixture_migrate_resources_with_existing_resource_id_segment(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "case.case.json"
+    legacy_dir = root / bucket / "resources" / "old" / "rid1"
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = legacy_dir / "file.txt"
+    legacy_path.write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        },
+        resources={"rid1": {"data_ref": {"file": "resources/old/rid1/file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+
+    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
+    assert bundles_updated == 1
+    assert files_moved == 1
+    data = json.loads(case_path.read_text(encoding="utf-8"))
+    assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/file.txt"
+    assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()


### PR DESCRIPTION
### Motivation
- The fixture migration logic could produce non-canonical paths by duplicating `resource_id` when a source path already contains `resources/<stem>/<resource_id>/...`, which breaks tools expecting the canonical layout. 
- The change ensures migrated resource paths are normalized to `resources/<case_stem>/<resource_id>/...` without repeating the `resource_id` segment. 

### Description
- Update `fixture_migrate` path normalization in `src/fetchgraph/tracer/fixture_tools.py` to detect `resources/<...>/<resource_id>/...` and strip the leading `resource_id` segment before re-prefixing so `resource_id` is not duplicated. 
- Add a clarifying comment next to the normalization logic explaining the intent. 
- Add a regression test `test_fixture_migrate_resources_with_existing_resource_id_segment` to `tests/test_tracer_fixture_tools.py` that covers migrating `resources/old/<rid>/file.txt` into the canonical `resources/case/<rid>/file.txt` layout. 
- Modified files: `src/fetchgraph/tracer/fixture_tools.py` and `tests/test_tracer_fixture_tools.py`. 

### Testing
- Ran `pytest tests/test_tracer_fixture_tools.py` and all tests passed (6 passed). 
- The new regression test verifies the source file is moved and the bundle's `data_ref.file` is updated to the canonical `resources/case/rid1/file.txt` path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef9ea89bc832fae1f2fabff4500a0)