### PR TITLE
Fix replay-id discovery: list modes accept latest run with any replay; export requires --id

### DIFF
--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -12,7 +12,6 @@ from fetchgraph.tracer.resolve import (
     format_case_run_listings,
     format_case_runs,
     format_case_run_debug,
-    has_replay_case,
     format_events_search,
     list_case_run_listings,
     list_case_runs,
@@ -285,6 +284,7 @@ def main(argv: list[str] | None = None) -> int:
             stats: RunScanStats | None = None
             pick_run = args.pick_run
             list_only = args.list_matches or args.list_replay_matches or args.list_replay_ids
+            replay_id_for_pick: str | None = None
             if not args.out and not list_only and not args.print_resolve:
                 raise ValueError("--out is required unless using list-only or print-resolve modes.")
             if args.events:
@@ -334,13 +334,16 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     if not args.case or not args.data:
                         raise ValueError("--case and --data are required when --events is not provided.")
-                    if args.pick_run == "latest_with_replay" and not args.id:
-                        print(
-                            "WARNING: pick_run=latest_with_replay requires --id; "
-                            "using pick_run=latest_non_missed for replay-id discovery.",
-                            file=sys.stderr,
-                        )
-                        pick_run = "latest_non_missed"
+                    if args.pick_run == "latest_with_replay":
+                        if list_only:
+                            replay_id_for_pick = None
+                        elif not args.id:
+                            raise ValueError(
+                                "--id is required when pick_run=latest_with_replay "
+                                "(except list-replay-ids/matches)."
+                            )
+                        else:
+                            replay_id_for_pick = args.id
                     if debug_enabled:
                         infos, stats = scan_case_runs(
                             case_id=args.case,
@@ -372,7 +375,7 @@ def main(argv: list[str] | None = None) -> int:
                         data_dir=args.data,
                         tag=args.tag,
                         pick_run=pick_run,
-                        replay_id=args.id if pick_run == "latest_with_replay" else None,
+                        replay_id=replay_id_for_pick,
                         runs_subdir=args.runs_subdir,
                     )
                     if not candidates:
@@ -424,7 +427,7 @@ def main(argv: list[str] | None = None) -> int:
                             data_dir=args.data,
                             tag=args.tag,
                             pick_run=pick_run,
-                            replay_id=args.id if pick_run == "latest_with_replay" else None,
+                            replay_id=replay_id_for_pick,
                             runs_subdir=args.runs_subdir,
                         )
                     print(f"runs_root_cli: {resolve_stats.runs_root_cli}")
@@ -482,34 +485,6 @@ def main(argv: list[str] | None = None) -> int:
                 print(format_replay_case_match_table(matches))
                 return 0
             if args.list_replay_ids:
-                if auto_resolve and not args.events and args.case and args.data:
-                    original_case_dir = case_dir
-                    original_events_path = events_path
-                    candidates, _ = list_case_runs(
-                        case_id=args.case,
-                        data_dir=args.data,
-                        tag=args.tag,
-                        pick_run=pick_run,
-                        replay_id=args.id if pick_run == "latest_with_replay" else None,
-                        runs_subdir=args.runs_subdir,
-                    )
-                    selected_candidate = None
-                    for candidate in candidates:
-                        if has_replay_case(candidate.events_path):
-                            selected_candidate = candidate
-                            break
-                    if selected_candidate is None:
-                        raise LookupError(_format_no_replay_ids_all_candidates_error(candidates))
-                    run_dir = selected_candidate.run_dir
-                    case_dir = selected_candidate.case_dir
-                    events_path = selected_candidate.events_path
-                    selection_rule = _format_selection_rule(tag=args.tag, pick_run=pick_run)
-                    run_dir_source = "auto-resolve (replay-id list)"
-                    if args.print_resolve and (
-                        case_dir != original_case_dir or events_path != original_events_path
-                    ):
-                        print(f"Adjusted for replay-id listing: case_dir={case_dir}")
-                        print(f"Adjusted events.jsonl: {events_path}")
                 if auto_resolve and not args.events:
                     print(
                         f"INFO: events={events_path} selection_rule={selection_rule} run_dir={run_dir}",

--- a/src/fetchgraph/tracer/cli.py
+++ b/src/fetchgraph/tracer/cli.py
@@ -334,7 +334,10 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     if not args.case or not args.data:
                         raise ValueError("--case and --data are required when --events is not provided.")
-                    if args.pick_run == "latest_with_replay":
+                    if list_only and (args.list_replay_ids or args.list_replay_matches):
+                        pick_run = "latest_with_replay"
+                        replay_id_for_pick = args.id if args.id else None
+                    elif args.pick_run == "latest_with_replay":
                         if list_only:
                             replay_id_for_pick = None
                         elif not args.id:
@@ -461,7 +464,7 @@ def main(argv: list[str] | None = None) -> int:
                         infos,
                         tag=args.tag,
                         pick_run=pick_run,
-                        replay_id=args.id,
+                        replay_id=replay_id_for_pick,
                         selected_case_dir=case_dir,
                     )
                 if rejections:

