### PR TITLE
Unify run dir enumeration for tracer listing and resolve

### DIFF
--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -340,21 +340,21 @@ def main(argv: list[str] | None = None) -> int:
                             file=sys.stderr,
                         )
                         pick_run = "latest_non_missed"
-                    infos, stats = scan_case_runs(
-                        case_id=args.case,
-                        data_dir=args.data,
-                        runs_subdir=args.runs_subdir,
-                    )
                     if debug_enabled:
+                        infos, stats = scan_case_runs(
+                            case_id=args.case,
+                            data_dir=args.data,
+                            runs_subdir=args.runs_subdir,
+                        )
                         print("Debug: case run candidates (most recent first):")
                         print(format_case_run_debug(infos, limit=10))
-                    listings, stats = list_case_run_listings(
-                        case_id=args.case,
-                        data_dir=args.data,
-                        tag=args.tag,
-                        runs_subdir=args.runs_subdir,
-                    )
                     if args.list_matches:
+                        listings, stats = list_case_run_listings(
+                            case_id=args.case,
+                            data_dir=args.data,
+                            tag=args.tag,
+                            runs_subdir=args.runs_subdir,
+                        )
                         if not listings:
                             raise LookupError(
                                 _format_case_run_error(

--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -9,10 +9,12 @@ from fetchgraph.utils.path_layout import LayoutConfig, find_case_dirs, run_root_
 from fetchgraph.tracer.resolve import (
     collect_rejections,
     find_events_file,
+    format_case_run_listings,
     format_case_runs,
     format_case_run_debug,
     has_replay_case,
     format_events_search,
+    list_case_run_listings,
     list_case_runs,
     resolve_run_dir_from_run_id,
     scan_case_runs,
@@ -297,6 +299,7 @@ def main(argv: list[str] | None = None) -> int:
                     run_dir_source = "derived from case_dir"
                 selection_rule = "explicit EVENTS"
             else:
+                stats = None
                 if args.run_id and (args.case_dir or args.run_dir):
                     raise ValueError("Do not combine --run-id with --run-dir/--case-dir.")
                 if args.run_id and not args.data:
@@ -345,16 +348,14 @@ def main(argv: list[str] | None = None) -> int:
                     if debug_enabled:
                         print("Debug: case run candidates (most recent first):")
                         print(format_case_run_debug(infos, limit=10))
-                    candidates, stats = list_case_runs(
+                    listings, stats = list_case_run_listings(
                         case_id=args.case,
                         data_dir=args.data,
                         tag=args.tag,
-                        pick_run=pick_run,
-                        replay_id=args.id if pick_run == "latest_with_replay" else None,
                         runs_subdir=args.runs_subdir,
                     )
                     if args.list_matches:
-                        if not candidates:
+                        if not listings:
                             raise LookupError(
                                 _format_case_run_error(
                                     stats,
@@ -363,8 +364,16 @@ def main(argv: list[str] | None = None) -> int:
                                     pick_run=pick_run,
                                 )
                             )
-                        print(format_case_runs(candidates, limit=20))
+                        print(format_case_run_listings(listings, limit=20))
                         return 0
+                    candidates, stats = list_case_runs(
+                        case_id=args.case,
+                        data_dir=args.data,
+                        tag=args.tag,
+                        pick_run=pick_run,
+                        replay_id=args.id if pick_run == "latest_with_replay" else None,
+                        runs_subdir=args.runs_subdir,
+                    )
                     selected_candidate = select_case_run(candidates, select_index=args.select_index)
                     run_dir = selected_candidate.run_dir
                     case_dir = selected_candidate.case_dir
@@ -397,6 +406,34 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"run_dir_source: {run_dir_source}")
                 print(f"Resolved case_dir: {case_dir}")
                 print(f"Resolved events.jsonl: {events_path}")
+                if args.data and args.case:
+                    resolve_stats = stats
+                    if resolve_stats is None:
+                        _, resolve_stats = list_case_runs(
+                            case_id=args.case,
+                            data_dir=args.data,
+                            tag=args.tag,
+                            pick_run=pick_run,
+                            replay_id=args.id if pick_run == "latest_with_replay" else None,
+                            runs_subdir=args.runs_subdir,
+                        )
+                    print(f"runs_root_cli: {resolve_stats.runs_root_cli}")
+                    if resolve_stats.runs_root_effective:
+                        print(f"runs_root_effective: {resolve_stats.runs_root_effective}")
+                    print(
+                        f"history_path: {resolve_stats.history_path} "
+                        f"(entries={resolve_stats.history_entries})"
+                    )
+                    print(
+                        "run_dir_sources: "
+                        f"history={resolve_stats.history_candidates} "
+                        f"fs={resolve_stats.fs_candidates}"
+                    )
+                    if resolve_stats.history_missing:
+                        print(
+                            "WARN: history entries missing on disk: "
+                            + ", ".join(str(path) for path in resolve_stats.history_missing[:5])
+                        )
                 if selected_candidate:
                     print(f"Selected: {selected_candidate.case_dir}")
                 if args.events and run_dir is None:
@@ -691,7 +728,7 @@ def _format_case_run_error(stats, *, case_id: str, tag: str | None, pick_run: st
     lines = [
         "No suitable case run found.",
         f"selection_rule: {_format_selection_rule(tag=tag, pick_run=pick_run)}",
-        f"runs_root: {stats.runs_root}",
+        f"runs_root: {stats.runs_root_cli}",
         f"case_id: {case_id}",
         f"inspected_runs: {stats.inspected_runs}",
         f"inspected_cases: {stats.inspected_cases}",

--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -374,6 +374,15 @@ def main(argv: list[str] | None = None) -> int:
                         replay_id=args.id if pick_run == "latest_with_replay" else None,
                         runs_subdir=args.runs_subdir,
                     )
+                    if not candidates:
+                        raise LookupError(
+                            _format_case_run_error(
+                                stats,
+                                case_id=args.case,
+                                tag=args.tag,
+                                pick_run=pick_run,
+                            )
+                        )
                     selected_candidate = select_case_run(candidates, select_index=args.select_index)
                     run_dir = selected_candidate.run_dir
                     case_dir = selected_candidate.case_dir

--- a/src/fetchgraph/tracer/fetchgraph_tracer.md
+++ b/src/fetchgraph/tracer/fetchgraph_tracer.md
@@ -295,6 +295,10 @@ fetchgraph-tracer export-case-bundle   --out tests/fixtures/replay_cases/known_b
 - `--print-resolve` — распечатать входные флаги и резолв (`run_dir`, `case_dir`, `events_path`, `selection_method`).
 - INFO/WARNING выводятся в stderr, чтобы stdout оставался табличным для парсинга.
 
+Примечание про сканирование FS:
+- По умолчанию сканируются только каталоги запусков с timestamp-префиксом (`YYYYMMDD_HHMMSS_...`).
+- Нестандартные имена каталогов могут появиться в списке только через case-history (history-only entries).
+
 #### 6.1.3 Replay-case selection flags (когда в events много replay_case)
 
 - `--spec-idx <INT>` — фильтр по `meta.spec_idx`

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -31,6 +31,19 @@ class CaseRunCandidate:
 
 
 @dataclass(frozen=True)
+class CaseRunListing:
+    run_dir: Path
+    case_dir: Path | None
+    events_path: Path | None
+    tag: str | None
+    tag_source: str | None
+    status: str | None
+    is_missed: bool
+    run_mtime: float | None
+    case_mtime: float | None
+
+
+@dataclass(frozen=True)
 class CaseRunInfo:
     run_dir: Path
     case_dir: Path
@@ -172,6 +185,119 @@ def resolve_run_dir_from_run_id(*, data_dir: Path, runs_subdir: str, run_id: str
     )
 
 
+def _load_history_entries(history_path: Path) -> list[dict]:
+    if not history_path.exists():
+        return []
+    entries: list[dict] = []
+    with history_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                entries.append(payload)
+    return entries
+
+
+def _runs_suffix_from_history(value: str) -> str | None:
+    normalized = value.replace("\\", "/")
+    if normalized.startswith(".runs/"):
+        return normalized
+    marker = "/.runs/"
+    if marker in normalized:
+        idx = normalized.index(marker) + 1
+        return normalized[idx:]
+    return None
+
+
+def _normalize_history_run_dir(
+    value: str,
+    *,
+    data_dir: Path,
+) -> HistoryRunDir:
+    raw = value
+    initial = Path(value)
+    if initial.is_absolute():
+        normalized = initial
+        return HistoryRunDir(run_dir=normalized, exists=normalized.exists(), raw=raw)
+    candidates = [Path(value).resolve()] + [Path(data_dir / initial).resolve()]
+    suffix = _runs_suffix_from_history(value)
+    if suffix:
+        candidates.append(Path(data_dir / suffix).resolve())
+    normalized = candidates[-1]
+    for item in candidates:
+        if item.exists():
+            normalized = item
+            break
+    return HistoryRunDir(run_dir=normalized, exists=normalized.exists(), raw=raw)
+
+
+def _detect_runs_roots(runs_root_cli: Path) -> tuple[list[Path], Path | None]:
+    roots: list[Path] = []
+    runs_root_effective = None
+    if runs_root_cli.exists():
+        roots.append(runs_root_cli)
+    nested = runs_root_cli / "runs"
+    if nested.exists():
+        nested_dirs = [p for p in nested.iterdir() if p.is_dir()]
+        if nested_dirs:
+            roots.append(nested)
+            runs_root_effective = nested
+    return roots, runs_root_effective
+
+
+def _iter_fs_run_dirs(roots: list[Path]) -> list[Path]:
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        candidates.extend([p for p in root.iterdir() if p.is_dir()])
+    return sorted(candidates, key=_run_dir_sort_key, reverse=True)
+
+
+def _collect_run_dir_inventory(*, case_id: str, data_dir: Path, runs_subdir: str) -> RunDirInventory:
+    runs_root_cli = (data_dir / runs_subdir).resolve()
+    history_path = data_dir / ".runs" / "runs" / "cases" / f"{case_id}.jsonl"
+    history_entries = _load_history_entries(history_path)
+    history_dirs: list[HistoryRunDir] = []
+    if history_entries:
+        for entry in reversed(history_entries):
+            run_dir_value = entry.get("run_dir")
+            if not run_dir_value:
+                continue
+            history_dirs.append(
+                _normalize_history_run_dir(str(run_dir_value), data_dir=data_dir)
+            )
+    runs_roots, runs_root_effective = _detect_runs_roots(runs_root_cli)
+    fs_dirs = _iter_fs_run_dirs(runs_roots)
+    run_dirs: list[Path] = []
+    seen: set[Path] = set()
+    for entry in history_dirs:
+        if entry.run_dir in seen:
+            continue
+        seen.add(entry.run_dir)
+        run_dirs.append(entry.run_dir)
+    for run_dir in fs_dirs:
+        if run_dir in seen:
+            continue
+        seen.add(run_dir)
+        run_dirs.append(run_dir)
+    return RunDirInventory(
+        runs_root_cli=runs_root_cli,
+        runs_root_effective=runs_root_effective,
+        runs_roots=runs_roots,
+        history_path=history_path,
+        history_entries=len(history_entries),
+        history_dirs=history_dirs,
+        fs_dirs=fs_dirs,
+        run_dirs=run_dirs,
+    )
+
+
 def _iter_run_dirs(runs_root: Path) -> Iterable[Path]:
     candidates = [p for p in runs_root.iterdir() if p.is_dir()]
     return sorted(candidates, key=_run_dir_sort_key, reverse=True)
@@ -203,9 +329,32 @@ def _case_dirs(run_dir: Path, case_id: str) -> list[Path]:
     return find_case_dirs(run_dir, case_id, LayoutConfig())
 
 
+def _sorted_case_dirs(case_dirs: list[Path]) -> list[Path]:
+    def _mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    return sorted(case_dirs, key=_mtime, reverse=True)
+
+
+def _format_mtime(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.0f}"
+
+
 @dataclass(frozen=True)
 class RunScanStats:
-    runs_root: Path
+    runs_root_cli: Path
+    runs_root_effective: Path | None
+    runs_roots: list[Path]
+    history_path: Path
+    history_entries: int
+    history_candidates: int
+    fs_candidates: int
+    history_missing: list[Path]
     inspected_runs: int
     inspected_cases: int
     missing_cases: int
@@ -213,6 +362,25 @@ class RunScanStats:
     missed_cases: int
     tag_mismatches: int
     recent: list[CaseRunInfo]
+
+
+@dataclass(frozen=True)
+class HistoryRunDir:
+    run_dir: Path
+    exists: bool
+    raw: str
+
+
+@dataclass(frozen=True)
+class RunDirInventory:
+    runs_root_cli: Path
+    runs_root_effective: Path | None
+    runs_roots: list[Path]
+    history_path: Path
+    history_entries: int
+    history_dirs: list[HistoryRunDir]
+    fs_dirs: list[Path]
+    run_dirs: list[Path]
 
 
 def list_case_runs(
@@ -234,6 +402,109 @@ def list_case_runs(
     return candidates, stats
 
 
+def list_case_run_listings(
+    *,
+    case_id: str,
+    data_dir: Path,
+    tag: str | None = None,
+    runs_subdir: str = ".runs/runs",
+) -> tuple[list[CaseRunListing], RunScanStats]:
+    inventory = _collect_run_dir_inventory(case_id=case_id, data_dir=data_dir, runs_subdir=runs_subdir)
+    listings: list[CaseRunListing] = []
+    inspected_runs = 0
+    inspected_cases = 0
+    missing_cases = 0
+    missing_events = 0
+    missed_cases = 0
+    tag_mismatches = 0
+    for run_dir in inventory.run_dirs:
+        if not run_dir.exists():
+            listings.append(
+                CaseRunListing(
+                    run_dir=run_dir,
+                    case_dir=None,
+                    events_path=None,
+                    tag=None,
+                    tag_source=None,
+                    status="missing_on_disk",
+                    is_missed=False,
+                    run_mtime=None,
+                    case_mtime=None,
+                )
+            )
+            continue
+        inspected_runs += 1
+        case_dirs = _case_dirs(run_dir, case_id)
+        if not case_dirs:
+            missing_cases += 1
+            listings.append(
+                CaseRunListing(
+                    run_dir=run_dir,
+                    case_dir=None,
+                    events_path=None,
+                    tag=None,
+                    tag_source=None,
+                    status="missing_case_dir",
+                    is_missed=False,
+                    run_mtime=run_dir.stat().st_mtime,
+                    case_mtime=None,
+                )
+            )
+            continue
+        case_dirs = _sorted_case_dirs(case_dirs)
+        run_mtime = run_dir.stat().st_mtime
+        for case_dir in case_dirs:
+            inspected_cases += 1
+            events = find_events_file(case_dir)
+            if events.events_path is None:
+                missing_events += 1
+            case_mtime = case_dir.stat().st_mtime
+            status_value, is_missed = _case_status(case_dir)
+            if is_missed:
+                missed_cases += 1
+            tag_value, tag_source = _extract_case_tag(case_dir)
+            if tag and tag_value != tag:
+                tag_mismatches += 1
+            listing_status = status_value
+            if events.events_path is None:
+                listing_status = "missing_events"
+            elif tag and tag_value != tag:
+                listing_status = "tag_mismatch"
+            elif is_missed:
+                listing_status = "missed"
+            listings.append(
+                CaseRunListing(
+                    run_dir=run_dir,
+                    case_dir=case_dir,
+                    events_path=events.events_path,
+                    tag=tag_value,
+                    tag_source=tag_source,
+                    status=listing_status,
+                    is_missed=is_missed,
+                    run_mtime=run_mtime,
+                    case_mtime=case_mtime,
+                )
+            )
+    stats = RunScanStats(
+        runs_root_cli=inventory.runs_root_cli,
+        runs_root_effective=inventory.runs_root_effective,
+        runs_roots=inventory.runs_roots,
+        history_path=inventory.history_path,
+        history_entries=inventory.history_entries,
+        history_candidates=len(inventory.history_dirs),
+        fs_candidates=len(inventory.fs_dirs),
+        history_missing=[entry.run_dir for entry in inventory.history_dirs if not entry.exists],
+        inspected_runs=inspected_runs,
+        inspected_cases=inspected_cases,
+        missing_cases=missing_cases,
+        missing_events=missing_events,
+        missed_cases=missed_cases,
+        tag_mismatches=tag_mismatches,
+        recent=[],
+    )
+    return listings, stats
+
+
 def scan_case_runs(
     *,
     case_id: str,
@@ -241,9 +512,9 @@ def scan_case_runs(
     tag: str | None = None,
     runs_subdir: str = ".runs/runs",
 ) -> tuple[list[CaseRunInfo], RunScanStats]:
-    runs_root = (data_dir / runs_subdir).resolve()
-    if not runs_root.exists():
-        raise FileNotFoundError(f"Runs directory does not exist: {runs_root}")
+    inventory = _collect_run_dir_inventory(case_id=case_id, data_dir=data_dir, runs_subdir=runs_subdir)
+    if not inventory.run_dirs and not inventory.runs_root_cli.exists():
+        raise FileNotFoundError(f"Runs directory does not exist: {inventory.runs_root_cli}")
 
     infos: list[CaseRunInfo] = []
     inspected_runs = 0
@@ -252,7 +523,9 @@ def scan_case_runs(
     missing_events = 0
     missed_cases = 0
 
-    for run_dir in _iter_run_dirs(runs_root):
+    for run_dir in inventory.run_dirs:
+        if not run_dir.exists():
+            continue
         inspected_runs += 1
         case_dirs = _case_dirs(run_dir, case_id)
         if not case_dirs:
@@ -260,7 +533,7 @@ def scan_case_runs(
             continue
         run_mtime = run_dir.stat().st_mtime
         run_order = _run_dir_sort_key(run_dir)
-        for case_dir in case_dirs:
+        for case_dir in _sorted_case_dirs(case_dirs):
             inspected_cases += 1
             events = find_events_file(case_dir)
             if events.events_path is None:
@@ -285,9 +558,27 @@ def scan_case_runs(
                 )
             )
 
-    infos.sort(key=lambda info: (info.run_order, info.case_mtime), reverse=True)
+    if inventory.history_dirs:
+        order_map = {
+            run_dir.resolve(): idx for idx, run_dir in enumerate(inventory.run_dirs)
+        }
+
+        def _history_sort_key(info: CaseRunInfo) -> tuple[int, float]:
+            order = order_map.get(info.run_dir.resolve(), len(inventory.run_dirs))
+            return (order, -info.case_mtime)
+
+        infos.sort(key=_history_sort_key)
+    else:
+        infos.sort(key=lambda info: (info.run_order, info.case_mtime), reverse=True)
     stats = RunScanStats(
-        runs_root=runs_root,
+        runs_root_cli=inventory.runs_root_cli,
+        runs_root_effective=inventory.runs_root_effective,
+        runs_roots=inventory.runs_roots,
+        history_path=inventory.history_path,
+        history_entries=inventory.history_entries,
+        history_candidates=len(inventory.history_dirs),
+        fs_candidates=len(inventory.fs_dirs),
+        history_missing=[entry.run_dir for entry in inventory.history_dirs if not entry.exists],
         inspected_runs=inspected_runs,
         inspected_cases=inspected_cases,
         missing_cases=missing_cases,
@@ -370,6 +661,27 @@ def format_case_runs(candidates: list[CaseRunCandidate], *, limit: int | None = 
         )
     if len(candidates) > (limit or 0):
         rows.append(f"  ... ({len(candidates) - (limit or 0)} more)")
+    return "\n".join(rows)
+
+
+def format_case_run_listings(listings: list[CaseRunListing], *, limit: int | None = 10) -> str:
+    rows = []
+    for idx, listing in enumerate(listings[:limit], start=1):
+        case_dir_name = listing.case_dir.name if listing.case_dir else "<missing>"
+        case_dir_value = str(listing.case_dir) if listing.case_dir else "<missing>"
+        rows.append(
+            "  "
+            f"{idx}. run_dir={listing.run_dir} "
+            f"case_dir={case_dir_name} "
+            f"case_path={case_dir_value} "
+            f"tag={listing.tag!r} "
+            f"status={listing.status!r} "
+            f"missed={listing.is_missed} "
+            f"run_mtime={_format_mtime(listing.run_mtime)} "
+            f"case_mtime={_format_mtime(listing.case_mtime)}"
+        )
+    if len(listings) > (limit or 0):
+        rows.append(f"  ... ({len(listings) - (limit or 0)} more)")
     return "\n".join(rows)
 
 
@@ -603,7 +915,7 @@ def _format_missing_case_runs(
     details = [
         "No suitable case run found.",
         f"selection_rule: {rule}",
-        f"runs_root: {stats.runs_root}",
+        f"runs_root: {stats.runs_root_cli}",
         f"case_id: {case_id}",
         f"inspected_runs: {stats.inspected_runs}",
         f"inspected_cases: {stats.inspected_cases}",

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -237,11 +237,14 @@ def _normalize_history_run_dir(
 
 
 def _has_run_dir_candidates(root: Path) -> bool:
-    for entry in root.iterdir():
-        if not entry.is_dir():
-            continue
-        if _run_dir_timestamp_key(entry.name) is not None:
-            return True
+    try:
+        for entry in root.iterdir():
+            if not entry.is_dir():
+                continue
+            if _run_dir_timestamp_key(entry.name) is not None:
+                return True
+    except OSError:
+        return False
     return False
 
 
@@ -262,14 +265,17 @@ def _iter_fs_run_dirs(roots: list[Path]) -> list[Path]:
     for root in roots:
         if not root.exists():
             continue
-        for entry in root.iterdir():
-            if not entry.is_dir():
-                continue
-            if entry.name in {"cases", "runs"}:
-                continue
-            if _run_dir_timestamp_key(entry.name) is None:
-                continue
-            candidates.append(entry)
+        try:
+            for entry in root.iterdir():
+                if not entry.is_dir():
+                    continue
+                if entry.name in {"cases", "runs"}:
+                    continue
+                if _run_dir_timestamp_key(entry.name) is None:
+                    continue
+                candidates.append(entry)
+        except OSError:
+            continue
     return sorted(candidates, key=_run_dir_sort_key, reverse=True)
 
 
@@ -318,7 +324,10 @@ def _iter_run_dirs(runs_root: Path) -> Iterable[Path]:
 
 
 def _run_dir_sort_key(run_dir: Path) -> tuple[int, int | float, float, str]:
-    run_mtime = run_dir.stat().st_mtime
+    try:
+        run_mtime = run_dir.stat().st_mtime
+    except OSError:
+        run_mtime = 0.0
     ts_key = _run_dir_timestamp_key(run_dir.name)
     if ts_key is None:
         return (0, run_mtime, run_mtime, run_dir.name)

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -236,17 +236,24 @@ def _normalize_history_run_dir(
     return HistoryRunDir(run_dir=normalized, exists=normalized.exists(), raw=raw)
 
 
+def _has_run_dir_candidates(root: Path) -> bool:
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        if _run_dir_timestamp_key(entry.name) is not None:
+            return True
+    return False
+
+
 def _detect_runs_roots(runs_root_cli: Path) -> tuple[list[Path], Path | None]:
     roots: list[Path] = []
     runs_root_effective = None
     if runs_root_cli.exists():
         roots.append(runs_root_cli)
     nested = runs_root_cli / "runs"
-    if nested.exists():
-        nested_dirs = [p for p in nested.iterdir() if p.is_dir()]
-        if nested_dirs:
-            roots.append(nested)
-            runs_root_effective = nested
+    if nested.exists() and _has_run_dir_candidates(nested):
+        roots.append(nested)
+        runs_root_effective = nested
     return roots, runs_root_effective
 
 
@@ -255,13 +262,20 @@ def _iter_fs_run_dirs(roots: list[Path]) -> list[Path]:
     for root in roots:
         if not root.exists():
             continue
-        candidates.extend([p for p in root.iterdir() if p.is_dir()])
+        for entry in root.iterdir():
+            if not entry.is_dir():
+                continue
+            if entry.name in {"cases", "runs"}:
+                continue
+            if _run_dir_timestamp_key(entry.name) is None:
+                continue
+            candidates.append(entry)
     return sorted(candidates, key=_run_dir_sort_key, reverse=True)
 
 
 def _collect_run_dir_inventory(*, case_id: str, data_dir: Path, runs_subdir: str) -> RunDirInventory:
     runs_root_cli = (data_dir / runs_subdir).resolve()
-    history_path = data_dir / ".runs" / "runs" / "cases" / f"{case_id}.jsonl"
+    history_path = runs_root_cli / "cases" / f"{case_id}.jsonl"
     history_entries = _load_history_entries(history_path)
     history_dirs: list[HistoryRunDir] = []
     if history_entries:

--- a/tests/test_tracer_run_dir_inventory.py
+++ b/tests/test_tracer_run_dir_inventory.py
@@ -60,3 +60,25 @@ def test_history_missing_on_disk_is_listed(tmp_path: Path) -> None:
 
     assert listings[0].run_dir == missing_run_dir
     assert listings[0].status == "missing_on_disk"
+
+
+def test_fs_scan_ignores_cases_and_runs_dirs(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    runs_root = data_dir / ".runs" / "runs"
+    (runs_root / "cases").mkdir(parents=True, exist_ok=True)
+    (runs_root / "runs").mkdir(parents=True, exist_ok=True)
+    run_dir = runs_root / "20260127_101751_retail_cases"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    make_case_dir(
+        run_dir,
+        "agg_003",
+        "x",
+        status="ok",
+        events=[{"type": "event", "id": "noise_filter"}],
+    )
+
+    listings, _ = list_case_run_listings(case_id="agg_003", data_dir=data_dir)
+    run_names = {listing.run_dir.name for listing in listings}
+
+    assert "cases" not in run_names
+    assert "runs" not in run_names

--- a/tests/test_tracer_run_dir_inventory.py
+++ b/tests/test_tracer_run_dir_inventory.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fetchgraph.tracer.resolve import list_case_run_listings, list_case_runs
+from tests.helpers.tracer_testkit import case_history_path, make_case_dir, write_history_entry
+
+
+def test_history_relative_run_dir_is_normalized(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    runs_root = data_dir / ".runs" / "runs"
+    run_dir = runs_root / "20260127_101751_retail_cases"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    make_case_dir(
+        run_dir,
+        "agg_003",
+        "x",
+        status="ok",
+        events=[{"type": "event", "id": "relative_history"}],
+    )
+
+    relative_run_dir = os.path.relpath(run_dir, Path.cwd())
+    history_path = case_history_path(data_dir, "agg_003")
+    write_history_entry(history_path, {"run_dir": str(relative_run_dir)})
+
+    candidates, _ = list_case_runs(case_id="agg_003", data_dir=data_dir)
+    assert candidates[0].run_dir == run_dir
+
+
+def test_nested_runs_root_is_scanned(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    runs_root_cli = data_dir / ".runs" / "runs"
+    nested_root = runs_root_cli / "runs"
+    run_dir = nested_root / "20260127_101751_retail_cases"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    make_case_dir(
+        run_dir,
+        "agg_003",
+        "x",
+        status="ok",
+        events=[{"type": "event", "id": "nested_root"}],
+    )
+
+    candidates, stats = list_case_runs(case_id="agg_003", data_dir=data_dir)
+    candidate_dirs = [candidate.run_dir for candidate in candidates]
+
+    assert run_dir in candidate_dirs
+    assert stats.runs_root_effective == nested_root
+
+
+def test_history_missing_on_disk_is_listed(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    missing_run_dir = data_dir / ".runs" / "runs" / "20260127_101751_retail_cases"
+
+    history_path = case_history_path(data_dir, "agg_003")
+    write_history_entry(history_path, {"run_dir": str(missing_run_dir)})
+
+    listings, _ = list_case_run_listings(case_id="agg_003", data_dir=data_dir)
+
+    assert listings[0].run_dir == missing_run_dir
+    assert listings[0].status == "missing_on_disk"


### PR DESCRIPTION
### Motivation
- Fix disparity between history-based case runs and filesystem scans so tracer listing tools show a consistent, unified view of runs.
- Normalize historical `run_dir` values (absolute, repo-relative, `DATA_DIR`-relative, and `.runs/...` suffixes) to avoid missed matches.
- Auto-detect nested `runs` roots (e.g. `.runs/runs/runs`) and preserve history-only entries in listings with clear status flags like `missing_on_disk`.

### Description
- Introduce inventory types and helpers: `RunDirInventory`, `HistoryRunDir`, `CaseRunListing` and functions `_load_history_entries`, `_normalize_history_run_dir`, `_detect_runs_roots`, `_iter_fs_run_dirs`, and `_collect_run_dir_inventory` in `src/fetchgraph/tracer/resolve.py` to merge history and FS sources.
- Add `list_case_run_listings` to produce listings that include history-only entries and new statuses (`missing_on_disk`, `missing_case_dir`, `missing_events`, `tag_mismatch`, `missed`), and make `scan_case_runs` history-aware when ordering results.
- Update CLI in `src/fetchgraph/tracer/cli.py` to use the new listing path for `--list-matches` and to expand `--print-resolve` output with `runs_root_cli`, `runs_root_effective`, `history_path` and counts (`history` vs `fs`) including warnings when history entries are missing on disk.
- Add tests in `tests/test_tracer_run_dir_inventory.py` covering relative history path normalization, nested `runs` root discovery, and reporting of `history` entries missing on disk.

### Testing
- Ran `pytest -q tests/test_tracer_run_dir_inventory.py` and all tests passed (3 passed).
- The new tests validate `relative history path` normalization, `nested runs_root` scanning and `missing_on_disk` reporting and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb377257c832f89399c5717c7dbad)