### PR TITLE
Preserve relative paths when promoting known_bad fixtures (fix fixture-green)

### DIFF
--- a/src/fetchgraph/replay/runtime.py
+++ b/src/fetchgraph/replay/runtime.py
@@ -11,12 +11,16 @@ from fetchgraph.utils.path_layout import (
     validate_safe_path_segment,
 )
 
+_VALID_FIXTURE_BUCKETS = {"fixed", "known_bad"}
+
+
 @dataclass(frozen=True)
 class ReplayContext:
     resources: Dict[str, dict] = field(default_factory=dict)
     extras: Dict[str, dict] = field(default_factory=dict)
     base_dir: Path | None = None
     fixture_stem: str | None = None
+    fixture_bucket_dir: Path | None = None
 
     def resolve_resource_path(self, resource_path: str | Path) -> Path:
         path = Path(resource_path)
@@ -26,16 +30,21 @@ class ReplayContext:
             raise ValueError(f"resource path must be relative to base_dir: {path}")
         resource_str = resource_path.as_posix() if isinstance(resource_path, Path) else str(resource_path)
         rel_path = validate_run_relative_posix(resource_str)
+
+        fixture_root = self.fixture_bucket_dir or self.base_dir
+        fixture_stem = None
+        if self.fixture_stem:
+            fixture_stem = validate_run_relative_posix(self.fixture_stem).as_posix()
+
         if resource_str.startswith("resources/"):
-            if not self.fixture_stem:
+            if not fixture_stem:
                 raise ValueError("fixture_stem is required for resources/ paths")
-            fixture_stem = validate_safe_path_segment(self.fixture_stem, what="fixture_stem")
             prefix = f"resources/{fixture_stem}/"
             if not resource_str.startswith(prefix):
                 raise ValueError(f"resource path must be under {prefix}")
-            return safe_join_under_validated(self.base_dir, rel_path)
-        if self.fixture_stem and self.resources:
-            fixture_stem = validate_safe_path_segment(self.fixture_stem, what="fixture_stem")
+            return safe_join_under_validated(fixture_root, rel_path)
+
+        if fixture_stem and self.resources:
             for resource_id, resource in self.resources.items():
                 resource_id = validate_safe_path_segment(resource_id, what="resource_id")
                 if not isinstance(resource, dict):
@@ -47,7 +56,8 @@ class ReplayContext:
                 if file_name == resource_str:
                     fixture_rel = Path("resources") / fixture_stem / resource_id / rel_path
                     fixture_rel = validate_run_relative_posix(fixture_rel.as_posix())
-                    return safe_join_under_validated(self.base_dir, fixture_rel)
+                    return safe_join_under_validated(fixture_root, fixture_rel)
+
         return safe_join_under_validated(self.base_dir, rel_path)
 
 
@@ -65,16 +75,32 @@ def run_case(root: dict, ctx: ReplayContext) -> dict:
     return handler(root["input"], ctx)
 
 
+def _infer_fixture_layout(path: Path) -> tuple[Path, str]:
+    resolved = path.resolve()
+    if not resolved.name.endswith(".case.json"):
+        raise ValueError(f"Unsupported case bundle filename: {resolved}")
+
+    parts = resolved.parts
+    for idx in range(len(parts) - 1, -1, -1):
+        if parts[idx] not in _VALID_FIXTURE_BUCKETS:
+            continue
+        bucket_dir = Path(*parts[: idx + 1])
+        stem = resolved.relative_to(bucket_dir).as_posix().removesuffix(".case.json")
+        return bucket_dir, stem
+    return resolved.parent, resolved.name.removesuffix(".case.json")
+
+
 def load_case_bundle(path: Path) -> tuple[dict, ReplayContext]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("schema") != "fetchgraph.tracer.case_bundle" or data.get("v") != 1:
         raise ValueError(f"Unsupported case bundle schema in {path}")
     root = data["root"]
-    fixture_stem = path.name.replace(".case.json", "")
+    fixture_bucket_dir, fixture_stem = _infer_fixture_layout(path)
     ctx = ReplayContext(
         resources=data.get("resources", {}),
         extras=data.get("extras", {}),
-        base_dir=path.parent,
+        base_dir=fixture_bucket_dir,
         fixture_stem=fixture_stem,
+        fixture_bucket_dir=fixture_bucket_dir,
     )
     return root, ctx

--- a/src/fetchgraph/replay/runtime.py
+++ b/src/fetchgraph/replay/runtime.py
@@ -81,8 +81,8 @@ def _infer_fixture_layout(path: Path) -> tuple[Path, str]:
         raise ValueError(f"Unsupported case bundle filename: {resolved}")
 
     parts = resolved.parts
-    # Prefer canonical .../replay_cases/<bucket>/... anchor when available.
-    for idx in range(len(parts) - 2):
+    # Prefer canonical .../replay_cases/<bucket>/... anchor closest to the case file.
+    for idx in range(len(parts) - 3, -1, -1):
         if parts[idx] != "replay_cases":
             continue
         bucket_idx = idx + 1

--- a/src/fetchgraph/replay/runtime.py
+++ b/src/fetchgraph/replay/runtime.py
@@ -81,12 +81,29 @@ def _infer_fixture_layout(path: Path) -> tuple[Path, str]:
         raise ValueError(f"Unsupported case bundle filename: {resolved}")
 
     parts = resolved.parts
-    for idx in range(len(parts) - 1, -1, -1):
+    # Prefer canonical .../replay_cases/<bucket>/... anchor when available.
+    for idx in range(len(parts) - 2):
+        if parts[idx] != "replay_cases":
+            continue
+        bucket_idx = idx + 1
+        if parts[bucket_idx] not in _VALID_FIXTURE_BUCKETS:
+            continue
+        bucket_dir = Path(*parts[: bucket_idx + 1])
+        rel = resolved.relative_to(bucket_dir)
+        if rel.parts and rel.parts[0] == "resources":
+            continue
+        return bucket_dir, rel.as_posix().removesuffix(".case.json")
+
+    # Fallback: choose the left-most bucket segment to avoid nested "fixed/known_bad" stem collisions.
+    for idx in range(len(parts) - 1):
         if parts[idx] not in _VALID_FIXTURE_BUCKETS:
             continue
         bucket_dir = Path(*parts[: idx + 1])
-        stem = resolved.relative_to(bucket_dir).as_posix().removesuffix(".case.json")
-        return bucket_dir, stem
+        rel = resolved.relative_to(bucket_dir)
+        if rel.parts and rel.parts[0] == "resources":
+            continue
+        return bucket_dir, rel.as_posix().removesuffix(".case.json")
+
     return resolved.parent, resolved.name.removesuffix(".case.json")
 
 
@@ -99,7 +116,7 @@ def load_case_bundle(path: Path) -> tuple[dict, ReplayContext]:
     ctx = ReplayContext(
         resources=data.get("resources", {}),
         extras=data.get("extras", {}),
-        base_dir=fixture_bucket_dir,
+        base_dir=path.resolve().parent,
         fixture_stem=fixture_stem,
         fixture_bucket_dir=fixture_bucket_dir,
     )

--- a/src/fetchgraph/tracer/fixture_layout.py
+++ b/src/fetchgraph/tracer/fixture_layout.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from functools import lru_cache
 from pathlib import Path, PurePosixPath
 
 VALID_BUCKETS = {"fixed", "known_bad"}
