### PR TITLE
Fix pyright typing for replay export tests and guard meta access

### DIFF
--- a/src/fetchgraph/replay/export.py
+++ b/src/fetchgraph/replay/export.py
@@ -251,7 +251,8 @@ def format_replay_case_matches(selections: list[ExportSelection], *, limit: int 
     rows = []
     for idx, selection in enumerate(selections[:limit], start=1):
         event = selection.event
-        meta = event.get("meta") or {}
+        meta = event.get("meta")
+        meta = meta if isinstance(meta, dict) else {}
         provider = meta.get("provider")
         spec_idx = meta.get("spec_idx")
         timestamp = event.get("timestamp")

--- a/tests/test_tracer_export_input_hash_filter.py
+++ b/tests/test_tracer_export_input_hash_filter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from _pytest.capture import CaptureFixture
+
 from fetchgraph.replay.export import input_hash8
 from fetchgraph.tracer import cli
 
@@ -12,7 +14,7 @@ def _write_events(path: Path, events: list[dict]) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def test_export_filters_by_input_hash(tmp_path: Path, capsys: object) -> None:
+def test_export_filters_by_input_hash(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
     events_path = tmp_path / "events.jsonl"
     out_dir = tmp_path / "out"
     events = [

--- a/tests/test_tracer_export_list_replay_matches.py
+++ b/tests/test_tracer_export_list_replay_matches.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from _pytest.capture import CaptureFixture
+
 from fetchgraph.replay.export import input_hash8
 from fetchgraph.tracer import cli
 
@@ -12,7 +14,7 @@ def _write_events(path: Path, events: list[dict]) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def test_list_replay_matches_outputs_table(tmp_path: Path, capsys: object) -> None:
+def test_list_replay_matches_outputs_table(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
     events_path = tmp_path / "events.jsonl"
     events = [
         {

--- a/tests/test_tracer_export_provider_specidx_optional.py
+++ b/tests/test_tracer_export_provider_specidx_optional.py
@@ -4,6 +4,8 @@ import json
 import logging
 from pathlib import Path
 
+from _pytest.logging import LogCaptureFixture
+
 from fetchgraph.replay.export import export_replay_case_bundle
 
 
@@ -35,7 +37,9 @@ def test_export_without_provider_specidx_for_single_match(tmp_path: Path) -> Non
     assert out_path.exists()
 
 
-def test_export_warns_with_select_index_and_input_hash(tmp_path: Path, caplog: object) -> None:
+def test_export_warns_with_select_index_and_input_hash(
+    tmp_path: Path, caplog: LogCaptureFixture
+) -> None:
     events_path = tmp_path / "events.jsonl"
     out_dir = tmp_path / "out"
     events = [

--- a/tests/test_tracer_export_resolve_latest_with_replay_ignores_provider_specidx.py
+++ b/tests/test_tracer_export_resolve_latest_with_replay_ignores_provider_specidx.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+from _pytest.capture import CaptureFixture
+
 from fetchgraph.tracer import cli
 
 
@@ -17,7 +19,9 @@ def _make_case_dir(run_dir: Path, case_id: str, suffix: str) -> Path:
     return case_dir
 
 
-def test_latest_with_replay_ignores_provider_specidx(tmp_path: Path, capsys: object) -> None:
+def test_latest_with_replay_ignores_provider_specidx(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
     data_dir = tmp_path / "data"
     runs_root = data_dir / ".runs" / "runs"
     runs_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Motivation
- Address Pyright/type-checker errors about untyped `capsys`/`caplog` fixtures and an optional member access on replay event `meta` reported in `src/fetchgraph/replay/export.py` and test files. 

### Description
- Add explicit pytest fixture typing imports and annotations using `CaptureFixture[str]` and `LogCaptureFixture` in the replay export tests to satisfy static typing. 
- Protect metadata access in `format_replay_case_matches` by normalizing `meta = event.get("meta")` to an empty dict when it's not a `dict`, avoiding optional member access on `None`. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5b5fc5b8832f8c5945f3ed8bd460)