### PR TITLE
Handle schema snapshot extensions in case open

### DIFF
--- a/examples/demo_qa/batch.py
+++ b/examples/demo_qa/batch.py
@@ -1452,8 +1452,10 @@ def handle_case_open(args) -> int:
     status = case_dir / "status.json"
     events = case_dir / "events.jsonl"
     error = case_dir / "error.txt"
-    schema_snapshot = case_dir / "schema_snapshot.yaml"
-    for path in [plan, answer, status, events, error, schema_snapshot]:
+    # Schema snapshots may use the schema file extension (json/yaml), so match all.
+    schema_snapshots = sorted(case_dir.glob("schema_snapshot.*"))
+    artifacts = [plan, answer, status, events, error, *schema_snapshots]
+    for path in artifacts:
         if path.exists():
             print(f"- {path}")
     return 0


### PR DESCRIPTION
### Motivation
- Ensure `handle_case_open` reliably lists schema snapshot artifacts when snapshots use different extensions (e.g. `.json` vs `.yaml`) so produced snapshots are visible to users.

### Description
- Update `examples/demo_qa/batch.py` in `handle_case_open` to glob `schema_snapshot.*` rather than hardcoding `schema_snapshot.yaml`, build an `artifacts` list including any matching snapshots, and add a brief explanatory comment.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f093f1ac8832f8c8c748b3f9a4c49)