### PR TITLE
Include non-timestamp run dirs in scan

### DIFF
--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -16,6 +16,7 @@ from fetchgraph.tracer.resolve import (
     format_events_search,
     list_case_run_listings,
     list_case_runs,
+    RunScanStats,
     resolve_run_dir_from_run_id,
     scan_case_runs,
     select_case_run,
@@ -281,6 +282,7 @@ def main(argv: list[str] | None = None) -> int:
             run_dir_source = "unresolved"
             auto_resolve = False
             selected_candidate = None
+            stats: RunScanStats | None = None
             pick_run = args.pick_run
             list_only = args.list_matches or args.list_replay_matches or args.list_replay_ids
             if not args.out and not list_only and not args.print_resolve:
@@ -299,7 +301,6 @@ def main(argv: list[str] | None = None) -> int:
                     run_dir_source = "derived from case_dir"
                 selection_rule = "explicit EVENTS"
             else:
-                stats = None
                 if args.run_id and (args.case_dir or args.run_dir):
                     raise ValueError("Do not combine --run-id with --run-dir/--case-dir.")
                 if args.run_id and not args.data:

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -271,8 +271,6 @@ def _iter_fs_run_dirs(roots: list[Path]) -> list[Path]:
                     continue
                 if entry.name in {"cases", "runs"}:
                     continue
-                if _run_dir_timestamp_key(entry.name) is None:
-                    continue
                 candidates.append(entry)
         except OSError:
             continue


### PR DESCRIPTION
### Motivation
- Filesystem scans ignored run directories that did not match the timestamp naming convention (e.g. `run_old`, `run_new`), causing auto-resolve and replay selection to find zero inspected runs and fail.
- Allowing non-timestamped run directories to be considered ensures runs created with non-timestamp names are discoverable and selection logic works correctly.

### Description
- Stop filtering out non-timestamped directories in `_iter_fs_run_dirs` so all subdirectories (except reserved names `cases` and `runs`) are considered during the filesystem scan in `src/fetchgraph/tracer/resolve.py`.
- Preserve existing sorting via `_run_dir_sort_key` so timestamped runs remain ordered appropriately while still including other run directories.
- Change affects run discovery only; no other behavior or public APIs were modified.

### Testing
- Ran `pytest tests/test_tracer_auto_resolve.py tests/test_tracer_export_resolve_latest_with_replay_ignores_provider_specidx.py tests/test_tracer_export_resolve_prefers_run_with_replay.py` and all tests passed.
- Test run summary: `13 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb8c906f0832fb58355203a5c9764)