### PR TITLE
Remove legacy fixture migration paths and simplify resource normalization

### DIFF
--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import filecmp
 import json
 import shutil
 import subprocess
@@ -705,42 +704,18 @@ def fixture_migrate(
             if not isinstance(file_name, str) or not file_name:
                 continue
             rel = _safe_resource_path(file_name, stem=stem)
-            rel_tail: Path
-            if rel.parts[:3] == ("resources", stem, resource_id):
-                rel_tail = Path(*rel.parts[3:])
-                if not rel_tail.parts:
-                    rel_tail = Path(rel.name)
-                src_rel = rel
-            elif len(rel.parts) >= 3 and rel.parts[0] == "resources" and rel.parts[2] == resource_id:
-                rel_tail = Path(*rel.parts[3:])
-                if not rel_tail.parts:
-                    rel_tail = Path(rel.name)
-                src_rel = rel
-            else:
-                rel_tail = rel
-                src_rel = rel
-            target_rel = Path("resources") / stem / resource_id / rel_tail
-            src_path = case_path.parent / src_rel
-            dest_path = case_path.parent / target_rel
-            if not src_path.exists():
-                if dest_path.exists():
-                    src_path = dest_path
-                else:
-                    raise FileNotFoundError(f"Missing resource file: {src_path}")
-            if dest_path.exists() and dest_path != src_path and not filecmp.cmp(src_path, dest_path, shallow=False):
-                raise FileExistsError(
-                    "Resource collision at destination:\n"
-                    f"  dest: {dest_path}\n"
-                    "Hint: clean the destination or run migrate in an empty output directory."
+            if rel.parts[:3] != ("resources", stem, resource_id):
+                raise ValueError(
+                    "Resource path must be in resources/<stem>/<resource_id>/...; "
+                    f"found {file_name!r} in {case_path}"
                 )
-            if src_path != dest_path:
-                if dry_run:
-                    print(f"Would move {src_path} -> {dest_path}")
-                else:
-                    dest_path.parent.mkdir(parents=True, exist_ok=True)
-                    if not dest_path.exists():
-                        git_ops.move(src_path, dest_path)
-                        files_moved += 1
+            rel_tail = Path(*rel.parts[3:])
+            if not rel_tail.parts:
+                raise ValueError(f"Resource path must include a file name: {file_name!r} in {case_path}")
+            target_rel = Path("resources") / stem / resource_id / rel_tail
+            src_path = case_path.parent / target_rel
+            if not src_path.exists():
+                raise FileNotFoundError(f"Missing resource file: {src_path}")
             canonical_file = target_rel.as_posix()
             if file_name != canonical_file:
                 data_ref["file"] = canonical_file

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -128,14 +128,13 @@ def test_fixture_fix_renames_and_updates_resource_paths(tmp_path: Path) -> None:
     assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/new/rid1/file.txt"
 
 
-def test_fixture_migrate_moves_resources(tmp_path: Path) -> None:
+def test_fixture_migrate_leaves_canonical_paths(tmp_path: Path) -> None:
     root = tmp_path / "fixtures"
     bucket = "fixed"
     case_path = root / bucket / "case.case.json"
-    legacy_dir = root / bucket / "legacy"
-    legacy_dir.mkdir(parents=True, exist_ok=True)
-    legacy_path = legacy_dir / "file.txt"
-    legacy_path.write_text("data", encoding="utf-8")
+    resources_dir = root / bucket / "resources" / "case" / "rid1"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "file.txt").write_text("data", encoding="utf-8")
     payload = _bundle_payload(
         {
             "type": "replay_case",
@@ -144,41 +143,13 @@ def test_fixture_migrate_moves_resources(tmp_path: Path) -> None:
             "input": {"spec": {"provider": "sql"}},
             "observed": {"out_spec": {"provider": "sql"}},
         },
-        resources={"rid1": {"data_ref": {"file": "legacy/file.txt"}}},
+        resources={"rid1": {"data_ref": {"file": "resources/case/rid1/file.txt"}}},
     )
     _write_bundle(case_path, payload)
 
     bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
-    assert bundles_updated == 1
-    assert files_moved == 1
-    data = json.loads(case_path.read_text(encoding="utf-8"))
-    assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/legacy/file.txt"
-    assert (root / bucket / "resources" / "case" / "rid1" / "legacy" / "file.txt").exists()
-
-
-def test_fixture_migrate_resources_with_existing_resource_id_segment(tmp_path: Path) -> None:
-    root = tmp_path / "fixtures"
-    bucket = "fixed"
-    case_path = root / bucket / "case.case.json"
-    legacy_dir = root / bucket / "resources" / "old" / "rid1"
-    legacy_dir.mkdir(parents=True, exist_ok=True)
-    legacy_path = legacy_dir / "file.txt"
-    legacy_path.write_text("data", encoding="utf-8")
-    payload = _bundle_payload(
-        {
-            "type": "replay_case",
-            "v": 2,
-            "id": "plan_normalize.spec_v1",
-            "input": {"spec": {"provider": "sql"}},
-            "observed": {"out_spec": {"provider": "sql"}},
-        },
-        resources={"rid1": {"data_ref": {"file": "resources/old/rid1/file.txt"}}},
-    )
-    _write_bundle(case_path, payload)
-
-    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
-    assert bundles_updated == 1
-    assert files_moved == 1
+    assert bundles_updated == 0
+    assert files_moved == 0
     data = json.loads(case_path.read_text(encoding="utf-8"))
     assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/file.txt"
     assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()
@@ -188,10 +159,9 @@ def test_fixture_migrate_normalizes_backslashes(tmp_path: Path) -> None:
     root = tmp_path / "fixtures"
     bucket = "fixed"
     case_path = root / bucket / "case.case.json"
-    legacy_dir = root / bucket / "resources" / "old" / "rid1"
-    legacy_dir.mkdir(parents=True, exist_ok=True)
-    legacy_path = legacy_dir / "file.txt"
-    legacy_path.write_text("data", encoding="utf-8")
+    resources_dir = root / bucket / "resources" / "case" / "rid1"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "file.txt").write_text("data", encoding="utf-8")
     payload = _bundle_payload(
         {
             "type": "replay_case",
@@ -200,13 +170,13 @@ def test_fixture_migrate_normalizes_backslashes(tmp_path: Path) -> None:
             "input": {"spec": {"provider": "sql"}},
             "observed": {"out_spec": {"provider": "sql"}},
         },
-        resources={"rid1": {"data_ref": {"file": r"resources\\old\\rid1\\file.txt"}}},
+        resources={"rid1": {"data_ref": {"file": r"resources\\case\\rid1\\file.txt"}}},
     )
     _write_bundle(case_path, payload)
 
     bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
     assert bundles_updated == 1