@@ -45,6 +47,31 @@ def _stem_from_case_path(layout: FixtureLayout, case_path: Path) -> str:
     return rel.removesuffix(".case.json")
 
 
+
+def _stem_matches_pattern(stem: str, pattern: str) -> bool:
+    normalized = pattern.removesuffix(".case.json")
+    stem_parts = PurePosixPath(stem).parts
+    pattern_parts = PurePosixPath(normalized).parts
+
+    @lru_cache(maxsize=None)
+    def match(si: int, pi: int) -> bool:
+        if pi == len(pattern_parts):
+            return si == len(stem_parts)
+
+        token = pattern_parts[pi]
+        if token == "**":
+            return match(si, pi + 1) or (si < len(stem_parts) and match(si + 1, pi))
+
+        if si >= len(stem_parts):
+            return False
+
+        if not fnmatchcase(stem_parts[si], token):
+            return False
+
+        return match(si + 1, pi + 1)
+
+    return match(0, 0)
+
 def find_case_bundles(
     *,
     root: Path,
@@ -77,15 +104,9 @@ def find_case_bundles(
             matches.extend(all_cases)
             continue
 
-        normalized_pattern = pattern.removesuffix(".case.json")
         for case_path in all_cases:
             stem = _stem_from_case_path(layout, case_path)
-            if normalized_pattern.endswith("/**"):
-                prefix = normalized_pattern.removesuffix("/**")
-                if stem == prefix or stem.startswith(f"{prefix}/"):
-                    matches.append(case_path)
-                continue
-            if PurePosixPath(stem).match(normalized_pattern):
+            if _stem_matches_pattern(stem, pattern):
                 matches.append(case_path)
 
     return sorted(matches)

--- a/src/fetchgraph/tracer/fixture_layout.py
+++ b/src/fetchgraph/tracer/fixture_layout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from fnmatch import fnmatchcase
 
 VALID_BUCKETS = {"fixed", "known_bad"}
 
@@ -25,6 +26,26 @@ class FixtureLayout:
         return self.bucket_dir / "resources" / stem
 
 
+def _iter_bucket_case_paths(layout: FixtureLayout) -> list[Path]:
+    if not layout.bucket_dir.exists():
+        return []
+    matches: list[Path] = []
+    for case_path in layout.bucket_dir.rglob("*.case.json"):
+        try:
+            rel = case_path.relative_to(layout.bucket_dir)
+        except ValueError:
+            continue
+        if rel.parts and rel.parts[0] == "resources":
+            continue
+        matches.append(case_path)
+    return sorted(matches)
+
+
+def _stem_from_case_path(layout: FixtureLayout, case_path: Path) -> str:
+    rel = case_path.relative_to(layout.bucket_dir).as_posix()
+    return rel.removesuffix(".case.json")
+
+
 def find_case_bundles(
     *,
     root: Path,
@@ -43,27 +64,24 @@ def find_case_bundles(
     else:
         raise ValueError(f"Unsupported bucket: {bucket}")
 
-    if name:
-        matches: list[Path] = []
-        for entry in buckets:
-            layout = FixtureLayout(root, entry)
+    matches: list[Path] = []
+    for entry in buckets:
+        layout = FixtureLayout(root, entry)
+        if name:
             case_path = layout.case_path(name)
             if case_path.exists():
                 matches.append(case_path)
-        return matches
-
-    if pattern:
-        if pattern.endswith(".case.json"):
-            glob_pattern = pattern
-        else:
-            glob_pattern = f"{pattern}.case.json"
-    else:
-        glob_pattern = "*.case.json"
-
-    matches = []
-    for entry in buckets:
-        layout = FixtureLayout(root, entry)
-        if not layout.bucket_dir.exists():
             continue
-        matches.extend(layout.bucket_dir.glob(glob_pattern))
+
+        all_cases = _iter_bucket_case_paths(layout)
+        if not pattern:
+            matches.extend(all_cases)
+            continue
+
+        normalized_pattern = pattern.removesuffix(".case.json")
+        for case_path in all_cases:
+            stem = _stem_from_case_path(layout, case_path)
+            if fnmatchcase(stem, normalized_pattern):
+                matches.append(case_path)
+
     return sorted(matches)

--- a/src/fetchgraph/tracer/fixture_layout.py
+++ b/src/fetchgraph/tracer/fixture_layout.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from fnmatch import fnmatchcase
+from pathlib import Path, PurePosixPath
 
 VALID_BUCKETS = {"fixed", "known_bad"}
 
@@ -81,7 +80,12 @@ def find_case_bundles(
         normalized_pattern = pattern.removesuffix(".case.json")
         for case_path in all_cases:
             stem = _stem_from_case_path(layout, case_path)
-            if fnmatchcase(stem, normalized_pattern):
+            if normalized_pattern.endswith("/**"):
+                prefix = normalized_pattern.removesuffix("/**")
+                if stem == prefix or stem.startswith(f"{prefix}/"):
+                    matches.append(case_path)
+                continue
+            if PurePosixPath(stem).match(normalized_pattern):
                 matches.append(case_path)
 
     return sorted(matches)

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -779,12 +779,14 @@ def fixture_migrate(
             if not isinstance(file_name, str) or not file_name:
                 continue
             rel = _safe_resource_path(file_name, stem=stem)
-            if rel.parts[:3] != ("resources", stem, resource_id):
+            stem_parts = Path(stem).parts
+            expected_prefix = ("resources", *stem_parts, resource_id)
+            if rel.parts[: len(expected_prefix)] != expected_prefix:
                 raise ValueError(
                     "Resource path must be in resources/<stem>/<resource_id>/...; "
                     f"found {file_name!r} in {fixture_ref.case_abs}"
                 )
-            rel_tail = Path(*rel.parts[3:])
+            rel_tail = Path(*rel.parts[len(expected_prefix) :])
             if not rel_tail.parts:
                 raise ValueError(f"Resource path must include a file name: {file_name!r} in {fixture_ref.case_abs}")
             target_rel = Path("resources") / stem / resource_id / rel_tail

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -392,7 +392,8 @@ def fixture_green(
         raise ValueError(f"fixture-green expects a known_bad case path, got: {case_path}")
     if not case_path.name.endswith(".case.json"):
         raise ValueError(f"fixture-green expects a .case.json bundle, got: {case_path}")
-    stem = case_path.name.replace(".case.json", "")
+    case_rel_path = case_path.relative_to(known_layout.bucket_dir)
+    stem = case_rel_path.as_posix().removesuffix(".case.json")
     fixed_layout = FixtureLayout(out_root, "fixed")
 
     payload = load_bundle_json(case_path)

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from .diff_utils import first_diff_path
-from .fixture_layout import FixtureLayout, find_case_bundles
+from .fixture_layout import VALID_BUCKETS, FixtureLayout, find_case_bundles
 from .runtime import load_case_bundle, run_case
 from .validators import REPLAY_VALIDATORS
 
@@ -102,6 +102,36 @@ def _format_fixture_diff(output: object, expected: object) -> str:
     lines.append(f"output: {_format_json(output)}")
     return "\n".join(lines)
 
+
+
+def _resolve_case_path(root: Path, case_path: Path) -> Path:
+    if case_path.is_absolute():
+        return case_path.resolve()
+    return (root / case_path).resolve()
+
+
+def _stem_from_bucket_case_path(*, root: Path, bucket: str, case_path: Path) -> str:
+    case_abs = _resolve_case_path(root, case_path)
+    bucket_dir = FixtureLayout(root, bucket).bucket_dir.resolve()
+    if not case_abs.is_relative_to(bucket_dir):
+        raise ValueError(f"Fixture path {case_abs} is outside bucket {bucket_dir}")
+    rel = case_abs.relative_to(bucket_dir).as_posix()
+    if not rel.endswith('.case.json'):
+        raise ValueError(f"Expected .case.json fixture path, got: {case_abs}")
+    return rel.removesuffix('.case.json')
+
+
+def _bucket_and_stem_from_case_path(*, root: Path, case_path: Path) -> tuple[str, str]:
+    case_abs = _resolve_case_path(root, case_path)
+    for bucket in sorted(VALID_BUCKETS):
+        bucket_dir = FixtureLayout(root, bucket).bucket_dir.resolve()
+        if not case_abs.is_relative_to(bucket_dir):
+            continue
+        rel = case_abs.relative_to(bucket_dir).as_posix()
+        if not rel.endswith('.case.json'):
+            break
+        return bucket, rel.removesuffix('.case.json')
+    raise ValueError(f"Unsupported fixture path (not under known buckets): {case_abs}")
 
 def resolve_fixture_candidates(
     *,
@@ -392,8 +422,7 @@ def fixture_green(
         raise ValueError(f"fixture-green expects a known_bad case path, got: {case_path}")
     if not case_path.name.endswith(".case.json"):
         raise ValueError(f"fixture-green expects a .case.json bundle, got: {case_path}")
-    case_rel_path = case_path.relative_to(known_layout.bucket_dir)
-    stem = case_rel_path.as_posix().removesuffix(".case.json")
+    stem = _stem_from_bucket_case_path(root=out_root, bucket="known_bad", case_path=case_path)
     fixed_layout = FixtureLayout(out_root, "fixed")
 
     payload = load_bundle_json(case_path)
@@ -547,8 +576,7 @@ def fixture_rm(
 
     targets: list[Path] = []
     for case_path_item in matched:
-        bucket_name = case_path_item.parent.name
-        stem = case_path_item.name.replace(".case.json", "")
+        bucket_name, stem = _bucket_and_stem_from_case_path(root=root, case_path=case_path_item)
         layout = FixtureLayout(root, bucket_name)
         if scope in ("cases", "both"):
             targets.extend([layout.case_path(stem), layout.expected_path(stem)])
@@ -785,7 +813,7 @@ def fixture_demote(
         all_matches=all_matches,
     )
     for case_path_item in selected_paths:
-        stem = case_path_item.name.replace(".case.json", "")
+        stem = _stem_from_bucket_case_path(root=root, bucket=from_bucket, case_path=case_path_item)
         from_layout = FixtureLayout(root, from_bucket)
         to_layout = FixtureLayout(root, to_bucket)
         from_case = from_layout.case_path(stem)

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -19,6 +19,80 @@ class FixtureCandidate:
     source: dict
 
 
+@dataclass(frozen=True)
+class FixtureRef:
+    root: Path
+    bucket: str
+    bucket_dir: Path
+    case_abs: Path
+    stem: str
+
+
+def resolve_user_case_input(*, root: Path, case_path: Path) -> Path:
+    if case_path.is_absolute():
+        return case_path.resolve()
+
+    cwd_candidate = (Path.cwd() / case_path).resolve()
+    root_candidate = (root / case_path).resolve()
+    cwd_exists = cwd_candidate.exists()
+    root_exists = root_candidate.exists()
+
+    if cwd_exists and root_exists:
+        if cwd_candidate == root_candidate:
+            return cwd_candidate
+        raise ValueError(
+            "Ambiguous relative case_path; both cwd-relative and root-relative paths exist.\n"
+            f"  input: {case_path}\n"
+            f"  cwd candidate: {cwd_candidate}\n"
+            f"  root candidate: {root_candidate}\n"
+            f"  root: {root}"
+        )
+    if cwd_exists:
+        return cwd_candidate
+    if root_exists:
+        return root_candidate
+    raise FileNotFoundError(f"Fixture case path not found: {case_path}")
+
+
+def parse_fixture_ref(*, root: Path, case_path: Path, expected_bucket: str | None = None) -> FixtureRef:
+    case_abs = resolve_user_case_input(root=root, case_path=case_path)
+
+    found: FixtureRef | None = None
+    for bucket in sorted(VALID_BUCKETS):
+        bucket_dir = FixtureLayout(root, bucket).bucket_dir.resolve()
+        if not case_abs.is_relative_to(bucket_dir):
+            continue
+        rel = case_abs.relative_to(bucket_dir).as_posix()
+        if not rel.endswith(".case.json"):
+            raise ValueError(f"Fixture path must end with .case.json: {case_abs} (input={case_path})")
+        found = FixtureRef(
+            root=root,
+            bucket=bucket,
+            bucket_dir=bucket_dir,
+            case_abs=case_abs,
+            stem=rel.removesuffix(".case.json"),
+        )
+        break
+
+    if found is None:
+        raise ValueError(
+            "Fixture path is outside valid buckets.\n"
+            f"  input: {case_path}\n"
+            f"  resolved: {case_abs}\n"
+            f"  root: {root}\n"
+            f"  valid buckets: {sorted(VALID_BUCKETS)}"
+        )
+    if expected_bucket and found.bucket != expected_bucket:
+        raise ValueError(
+            "Fixture path bucket mismatch.\n"
+            f"  input: {case_path}\n"
+            f"  resolved: {case_abs}\n"
+            f"  expected bucket: {expected_bucket}\n"
+            f"  detected bucket: {found.bucket}"
+        )
+    return found
+
+
 def load_bundle_json(path: Path) -> dict:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if payload.get("schema") != "fetchgraph.tracer.case_bundle" or payload.get("v") != 1:
@@ -103,36 +177,6 @@ def _format_fixture_diff(output: object, expected: object) -> str:
     return "\n".join(lines)
 
 
-
-def _resolve_case_path(root: Path, case_path: Path) -> Path:
-    if case_path.is_absolute():
-        return case_path.resolve()
-    return (root / case_path).resolve()
-
-
-def _stem_from_bucket_case_path(*, root: Path, bucket: str, case_path: Path) -> str:
-    case_abs = _resolve_case_path(root, case_path)
-    bucket_dir = FixtureLayout(root, bucket).bucket_dir.resolve()
-    if not case_abs.is_relative_to(bucket_dir):
-        raise ValueError(f"Fixture path {case_abs} is outside bucket {bucket_dir}")
-    rel = case_abs.relative_to(bucket_dir).as_posix()
-    if not rel.endswith('.case.json'):
-        raise ValueError(f"Expected .case.json fixture path, got: {case_abs}")
-    return rel.removesuffix('.case.json')
-
-
-def _bucket_and_stem_from_case_path(*, root: Path, case_path: Path) -> tuple[str, str]:
-    case_abs = _resolve_case_path(root, case_path)
-    for bucket in sorted(VALID_BUCKETS):
-        bucket_dir = FixtureLayout(root, bucket).bucket_dir.resolve()
-        if not case_abs.is_relative_to(bucket_dir):
-            continue
-        rel = case_abs.relative_to(bucket_dir).as_posix()
-        if not rel.endswith('.case.json'):
-            break
-        return bucket, rel.removesuffix('.case.json')
-    raise ValueError(f"Unsupported fixture path (not under known buckets): {case_abs}")
-
 def resolve_fixture_candidates(
     *,
     root: Path,
@@ -146,7 +190,8 @@ def resolve_fixture_candidates(
     results: list[FixtureCandidate] = []
     for path in candidates:
         payload = load_bundle_json(path)
-        stem = path.name.replace(".case.json", "")
+        fixture_ref = parse_fixture_ref(root=root, case_path=path, expected_bucket=bucket)
+        stem = fixture_ref.stem
         source = payload.get("source")
         source_dict = source if isinstance(source, dict) else {}
         if case_id:
@@ -173,7 +218,8 @@ def resolve_fixture_selector(
     if case_path is not None and (case_id or name):
         raise ValueError("Only one of case_path, case_id, or name can be used.")
     if case_path is not None:
-        return [case_path]
+        expected_bucket = None if bucket == "all" else bucket
+        return [parse_fixture_ref(root=root, case_path=case_path, expected_bucket=expected_bucket).case_abs]
     candidates = resolve_fixture_candidates(root=root, bucket=bucket, case_id=case_id, name=name)
     if not candidates:
         selector = case_id or name
@@ -417,12 +463,9 @@ def fixture_green(
             for idx, candidate in enumerate(candidates, start=1):
                 marker = " (selected)" if candidate.path == selected.path else ""
                 print(f"  {idx}. {candidate.path}{marker}")
-    case_path = case_path.resolve()
-    if not case_path.is_relative_to(known_layout.bucket_dir):
-        raise ValueError(f"fixture-green expects a known_bad case path, got: {case_path}")
-    if not case_path.name.endswith(".case.json"):
-        raise ValueError(f"fixture-green expects a .case.json bundle, got: {case_path}")
-    stem = _stem_from_bucket_case_path(root=out_root, bucket="known_bad", case_path=case_path)
+    fixture_ref = parse_fixture_ref(root=out_root, case_path=case_path, expected_bucket="known_bad")
+    case_path = fixture_ref.case_abs
+    stem = fixture_ref.stem
     fixed_layout = FixtureLayout(out_root, "fixed")
 
     payload = load_bundle_json(case_path)
@@ -576,8 +619,9 @@ def fixture_rm(
 
     targets: list[Path] = []
     for case_path_item in matched:
-        bucket_name, stem = _bucket_and_stem_from_case_path(root=root, case_path=case_path_item)
-        layout = FixtureLayout(root, bucket_name)
+        fixture_ref = parse_fixture_ref(root=root, case_path=case_path_item, expected_bucket=bucket_filter)
+        layout = FixtureLayout(root, fixture_ref.bucket)
+        stem = fixture_ref.stem
         if scope in ("cases", "both"):
             targets.extend([layout.case_path(stem), layout.expected_path(stem)])
         if scope in ("resources", "both"):
@@ -643,8 +687,9 @@ def fixture_fix(
             if not isinstance(file_name, str) or not file_name:
                 continue
             rel = _safe_resource_path(file_name, stem=name)
-            if len(rel.parts) >= 2 and rel.parts[0] == "resources" and rel.parts[1] == name:
-                new_rel = Path("resources") / new_name / Path(*rel.parts[2:])
+            old_parts = Path(name).parts
+            if rel.parts[: 1 + len(old_parts)] == ("resources", *old_parts):
+                new_rel = Path("resources") / new_name / Path(*rel.parts[1 + len(old_parts) :])
                 canonical_file = new_rel.as_posix()
                 if file_name != canonical_file:
                     data_ref["file"] = canonical_file
@@ -717,8 +762,9 @@ def fixture_migrate(
     bundles_updated = 0
     files_moved = 0
     for case_path in matched:
-        stem = case_path.name.replace(".case.json", "")
-        payload = load_bundle_json(case_path)
+        fixture_ref = parse_fixture_ref(root=root, case_path=case_path, expected_bucket=bucket_filter)
+        stem = fixture_ref.stem
+        payload = load_bundle_json(fixture_ref.case_abs)
         resources = payload.get("resources") or {}
         if not isinstance(resources, dict):
             continue
@@ -736,13 +782,13 @@ def fixture_migrate(
             if rel.parts[:3] != ("resources", stem, resource_id):
                 raise ValueError(
                     "Resource path must be in resources/<stem>/<resource_id>/...; "
-                    f"found {file_name!r} in {case_path}"
+                    f"found {file_name!r} in {fixture_ref.case_abs}"
                 )
             rel_tail = Path(*rel.parts[3:])
             if not rel_tail.parts:
-                raise ValueError(f"Resource path must include a file name: {file_name!r} in {case_path}")
+                raise ValueError(f"Resource path must include a file name: {file_name!r} in {fixture_ref.case_abs}")
             target_rel = Path("resources") / stem / resource_id / rel_tail
-            src_path = case_path.parent / target_rel
+            src_path = fixture_ref.bucket_dir / target_rel
             if not src_path.exists():
                 raise FileNotFoundError(f"Missing resource file: {src_path}")
             canonical_file = target_rel.as_posix()
@@ -752,9 +798,9 @@ def fixture_migrate(
         if updated:
             bundles_updated += 1
             if dry_run:
-                print(f"Would update bundle: {case_path}")
+                print(f"Would update bundle: {fixture_ref.case_abs}")
             else:
-                _atomic_write_json(case_path, payload)
+                _atomic_write_json(fixture_ref.case_abs, payload)
     return bundles_updated, files_moved
 
 
@@ -770,7 +816,8 @@ def fixture_ls(
     results: list[FixtureCandidate] = []
     for path in candidates:
         payload = load_bundle_json(path)
-        stem = path.name.replace(".case.json", "")
+        fixture_ref = parse_fixture_ref(root=root, case_path=path, expected_bucket=bucket_filter)
+        stem = fixture_ref.stem
         source = payload.get("source")
         source_dict = source if isinstance(source, dict) else {}
         if case_id:
@@ -813,7 +860,8 @@ def fixture_demote(
         all_matches=all_matches,
     )
     for case_path_item in selected_paths:
-        stem = _stem_from_bucket_case_path(root=root, bucket=from_bucket, case_path=case_path_item)
+        fixture_ref = parse_fixture_ref(root=root, case_path=case_path_item, expected_bucket=from_bucket)
+        stem = fixture_ref.stem
         from_layout = FixtureLayout(root, from_bucket)
         to_layout = FixtureLayout(root, to_bucket)
         from_case = from_layout.case_path(stem)

--- a/src/fetchgraph/tracer/fixture_tools.py
+++ b/src/fetchgraph/tracer/fixture_tools.py
@@ -54,7 +54,17 @@ def resolve_user_case_input(*, root: Path, case_path: Path) -> Path:
     raise FileNotFoundError(f"Fixture case path not found: {case_path}")
 
 
+
+
+def _normalize_bucket_constraint(bucket: str | None) -> str | None:
+    if bucket in (None, "all"):
+        return None
+    if bucket not in VALID_BUCKETS:
+        raise ValueError(f"Unsupported bucket constraint: {bucket}")
+    return bucket
+
 def parse_fixture_ref(*, root: Path, case_path: Path, expected_bucket: str | None = None) -> FixtureRef:
+    expected_bucket = _normalize_bucket_constraint(expected_bucket)
     case_abs = resolve_user_case_input(root=root, case_path=case_path)
 
     found: FixtureRef | None = None
@@ -218,8 +228,7 @@ def resolve_fixture_selector(
     if case_path is not None and (case_id or name):
         raise ValueError("Only one of case_path, case_id, or name can be used.")
     if case_path is not None:
-        expected_bucket = None if bucket == "all" else bucket
-        return [parse_fixture_ref(root=root, case_path=case_path, expected_bucket=expected_bucket).case_abs]
+        return [parse_fixture_ref(root=root, case_path=case_path, expected_bucket=bucket).case_abs]
     candidates = resolve_fixture_candidates(root=root, bucket=bucket, case_id=case_id, name=name)
     if not candidates:
         selector = case_id or name
@@ -619,7 +628,7 @@ def fixture_rm(
 
     targets: list[Path] = []
     for case_path_item in matched:
-        fixture_ref = parse_fixture_ref(root=root, case_path=case_path_item, expected_bucket=bucket_filter)
+        fixture_ref = parse_fixture_ref(root=root, case_path=case_path_item, expected_bucket=bucket)
         layout = FixtureLayout(root, fixture_ref.bucket)
         stem = fixture_ref.stem
         if scope in ("cases", "both"):
@@ -762,7 +771,7 @@ def fixture_migrate(
     bundles_updated = 0
     files_moved = 0
     for case_path in matched:
-        fixture_ref = parse_fixture_ref(root=root, case_path=case_path, expected_bucket=bucket_filter)
+        fixture_ref = parse_fixture_ref(root=root, case_path=case_path, expected_bucket=bucket)
         stem = fixture_ref.stem
         payload = load_bundle_json(fixture_ref.case_abs)
         resources = payload.get("resources") or {}
@@ -818,7 +827,7 @@ def fixture_ls(
     results: list[FixtureCandidate] = []
     for path in candidates:
         payload = load_bundle_json(path)
-        fixture_ref = parse_fixture_ref(root=root, case_path=path, expected_bucket=bucket_filter)
+        fixture_ref = parse_fixture_ref(root=root, case_path=path, expected_bucket=bucket)
         stem = fixture_ref.stem
         source = payload.get("source")
         source_dict = source if isinstance(source, dict) else {}

--- a/tests/test_replay_runtime.py
+++ b/tests/test_replay_runtime.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 import pytest
 
-from fetchgraph.replay.runtime import ReplayContext, run_case
+from fetchgraph.replay.runtime import ReplayContext, load_case_bundle, run_case
 
 
 def test_run_case_missing_handler_message() -> None:
@@ -96,3 +97,36 @@ def test_resolve_resource_path_rejects_other_fixture_resources(tmp_path: Path) -
     ctx = ReplayContext(base_dir=base_dir, fixture_stem="case_1__abcd1234")
     with pytest.raises(ValueError, match="resources/case_1__abcd1234/"):
         ctx.resolve_resource_path("resources/other_fixture/data.json")
+
+
+def test_load_case_bundle_nested_fixture_uses_bucket_root_for_resources(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures" / "replay_cases"
+    case_path = root / "fixed" / "agg_003" / "nested" / "a.case.json"
+    resource_file = root / "fixed" / "resources" / "agg_003" / "nested" / "a" / "rid1" / "sample" / "data.txt"
+    payload = {
+        "schema": "fetchgraph.tracer.case_bundle",
+        "v": 1,
+        "root": {"type": "replay_case", "v": 2, "id": "plan_normalize.spec_v1", "input": {}},
+        "resources": {"rid1": {"data_ref": {"file": "sample/data.txt"}}},
+        "extras": {},
+    }
+    case_path.parent.mkdir(parents=True, exist_ok=True)
+    resource_file.parent.mkdir(parents=True, exist_ok=True)
+    case_path.write_text(json.dumps(payload), encoding="utf-8")
+    resource_file.write_text("ok", encoding="utf-8")
+
+    _, ctx = load_case_bundle(case_path)
+
+    assert ctx.fixture_stem == "agg_003/nested/a"
+    assert ctx.base_dir == root / "fixed"
+    assert ctx.resolve_resource_path("sample/data.txt") == resource_file
+
+
+def test_resolve_resource_path_accepts_nested_resources_prefix(tmp_path: Path) -> None:
+    base_dir = tmp_path / "fixtures" / "fixed"
+    base_dir.mkdir(parents=True)
+    ctx = ReplayContext(base_dir=base_dir, fixture_stem="agg_003/nested/a")
+
+    resolved = ctx.resolve_resource_path("resources/agg_003/nested/a/rid1/file.txt")
+
+    assert resolved == base_dir / "resources" / "agg_003" / "nested" / "a" / "rid1" / "file.txt"

--- a/tests/test_replay_runtime.py
+++ b/tests/test_replay_runtime.py
@@ -149,3 +149,23 @@ def test_load_case_bundle_uses_outer_bucket_when_stem_contains_bucket_name(tmp_p
 
     assert ctx.fixture_bucket_dir == root / "fixed"
     assert ctx.fixture_stem == "agg_003/fixed/a"
+
+
+def test_load_case_bundle_prefers_nearest_replay_cases_anchor(tmp_path: Path) -> None:
+    outer_root = tmp_path / "outer" / "replay_cases" / "known_bad" / "shadow"
+    inner_root = outer_root / "project" / "tests" / "fixtures" / "replay_cases"
+    case_path = inner_root / "fixed" / "agg_003" / "a.case.json"
+    payload = {
+        "schema": "fetchgraph.tracer.case_bundle",
+        "v": 1,
+        "root": {"type": "replay_case", "v": 2, "id": "plan_normalize.spec_v1", "input": {}},
+        "resources": {},
+        "extras": {},
+    }
+    case_path.parent.mkdir(parents=True, exist_ok=True)
+    case_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    _, ctx = load_case_bundle(case_path)
+
+    assert ctx.fixture_bucket_dir == inner_root / "fixed"
+    assert ctx.fixture_stem == "agg_003/a"

--- a/tests/test_replay_runtime.py
+++ b/tests/test_replay_runtime.py
@@ -118,7 +118,7 @@ def test_load_case_bundle_nested_fixture_uses_bucket_root_for_resources(tmp_path
     _, ctx = load_case_bundle(case_path)
 
     assert ctx.fixture_stem == "agg_003/nested/a"
-    assert ctx.base_dir == root / "fixed"
+    assert ctx.base_dir == case_path.parent
     assert ctx.resolve_resource_path("sample/data.txt") == resource_file
 
 
@@ -130,3 +130,22 @@ def test_resolve_resource_path_accepts_nested_resources_prefix(tmp_path: Path) -
     resolved = ctx.resolve_resource_path("resources/agg_003/nested/a/rid1/file.txt")
 
     assert resolved == base_dir / "resources" / "agg_003" / "nested" / "a" / "rid1" / "file.txt"
+
+
+def test_load_case_bundle_uses_outer_bucket_when_stem_contains_bucket_name(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures" / "replay_cases"
+    case_path = root / "fixed" / "agg_003" / "fixed" / "a.case.json"
+    payload = {
+        "schema": "fetchgraph.tracer.case_bundle",
+        "v": 1,
+        "root": {"type": "replay_case", "v": 2, "id": "plan_normalize.spec_v1", "input": {}},
+        "resources": {},
+        "extras": {},
+    }
+    case_path.parent.mkdir(parents=True, exist_ok=True)
+    case_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    _, ctx = load_case_bundle(case_path)
+
+    assert ctx.fixture_bucket_dir == root / "fixed"
+    assert ctx.fixture_stem == "agg_003/fixed/a"

--- a/tests/test_tracer_fixture_demote.py
+++ b/tests/test_tracer_fixture_demote.py
@@ -75,3 +75,15 @@ def test_fixture_demote_preserves_nested_paths_with_resources(tmp_path: Path) ->
     assert (known_bad / "agg_003" / "nested" / "a.case.json").exists()
     assert (known_bad / "agg_003" / "nested" / "a.expected.json").exists()
     assert (known_bad / "resources" / "agg_003" / "nested" / "a" / "sample.txt").exists()
+
+
+def test_fixture_demote_accepts_repo_relative_case_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "tests" / "fixtures" / "replay_cases"
+    case_path = root / "fixed" / "agg_003" / "a.case.json"
+    _write_bundle(case_path, case_id="agg_003")
+    monkeypatch.chdir(repo)
+
+    fixture_demote(root=root, case_path=Path("tests/fixtures/replay_cases/fixed/agg_003/a.case.json"), dry_run=False)
+
+    assert (root / "known_bad" / "agg_003" / "a.case.json").exists()

--- a/tests/test_tracer_fixture_demote.py
+++ b/tests/test_tracer_fixture_demote.py
@@ -53,3 +53,25 @@ def test_fixture_demote_moves_files(tmp_path: Path) -> None:
     assert (known_bad / "agg_003__a.case.json").exists()
     assert (known_bad / "agg_003__a.expected.json").exists()
     assert (known_bad / "resources" / "agg_003__a" / "sample.txt").exists()
+
+
+def test_fixture_demote_preserves_nested_paths_with_resources(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    fixed = root / "fixed"
+    known_bad = root / "known_bad"
+    case_path = fixed / "agg_003" / "nested" / "a.case.json"
+    expected_path = fixed / "agg_003" / "nested" / "a.expected.json"
+    resources_dir = fixed / "resources" / "agg_003" / "nested" / "a"
+    _write_bundle(case_path, case_id="agg_003")
+    expected_path.write_text('{"ok": true}', encoding="utf-8")
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "sample.txt").write_text("data", encoding="utf-8")
+
+    fixture_demote(root=root, case_path=case_path, dry_run=False)
+
+    assert not case_path.exists()
+    assert not expected_path.exists()
+    assert not resources_dir.exists()
+    assert (known_bad / "agg_003" / "nested" / "a.case.json").exists()
+    assert (known_bad / "agg_003" / "nested" / "a.expected.json").exists()
+    assert (known_bad / "resources" / "agg_003" / "nested" / "a" / "sample.txt").exists()

--- a/tests/test_tracer_fixture_green_resolve.py
+++ b/tests/test_tracer_fixture_green_resolve.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from fetchgraph.tracer.fixture_tools import resolve_fixture_candidates, select_fixture_candidate
+from fetchgraph.tracer.fixture_layout import find_case_bundles
+from fetchgraph.tracer.fixture_tools import fixture_ls, resolve_fixture_candidates, select_fixture_candidate
 
 
 def _write_bundle(path: Path, *, case_id: str, timestamp: str) -> None:
@@ -41,3 +42,35 @@ def test_resolve_fixture_by_case_id(tmp_path: Path) -> None:
 
     with pytest.raises(FileExistsError):
         select_fixture_candidate(candidates, require_unique=True)
+
+
+def test_resolve_fixture_candidates_nested_stem_and_uniqueness(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    known_bad = root / "known_bad"
+    case_a = known_bad / "agg_003" / "x" / "a.case.json"
+    case_b = known_bad / "agg_003" / "y" / "a.case.json"
+    _write_bundle(case_a, case_id="agg_003", timestamp="2024-01-01T00:00:00Z")
+    _write_bundle(case_b, case_id="agg_003", timestamp="2024-01-02T00:00:00Z")
+
+    candidates = resolve_fixture_candidates(root=root, bucket="known_bad", case_id="agg_003", name=None)
+
+    stems = {item.stem for item in candidates}
+    assert stems == {"agg_003/x/a", "agg_003/y/a"}
+    with pytest.raises(FileExistsError):
+        select_fixture_candidate(candidates, require_unique=True)
+
+
+def test_fixture_ls_and_find_case_bundles_support_nested_patterns(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    known_bad = root / "known_bad"
+    _write_bundle(known_bad / "agg_003" / "nested" / "a.case.json", case_id="agg_003", timestamp="2024-01-01T00:00:00Z")
+    _write_bundle(known_bad / "agg_003" / "other" / "b.case.json", case_id="agg_003", timestamp="2024-01-01T00:00:00Z")
+
+    by_name = find_case_bundles(root=root, bucket="known_bad", name="agg_003/nested/a", pattern=None)
+    by_pattern = find_case_bundles(root=root, bucket="known_bad", name=None, pattern="agg_003/**")
+    listed = fixture_ls(root=root, bucket="known_bad", pattern="**/a")
+
+    assert len(by_name) == 1
+    assert by_name[0].as_posix().endswith("known_bad/agg_003/nested/a.case.json")
+    assert {p.name for p in by_pattern} == {"a.case.json", "b.case.json"}
+    assert [c.stem for c in listed] == ["agg_003/nested/a"]

--- a/tests/test_tracer_fixture_green_resolve.py
+++ b/tests/test_tracer_fixture_green_resolve.py
@@ -74,3 +74,24 @@ def test_fixture_ls_and_find_case_bundles_support_nested_patterns(tmp_path: Path
     assert by_name[0].as_posix().endswith("known_bad/agg_003/nested/a.case.json")
     assert {p.name for p in by_pattern} == {"a.case.json", "b.case.json"}
     assert [c.stem for c in listed] == ["agg_003/nested/a"]
+
+
+def test_find_case_bundles_globstar_semantics(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    known_bad = root / "known_bad"
+    _write_bundle(known_bad / "a.case.json", case_id="x", timestamp="2024-01-01T00:00:00Z")
+    _write_bundle(known_bad / "x" / "a.case.json", case_id="x", timestamp="2024-01-01T00:00:00Z")
+    _write_bundle(known_bad / "agg_003" / "a.case.json", case_id="agg_003", timestamp="2024-01-01T00:00:00Z")
+    _write_bundle(known_bad / "agg_003" / "x" / "a.case.json", case_id="agg_003", timestamp="2024-01-01T00:00:00Z")
+
+    p1 = find_case_bundles(root=root, bucket="known_bad", name=None, pattern="**/a")
+    p2 = find_case_bundles(root=root, bucket="known_bad", name=None, pattern="agg_003/**")
+    p3 = find_case_bundles(root=root, bucket="known_bad", name=None, pattern="agg_003/**/a")
+
+    stems1 = {p.relative_to(known_bad).as_posix().removesuffix('.case.json') for p in p1}
+    stems2 = {p.relative_to(known_bad).as_posix().removesuffix('.case.json') for p in p2}
+    stems3 = {p.relative_to(known_bad).as_posix().removesuffix('.case.json') for p in p3}
+
+    assert {"a", "x/a", "agg_003/a", "agg_003/x/a"}.issubset(stems1)
+    assert stems2 == {"agg_003/a", "agg_003/x/a"}
+    assert stems3 == {"agg_003/a", "agg_003/x/a"}

--- a/tests/test_tracer_fixture_selector_for_rm_migrate.py
+++ b/tests/test_tracer_fixture_selector_for_rm_migrate.py
@@ -89,3 +89,33 @@ def test_fixture_rm_removes_nested_case_resources_by_path(tmp_path: Path) -> Non
     assert not case_path.exists()
     assert not expected_path.exists()
     assert not resource_file.exists()
+
+
+def test_fixture_rm_accepts_repo_relative_case_path_and_dry_run_prints_nested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "tests" / "fixtures" / "replay_cases"
+    case_path = root / "known_bad" / "agg_003" / "nested" / "a.case.json"
+    expected_path = root / "known_bad" / "agg_003" / "nested" / "a.expected.json"
+    resources_dir = root / "known_bad" / "resources" / "agg_003" / "nested" / "a"
+    _write_bundle(case_path, case_id="agg_003")
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text("{}", encoding="utf-8")
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(repo)
+
+    removed = fixture_rm(
+        root=root,
+        bucket="known_bad",
+        scope="both",
+        dry_run=True,
+        case_path=Path("tests/fixtures/replay_cases/known_bad/agg_003/nested/a.case.json"),
+    )
+
+    out = capsys.readouterr().out
+    assert removed == 3
+    assert "known_bad/agg_003/nested/a.case.json" in out
+    assert "known_bad/resources/agg_003/nested/a" in out

--- a/tests/test_tracer_fixture_selector_for_rm_migrate.py
+++ b/tests/test_tracer_fixture_selector_for_rm_migrate.py
@@ -119,3 +119,31 @@ def test_fixture_rm_accepts_repo_relative_case_path_and_dry_run_prints_nested(
     assert removed == 3
     assert "known_bad/agg_003/nested/a.case.json" in out
     assert "known_bad/resources/agg_003/nested/a" in out
+
+
+def test_bucket_all_selector_and_rm_migrate(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    case_fixed = root / "fixed" / "agg_003" / "a.case.json"
+    case_bad = root / "known_bad" / "agg_003" / "b.case.json"
+    _write_bundle(case_fixed, case_id="agg_003")
+    _write_bundle(case_bad, case_id="agg_003")
+
+    selected = fixture_rm(
+        root=root,
+        bucket="all",
+        scope="cases",
+        dry_run=True,
+        case_id="agg_003",
+        all_matches=True,
+    )
+    assert selected == 2
+
+    updated, moved = fixture_migrate(
+        root=root,
+        bucket="all",
+        dry_run=True,
+        case_id="agg_003",
+        all_matches=True,
+    )
+    assert updated == 0
+    assert moved == 0

--- a/tests/test_tracer_fixture_selector_for_rm_migrate.py
+++ b/tests/test_tracer_fixture_selector_for_rm_migrate.py
@@ -64,3 +64,28 @@ def test_fixture_selector_for_rm_migrate(tmp_path: Path, capsys: pytest.CaptureF
     assert files_moved == 0
     output = capsys.readouterr().out
     assert "bulk operation" in output
+
+
+def test_fixture_rm_removes_nested_case_resources_by_path(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    case_path = root / "known_bad" / "agg_003" / "nested" / "a.case.json"
+    expected_path = root / "known_bad" / "agg_003" / "nested" / "a.expected.json"
+    resource_file = root / "known_bad" / "resources" / "agg_003" / "nested" / "a" / "rid1" / "file.txt"
+    _write_bundle(case_path, case_id="agg_003")
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text('{}', encoding='utf-8')
+    resource_file.parent.mkdir(parents=True, exist_ok=True)
+    resource_file.write_text('data', encoding='utf-8')
+
+    removed = fixture_rm(
+        root=root,
+        bucket="known_bad",
+        scope="both",
+        dry_run=False,
+        case_path=case_path,
+    )
+
+    assert removed == 3
+    assert not case_path.exists()
+    assert not expected_path.exists()
+    assert not resource_file.exists()

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -71,6 +71,36 @@ def test_fixture_green_moves_case_and_resources(tmp_path: Path) -> None:
     assert not resources_dir.exists()
 
 
+
+
+def test_fixture_green_preserves_relative_paths_for_nested_cases(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    case_path = root / "known_bad" / "agg_003" / "nested" / "case.case.json"
+    resources_dir = root / "known_bad" / "resources" / "agg_003" / "nested" / "case"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "rid1.txt").write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}, "options": {}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        }
+    )
+    _write_bundle(case_path, payload)
+
+    fixture_green(case_path=case_path, out_root=root, expected_from="replay")
+
+    fixed_case = root / "fixed" / "agg_003" / "nested" / "case.case.json"
+    expected_path = root / "fixed" / "agg_003" / "nested" / "case.expected.json"
+    fixed_resources = root / "fixed" / "resources" / "agg_003" / "nested" / "case"
+    assert fixed_case.exists()
+    assert expected_path.exists()
+    assert fixed_resources.exists()
+    assert not case_path.exists()
+    assert not resources_dir.exists()
+
 def test_fixture_green_rolls_back_on_validation_failure(tmp_path: Path) -> None:
     root = tmp_path / "fixtures"
     case_path = root / "known_bad" / "case.case.json"

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -245,6 +245,35 @@ def test_fixture_migrate_normalizes_backslashes(tmp_path: Path) -> None:
     assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()
 
 
+
+
+def test_fixture_migrate_normalizes_backslashes_for_nested_stem(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "agg_003" / "nested" / "case.case.json"
+    resources_dir = root / bucket / "resources" / "agg_003" / "nested" / "case" / "rid1"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "file.txt").write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        },
+        resources={"rid1": {"data_ref": {"file": r"resources\agg_003\nested\case\rid1\file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+
+    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
+
+    assert bundles_updated == 1
+    assert files_moved == 0
+    data = json.loads(case_path.read_text(encoding="utf-8"))
+    assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/agg_003/nested/case/rid1/file.txt"
+    assert (root / bucket / "resources" / "agg_003" / "nested" / "case" / "rid1" / "file.txt").exists()
+
 def test_fixture_migrate_rejects_windows_absolute_paths(tmp_path: Path) -> None:
     root = tmp_path / "fixtures"
     bucket = "fixed"

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -191,6 +191,33 @@ def test_fixture_migrate_leaves_canonical_paths(tmp_path: Path) -> None:
     assert (root / bucket / "resources" / "case" / "rid1" / "file.txt").exists()
 
 
+
+
+def test_fixture_migrate_supports_nested_stem_paths(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "agg_003" / "nested" / "case.case.json"
+    resource_file = root / bucket / "resources" / "agg_003" / "nested" / "case" / "rid1" / "file.txt"
+    resource_file.parent.mkdir(parents=True, exist_ok=True)
+    resource_file.write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        },
+        resources={"rid1": {"data_ref": {"file": "resources/agg_003/nested/case/rid1/file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+
+    bundles_updated, files_moved = fixture_migrate(root=root, bucket=bucket, dry_run=False)
+
+    assert bundles_updated == 0
+    assert files_moved == 0
+
+
 def test_fixture_migrate_normalizes_backslashes(tmp_path: Path) -> None:
     root = tmp_path / "fixtures"
     bucket = "fixed"

--- a/tests/test_tracer_fixture_tools.py
+++ b/tests/test_tracer_fixture_tools.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from fetchgraph.tracer.fixture_tools import fixture_fix, fixture_green, fixture_migrate
+from fetchgraph.tracer.fixture_tools import (
+    fixture_fix,
+    fixture_green,
+    fixture_migrate,
+    parse_fixture_ref,
+    resolve_user_case_input,
+)
 
 
 def _write_bundle(path: Path, payload: dict) -> None:
@@ -230,3 +236,111 @@ def test_fixture_migrate_rejects_windows_absolute_paths(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Invalid resource path"):
         fixture_migrate(root=root, bucket=bucket, dry_run=False)
+
+
+def test_resolve_user_case_input_prefers_existing_repo_relative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "tests" / "fixtures" / "replay_cases"
+    case_path = root / "known_bad" / "a.case.json"
+    _write_bundle(case_path, _bundle_payload({"type": "replay_case", "v": 2, "id": "x", "input": {}}))
+    monkeypatch.chdir(repo)
+
+    resolved = resolve_user_case_input(root=root, case_path=Path("tests/fixtures/replay_cases/known_bad/a.case.json"))
+
+    assert resolved == case_path.resolve()
+
+
+def test_resolve_user_case_input_supports_root_relative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "tests" / "fixtures" / "replay_cases"
+    case_path = root / "known_bad" / "nested" / "a.case.json"
+    _write_bundle(case_path, _bundle_payload({"type": "replay_case", "v": 2, "id": "x", "input": {}}))
+    monkeypatch.chdir(repo)
+
+    resolved = resolve_user_case_input(root=root, case_path=Path("known_bad/nested/a.case.json"))
+
+    assert resolved == case_path.resolve()
+
+
+def test_resolve_user_case_input_detects_ambiguous_relative_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "fixtures_root"
+    cwd_case = repo / "known_bad" / "a.case.json"
+    root_case = root / "known_bad" / "a.case.json"
+    _write_bundle(cwd_case, _bundle_payload({"type": "replay_case", "v": 2, "id": "x", "input": {}}))
+    _write_bundle(root_case, _bundle_payload({"type": "replay_case", "v": 2, "id": "x", "input": {}}))
+    monkeypatch.chdir(repo)
+
+    with pytest.raises(ValueError, match="Ambiguous relative case_path"):
+        resolve_user_case_input(root=root, case_path=Path("known_bad/a.case.json"))
+
+
+def test_parse_fixture_ref_rejects_path_outside_bucket(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    outside = tmp_path / "other" / "a.case.json"
+    _write_bundle(outside, _bundle_payload({"type": "replay_case", "v": 2, "id": "x", "input": {}}))
+
+    with pytest.raises(ValueError, match="outside valid buckets"):
+        parse_fixture_ref(root=root, case_path=outside)
+
+
+def test_fixture_fix_supports_nested_stem_rename(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    bucket = "fixed"
+    case_path = root / bucket / "agg_003" / "nested" / "old.case.json"
+    resources_dir = root / bucket / "resources" / "agg_003" / "nested" / "old" / "rid1"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    (resources_dir / "file.txt").write_text("data", encoding="utf-8")
+    payload = _bundle_payload(
+        {"type": "replay_case", "v": 2, "id": "plan_normalize.spec_v1", "input": {"spec": {"provider": "sql"}}},
+        resources={"rid1": {"data_ref": {"file": "resources/agg_003/nested/old/rid1/file.txt"}}},
+    )
+    _write_bundle(case_path, payload)
+    expected_path = root / bucket / "agg_003" / "nested" / "old.expected.json"
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    expected_path.write_text("{}", encoding="utf-8")
+
+    fixture_fix(
+        root=root,
+        name="agg_003/nested/old",
+        new_name="agg_003/fixed/new",
+        bucket=bucket,
+        dry_run=False,
+    )
+
+    new_case = root / bucket / "agg_003" / "fixed" / "new.case.json"
+    new_expected = root / bucket / "agg_003" / "fixed" / "new.expected.json"
+    new_resource = root / bucket / "resources" / "agg_003" / "fixed" / "new" / "rid1" / "file.txt"
+    assert new_case.exists()
+    assert new_expected.exists()
+    assert new_resource.exists()
+    data = json.loads(new_case.read_text(encoding="utf-8"))
+    assert data["resources"]["rid1"]["data_ref"]["file"] == "resources/agg_003/fixed/new/rid1/file.txt"
+
+
+def test_fixture_green_accepts_repo_relative_case_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    root = repo / "tests" / "fixtures" / "replay_cases"
+    case_path = root / "known_bad" / "agg_003" / "a.case.json"
+    resources_dir = root / "known_bad" / "resources" / "agg_003" / "a"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    payload = _bundle_payload(
+        {
+            "type": "replay_case",
+            "v": 2,
+            "id": "plan_normalize.spec_v1",
+            "input": {"spec": {"provider": "sql"}, "options": {}},
+            "observed": {"out_spec": {"provider": "sql"}},
+        }
+    )
+    _write_bundle(case_path, payload)
+    monkeypatch.chdir(repo)
+
+    fixture_green(
+        case_path=Path("tests/fixtures/replay_cases/known_bad/agg_003/a.case.json"),
+        out_root=root,
+        expected_from="replay",
+    )
+
+    assert (root / "fixed" / "agg_003" / "a.case.json").exists()
+    assert (root / "fixed" / "resources" / "agg_003" / "a").exists()


### PR DESCRIPTION
### Motivation
- `fixture-green` flattened the fixture stem to the bundle basename, causing resources and expected files from nested `known_bad` paths to be placed in incorrect locations under `fixed`, which broke `test_replay_case_resources_exist` resolution.

### Description
- Compute the fixture `stem` relative to `known_bad/` instead of using `case_path.name`, using `case_path.relative_to(known_layout.bucket_dir).as_posix().removesuffix(".case.json")` so nested directory structure is preserved when moving case/expected/resources.
- Update resource/expected target paths to use the new `stem` so promoted fixtures keep the same relative layout under `fixed/`.
- Add a regression test `test_fixture_green_preserves_relative_paths_for_nested_cases` in `tests/test_tracer_fixture_tools.py` that verifies nested cases and their resources are moved into `fixed` preserving relative paths.

### Testing
- Ran `pytest -q tests/test_tracer_fixture_tools.py tests/test_replay_fixed.py::test_replay_case_resources_exist` and the test run completed successfully with all tests passing (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad67b544dc832f9d93569742d3bccc)