### PR TITLE
Fix meta typing in replay export

### DIFF
--- a/src/fetchgraph/replay/export.py
+++ b/src/fetchgraph/replay/export.py
@@ -209,7 +209,8 @@ def collect_replay_case_matches(
         replay_id = event.get("id")
         if not isinstance(replay_id, str):
             continue
-        meta = event.get("meta") if isinstance(event.get("meta"), dict) else {}
+        raw_meta = event.get("meta")
+        meta: dict[str, object] = raw_meta if isinstance(raw_meta, dict) else {}
         payload = event.get("input")
         matches.append(
             ReplayCaseMatch(


### PR DESCRIPTION
### Motivation
- Avoid optional-member access/type-checker errors when `event.get("meta")` may be `None` by ensuring `meta` is a concrete `dict` before accessing `provider`/`spec_idx`.

### Description
- Replace direct `event.get("meta")` usage with `raw_meta = event.get("meta")` and `meta: dict[str, object] = raw_meta if isinstance(raw_meta, dict) else {}` so subsequent accesses use a safely-typed dictionary.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5c6110c8832f84c70b0427edb1aa)