### PR TITLE
Handle case directories without suffix in tracer scans

### DIFF
--- a/src/fetchgraph/utils/path_layout.py
+++ b/src/fetchgraph/utils/path_layout.py
@@ -120,7 +120,16 @@ def find_case_dirs(run_root: Path, case_id: str, cfg: LayoutConfig | None = None
     cases_dir = _find_cases_dir(run_root, cfg)
     if not cases_dir.exists():
         return []
-    return sorted(cases_dir.glob(f"{case_id}_*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    candidates: list[Path] = []
+    direct = cases_dir / case_id
+    if direct.exists() and direct.is_dir():
+        candidates.append(direct)
+    candidates.extend([path for path in cases_dir.glob(f"{case_id}_*") if path.is_dir()])
+    unique: dict[Path, Path] = {}
+    for path in candidates:
+        resolved = path.resolve()
+        unique[resolved] = path
+    return sorted(unique.values(), key=lambda p: p.stat().st_mtime, reverse=True)
 
 
 def canonical_events_path(case_dir: Path, cfg: LayoutConfig | None = None) -> Path:

--- a/tests/test_tracer_layout.py
+++ b/tests/test_tracer_layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from fetchgraph.utils.path_layout import (
     case_dir_from_run_root,
     events_path_for_case,
+    find_case_dirs,
     run_relative_posix_path,
     run_root_from_case_dir,
     validate_run_relative_posix,
@@ -40,6 +42,26 @@ def test_run_relative_posix_path(tmp_path: Path) -> None:
     snapshot_path = case_dir / "schema_snapshot.json"
     snapshot_path.write_text("{}", encoding="utf-8")
     assert run_relative_posix_path(run_root, snapshot_path) == "cases/case_4_ghi/schema_snapshot.json"
+
+
+def test_find_case_dirs_includes_direct_case_dir(tmp_path: Path) -> None:
+    run_root = tmp_path / "run"
+    cases_dir = run_root / "cases"
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    direct = cases_dir / "case_5"
+    suffixed = cases_dir / "case_5_abc"
+    direct.mkdir()
+    suffixed.mkdir()
+    direct_mtime = 1000.0
+    suffixed_mtime = 2000.0
+    direct.touch()
+    suffixed.touch()
+    os.utime(direct, (direct_mtime, direct_mtime))
+    os.utime(suffixed, (suffixed_mtime, suffixed_mtime))
+
+    candidates = find_case_dirs(run_root, "case_5")
+
+    assert candidates == [suffixed, direct]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The tracer search skipped case directories named exactly as the `case_id` (without a `_suffix`), which caused older runs to be selected when mixed directory styles existed.
- Ensure discovery is robust for both legacy/direct case folders and suffixed case folders so `export-case-bundle`/Makefile helper commands find the intended run.

### Description
- Update `find_case_dirs` to also include a direct directory at `cases/<case_id>` when present and to collect only unique resolved paths.
- De-duplicate candidates by their resolved path and sort results by modification time (most recent first) to preserve selection behavior.
- Add a regression test `test_find_case_dirs_includes_direct_case_dir` covering discovery order for a direct case dir and a suffixed case dir.
- Small test hygiene change: import `os` in `tests/test_tracer_layout.py` to set mtimes.

### Testing
- Ran `pytest tests/test_tracer_layout.py` and all tests passed (`13 passed`), indicating the new behavior and existing layout tests are green.
- Verified the updated files are committed with the message `Handle case dirs without suffix`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa3441fac832fb5ed49a42d9a7757)