-    assert files_moved == 1
+    assert files_moved == 0
     data = json.loads(case_path.read_text(encoding="utf-8"))
     assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/case/rid1/file.txt"
     assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()


### PR DESCRIPTION
### Motivation
- Simplify fixture migration by removing support for legacy resource layout heuristics and require canonical `resources/<stem>/<resource_id>/...` paths in bundles.
- Make migration behavior deterministic: only normalize path syntax (backslashes) and validate resource files exist instead of guessing/moving legacy locations.

### Description
- Change `fixture_migrate` in `src/fetchgraph/tracer/fixture_tools.py` to reject non-canonical resource paths and to only normalize `data_ref.file` to the canonical POSIX path under `resources/<stem>/<resource_id>/...` instead of handling multiple legacy patterns or moving files.
- Remove file-content collision checks and actual resource-moving logic from migration, and drop the now-unused `filecmp` import.
- Update tests in `tests/test_tracer_fixture_tools.py` to remove legacy scenarios and assert that canonical paths are left unchanged or normalized (including backslash normalization) and that no files are moved when paths are already canonical.
- Modified files: `src/fetchgraph/tracer/fixture_tools.py` and `tests/test_tracer_fixture_tools.py`.

### Testing
- No automated test suite was executed as part of this change (no CI run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5b208780832fb011e4ccbe640000)