--- a/src/fetchgraph/tracer/resolve.py
+++ b/src/fetchgraph/tracer/resolve.py
@@ -626,8 +626,9 @@ def _filter_case_run_infos(
             continue
         if pick_run == "latest_with_replay":
             if replay_id is None:
-                raise ValueError("replay_id is required for latest_with_replay selection")
-            if not _has_replay_case_id(info.events.events_path, replay_id):
+                if not has_replay_case(info.events.events_path):
+                    continue
+            elif not _has_replay_case_id(info.events.events_path, replay_id):
                 continue
         if tag and info.tag != tag:
             continue

--- a/tests/test_tracer_replay_id_discovery.py
+++ b/tests/test_tracer_replay_id_discovery.py
@@ -106,3 +106,53 @@ def test_no_replay_case_triggers_fallback_scan_next_run(
     combined = "\n".join([captured.out, captured.err])
     assert "replay_old" in combined
     assert str(run_old) in combined
+
+
+def test_list_replay_ids_prefers_latest_run_with_replay_case_even_if_missed(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    data_dir = tmp_path / "data"
+    runs_root = data_dir / ".runs" / "runs"
+    runs_root.mkdir(parents=True, exist_ok=True)
+
+    run_new = runs_root / "20260201_173717_retail_cases"
+    run_old = runs_root / "20260125_155226_retail_cases"
+    run_new.mkdir()
+    run_old.mkdir()
+
+    make_case_dir(
+        run_new,
+        "agg_003",
+        "z",
+        status="missed",
+        events=[{"type": "replay_case", "id": "replay_new", "v": 2, "input": {}}],
+        mtime=200,
+    )
+    make_case_dir(
+        run_old,
+        "agg_003",
+        "x",
+        status="ok",
+        events=[{"type": "event", "id": "no_replay"}],
+        mtime=100,
+    )
+
+    set_mtime(run_old, 100)
+    set_mtime(run_new, 200)
+
+    exit_code = cli.main(
+        [
+            "export-case-bundle",
+            "--case",
+            "agg_003",
+            "--data",
+            str(data_dir),
+            "--list-replay-ids",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    combined = "\n".join([captured.out, captured.err])
+    assert "replay_new" in combined
+    assert str(run_new) in combined


### PR DESCRIPTION
### Motivation
- Ensure `--list-replay-ids`/`--list-replay-matches` use the “latest with any replay” semantics (include runs marked missed) instead of downgrading to `latest_non_missed` when `pick_run=latest_with_replay` is used without `--id`.
- Preserve the stricter semantics for real exports / replay-id resolution so that `pick_run=latest_with_replay` still requires `--id` outside of list-only modes.
- Make discovery logic simpler by reusing the resolver pipeline rather than doing a separate manual scan when listing replay ids.

### Description
- CLI: in `src/fetchgraph/tracer/cli.py` introduce `replay_id_for_pick` and keep `pick_run="latest_with_replay"` for list-only modes, while enforcing `--id` with a `ValueError` for non-list operations; pass `replay_id_for_pick` into `list_case_runs` instead of conditionally downgrading `pick_run` or manually scanning candidates.
- Resolver: in `src/fetchgraph/tracer/resolve.py` change `_filter_case_run_infos()` so that when `pick_run == "latest_with_replay"` and `replay_id is None` it accepts candidates that contain any `replay_case` (using `has_replay_case`), and when `replay_id` is provided it keeps the existing filtering by specific id.
- Tests: add `tests/test_tracer_replay_id_discovery.py::test_list_replay_ids_prefers_latest_run_with_replay_case_even_if_missed` which ensures listing returns the newest run that contains a `replay_case` even if that run is `missed`.

### Testing
- Ran `pytest -q tests/test_tracer_replay_id_discovery.py` and observed `3 passed` (the new test plus the existing two) which verifies the listing behavior and fallback logic for runs without replay cases.
- Local unit test run succeeded for the modified test file and exercised the updated selection and filtering logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fbbea8518832f82f4f02d326a2bee)